### PR TITLE
Add window.jquery to autoProvidejQuery()

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -233,7 +233,8 @@ class WebpackConfig {
     autoProvidejQuery() {
         this.autoProvideVariables({
             $: 'jquery',
-            jQuery: 'jquery'
+            jQuery: 'jquery',
+            "window.jQuery": "jquery"
         });
     }
 

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -234,7 +234,7 @@ class WebpackConfig {
         this.autoProvideVariables({
             $: 'jquery',
             jQuery: 'jquery',
-            "window.jQuery": "jquery"
+            'window.jQuery': 'jquery'
         });
     }
 


### PR DESCRIPTION
When using webpack it's common to also provide window.jQuery because some libraries use it this way.