### PR TITLE
Removing duplicate HotModuleReplacementPlugin()

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -413,10 +413,6 @@ class ConfigGenerator {
         const outputPath = this.webpackConfig.outputPath.replace(this.webpackConfig.getContext() + '/', '');
         plugins.push(new AssetsOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
 
-        if (this.webpackConfig.useDevServer()) {
-            plugins.push(new webpack.HotModuleReplacementPlugin());
-        }
-
         return plugins;
     }
 


### PR DESCRIPTION
https://github.com/webpack-contrib/style-loader/issues/18#issuecomment-56308183

We're enforcing that --hot is passed at the command line, which enables this plugin for you.