### PR TITLE
hide the 'Assets output' message when using the dev-server

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -13,7 +13,7 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('./webpack/webpack-manifest-plugin');
 const DeleteUnusedEntriesJSPlugin = require('./webpack/delete-unused-entries-js-plugin');
-const AssetsOutputDisplayPlugin = require('./friendly-errors/asset-output-display-plugin');
+const AssetOutputDisplayPlugin = require('./friendly-errors/asset-output-display-plugin');
 const loaderFeatures = require('./loader-features');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const WebpackChunkHash = require('webpack-chunk-hash');
@@ -410,8 +410,10 @@ class ConfigGenerator {
         });
         plugins.push(friendlyErrorsPlugin);
 
-        const outputPath = this.webpackConfig.outputPath.replace(this.webpackConfig.getContext() + '/', '');
-        plugins.push(new AssetsOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
+        if (!this.webpackConfig.useDevServer()) {
+            const outputPath = this.webpackConfig.outputPath.replace(this.webpackConfig.getContext() + '/', '');
+            plugins.push(new AssetOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
+        }
 
         if (this.webpackConfig.useDevServer()) {
             plugins.push(new webpack.HotModuleReplacementPlugin());


### PR DESCRIPTION
To give some feedback, we currently output this message after a build:

> 23 files written to web/build

But, that doesn't make sense when using the dev-server (as nothing - except `manifest.json` - is actually written). webpack-dev-server itself already renders helpful information about what address the server is running on, etc - we don't need to add that ourselves.