### PR TITLE
Adding Hot Module Replacement support

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -65,6 +65,7 @@ function showUsageInstructions() {
     console.log(`    ${chalk.green('dev-server')} : runs webpack-dev-server`);
     console.log(`       - ${chalk.yellow('--host')} The hostname/ip address the webpack-dev-server will bind to`);
     console.log(`       - ${chalk.yellow('--port')} The port the webpack-dev-server will bind to`);
+    console.log(`       - ${chalk.yellow('--hot')}  Enable HMR on webpack-dev-server`);
     console.log('       - Supports any webpack-dev-server options');
     console.log(`    ${chalk.green('production')} : runs webpack for production`);
     console.log('       - Supports any webpack options (e.g. --watch)');

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -245,6 +245,10 @@ class WebpackConfig {
         return this.runtimeConfig.devServerHttps;
     }
 
+    useHotModuleReplacementPlugin() {
+        return this.runtimeConfig.useHotModuleReplacement;
+    }
+
     isProduction() {
         return this.runtimeConfig.environment === 'production';
     }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -413,6 +413,10 @@ class ConfigGenerator {
         const outputPath = this.webpackConfig.outputPath.replace(this.webpackConfig.getContext() + '/', '');
         plugins.push(new AssetsOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
 
+        if (this.webpackConfig.useDevServer()) {
+            plugins.push(new webpack.HotModuleReplacementPlugin())
+        }
+
         return plugins;
     }
 
@@ -463,6 +467,7 @@ class ConfigGenerator {
             // avoid CORS concerns trying to load things like fonts from the dev server
             headers: { 'Access-Control-Allow-Origin': '*' },
             // required by FriendlyErrorsWebpackPlugin
+            hot: true,
             quiet: true,
             compress: true,
             historyApiFallback: true,

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -414,7 +414,7 @@ class ConfigGenerator {
         plugins.push(new AssetsOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
 
         if (this.webpackConfig.useDevServer()) {
-            plugins.push(new webpack.HotModuleReplacementPlugin())
+            plugins.push(new webpack.HotModuleReplacementPlugin());
         }
 
         return plugins;

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -467,7 +467,7 @@ class ConfigGenerator {
             // avoid CORS concerns trying to load things like fonts from the dev server
             headers: { 'Access-Control-Allow-Origin': '*' },
             // required by FriendlyErrorsWebpackPlugin
-            hot: true,
+            hot: this.webpackConfig.useHotModuleReplacementPlugin(),
             quiet: true,
             compress: true,
             historyApiFallback: true,

--- a/lib/config/RuntimeConfig.js
+++ b/lib/config/RuntimeConfig.js
@@ -19,6 +19,7 @@ class RuntimeConfig {
         this.useDevServer = null;
         this.devServerUrl = null;
         this.devServerHttps = null;
+        this.useHotModuleReplacement = null;
 
         this.babelRcFileExists = null;
 

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -23,6 +23,7 @@ module.exports = function(argv, cwd) {
     const runtimeConfig = new RuntimeConfig();
     runtimeConfig.command = argv._[0];
     runtimeConfig.useDevServer = false;
+    runtimeConfig.useHotModuleReplacement = false;
 
     switch (runtimeConfig.command) {
         case 'dev':
@@ -38,6 +39,7 @@ module.exports = function(argv, cwd) {
             runtimeConfig.environment = 'dev';
             runtimeConfig.useDevServer = true;
             runtimeConfig.devServerHttps = argv.https;
+            runtimeConfig.useHotModuleReplacement = argv.hot || false;
 
             var host = argv.host ? argv.host : 'localhost';
             var port = argv.port ? argv.port : '8080';

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -68,6 +68,7 @@ describe('parse-runtime', () => {
         expect(config.environment).to.equal('dev');
         expect(config.useDevServer).to.be.true;
         expect(config.devServerUrl).to.equal('http://localhost:8080/');
+        expect(config.useHotModuleReplacement).to.be.false;
     });
 
     it('dev-server command with options', () => {
@@ -104,5 +105,13 @@ describe('parse-runtime', () => {
         const config = parseArgv(createArgv(['dev']), projectDir);
 
         expect(config.babelRcFileExists).to.be.true;
+    });
+
+    it('dev-server command hot', () => {
+        const testDir = createTestDirectory();
+        const config = parseArgv(createArgv(['dev-server', '--hot']), testDir);
+
+        expect(config.useDevServer).to.be.true;
+        expect(config.useHotModuleReplacement).to.be.true;
     });
 });


### PR DESCRIPTION
This PR is a patch to provide simply add HMR support if the webpack-dev-server is use.
Sorry I don't know if there is a standard for PR on this repo.

To test, run `.node_modules/.bin/encore dev-server` and refresh the page of your project, then open the console and you should see `[WDS] Hot Module Replacement enabled.`

I think I can find a way to test it with the test suite.