### PR TITLE
Allow to add custom loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 'use strict';
 
 const WebpackConfig = require('./lib/WebpackConfig');

--- a/index.js
+++ b/index.js
@@ -136,6 +136,32 @@ module.exports = {
     },
 
     /**
+     * Adds a custom loader config
+     *
+     * @param {object} loader The loader config object
+     *
+     * @returns {exports}
+     */
+    addLoader(loader) {
+        webpackConfig.addLoader(loader);
+
+        return this;
+    },
+
+    /**
+     * Alias to addLoader
+     *
+     * @param {object} rule
+     *
+     * @returns {exports}
+     */
+    addRule(rule) {
+        this.addLoader(rule);
+
+        return this;
+    },
+
+    /**
      * When enabled, files are rendered with a hash based
      * on their contents (e.g. main.a2b61cc.js)
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -49,7 +49,7 @@ class WebpackConfig {
         this.providedVariables = {};
         this.babelConfigurationCallback = function() {};
         this.useReact = false;
-        this.loaders = new Set();
+        this.loaders = [];
     }
 
     getContext() {
@@ -158,8 +158,8 @@ class WebpackConfig {
         this.styleEntries.set(name, src);
     }
 
-    addLoader(test, use, options = { include: null, exclude: null }) {
-        this.loaders.add({ 'test': test, 'use': use, 'include': options.include || null, 'exclude': options.exclude || null });
+    addLoader(loader) {
+        this.loaders.push(loader);
     }
 
     enableVersioning(enabled = true) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -49,6 +49,7 @@ class WebpackConfig {
         this.providedVariables = {};
         this.babelConfigurationCallback = function() {};
         this.useReact = false;
+        this.loaders = new Set();
     }
 
     getContext() {
@@ -155,6 +156,10 @@ class WebpackConfig {
         }
 
         this.styleEntries.set(name, src);
+    }
+
+    addLoader(test, use, options = { include: null, exclude: null }) {
+        this.loaders.add({ 'test': test, 'use': use, 'include': options.include || null, 'exclude': options.exclude || null });
     }
 
     enableVersioning(enabled = true) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -235,11 +235,9 @@ class ConfigGenerator {
             });
         }
 
-        if (this.webpackConfig.loaders.size > 0) {
-            this.webpackConfig.loaders.forEach((loader) => {
-                rules.push(loader);
-            });
-        }
+        this.webpackConfig.loaders.forEach((loader) => {
+            rules.push(loader);
+        });
 
         return rules;
     }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -235,6 +235,12 @@ class ConfigGenerator {
             });
         }
 
+        if (this.webpackConfig.loaders.size > 0) {
+            this.webpackConfig.loaders.forEach((loader) => {
+                rules.push(loader);
+            });
+        }
+
         return rules;
     }
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -281,17 +281,9 @@ describe('WebpackConfig object', () => {
         it('Adds a new loader with default options', () => {
             const config = createConfig();
 
-            config.addLoader(/\.custom$/, 'custom-loader');
+            config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });
 
-            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': null }]);
-        });
-
-        it('Adds a custom exclude path', () => {
-            const config = createConfig();
-
-            config.addLoader(/\.custom$/, 'custom-loader', { 'exclude': 'node_modules' });
-
-            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': 'node_modules' }]);
+            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'loader': 'custom-loader' }]);
         });
     });
 });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -278,7 +278,7 @@ describe('WebpackConfig object', () => {
     });
 
     describe('addLoader', () => {
-        it('Adds a new loader with default options', () => {
+        it('Adds a new loader', () => {
             const config = createConfig();
 
             config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -283,7 +283,7 @@ describe('WebpackConfig object', () => {
 
             config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });
 
-            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'loader': 'custom-loader' }]);
+            expect(config.loaders).to.deep.equals([{ 'test': /\.custom$/, 'loader': 'custom-loader' }]);
         });
     });
 });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -276,4 +276,22 @@ describe('WebpackConfig object', () => {
             }).to.throw('Invalid option "fake_option" passed to enableSassLoader()');
         });
     });
+
+    describe('addLoader', () => {
+        it('Adds a new loader with default options', () => {
+            const config = createConfig();
+
+            config.addLoader(/\.custom$/, 'custom-loader');
+
+            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': null }]);
+        });
+
+        it('Adds a custom exclude path', () => {
+            const config = createConfig();
+
+            config.addLoader(/\.custom$/, 'custom-loader', { 'exclude': 'node_modules' });
+
+            expect(Array.from(config.loaders)).to.deep.equals([{ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': 'node_modules' }]);
+        });
+    });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -348,6 +348,30 @@ describe('The config-generator function', () => {
         });
     });
 
+    describe('addLoader() adds custom rules', () => {
+        it('addLoader()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addLoader(/\.custom$/, 'custom-loader');
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': null });
+        });
+
+        it('addLoader() with custom exlude path', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addLoader(/\.custom$/, 'custom-loader', { 'exclude': 'node_modules' });
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': 'node_modules' });
+        });
+    });
+
     describe('.js rule receives different configuration', () => {
         it('Use default config', () => {
             const config = createConfig();

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -348,27 +348,16 @@ describe('The config-generator function', () => {
         });
     });
 
-    describe('addLoader() adds custom rules', () => {
+    describe('addLoader() adds a custom loader', () => {
         it('addLoader()', () => {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
-            config.addLoader(/\.custom$/, 'custom-loader');
+            config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });
 
             const actualConfig = configGenerator(config);
 
-            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': null });
-        });
-
-        it('addLoader() with custom exlude path', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addLoader(/\.custom$/, 'custom-loader', { 'exclude': 'node_modules' });
-
-            const actualConfig = configGenerator(config);
-
-            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'use': 'custom-loader', 'include': null, 'exclude': 'node_modules' });
+            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'loader': 'custom-loader' });
         });
     });
 


### PR DESCRIPTION
Currently Encore only supports specific loaders, and adding additional loaders is not very intuitive and adds additional (ugly) code to the config, E.G we are using handlebars with the [handlebars-loader](https://github.com/pcardune/handlebars-loader) and have to manually add the loader to the config:

```js
var webpackConfig = Encore.getWebpackConfig();
webpackConfig.module.rules.push({ test: /\.hbs$/, loader: 'handlebars-loader' });
```

So I propose allowing to add custom loaders through a simple `addLoader(test, loader)` function.
This changes the above code to the following:

```js
// ...
    .addLoader(/\.hbs$/, 'handlebars-loader')
```

It is also possible to set custom config for the loaders by passing an object instead of a string:

```js
// ...
    .addLoader(/\.hbs$/, { 'loader': 'handlebars-loader', 'options' : { 'debug': !Encore.isProduction()} })
```

I have also added an object to define include and exclude directories. There are just so many options for a loader that I'm not sure which ones to support. Include and exclude seemed like the most obvious. Instead of having too many parameters for the function, I opted for an object with the options as keys, which makes it easier to add support for more options, but the drawback is that it is less clear which options are supported.