### PR TITLE
Allow to add extra plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,21 @@ module.exports = {
     },
 
     /**
+     * Add a plugin to the sets of plugins already registered by Encore
+     *
+     * For example, if you want to add the "webpack.IgnorePlugin()", then:
+     *      .addPlugin(new webpack.IgnorePlugin(requestRegExp, contextRegExp))
+     *
+     * @param {string} plugin
+     * @return {exports}
+     */
+    addPlugin(plugin) {
+        webpackConfig.addPlugin(plugin);
+
+        return this;
+    },
+
+    /**
      * When enabled, files are rendered with a hash based
      * on their contents (e.g. main.a2b61cc.js)
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -36,6 +36,7 @@ class WebpackConfig {
         this.manifestKeyPrefix = null;
         this.entries = new Map();
         this.styleEntries = new Map();
+        this.plugins = [];
         this.useVersioning = false;
         this.useSourceMaps = false;
         this.usePostCssLoader = false;
@@ -155,6 +156,10 @@ class WebpackConfig {
         }
 
         this.styleEntries.set(name, src);
+    }
+
+    addPlugin(plugin) {
+        this.plugins.push(plugin);
     }
 
     enableVersioning(enabled = true) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -417,6 +417,10 @@ class ConfigGenerator {
             plugins.push(new webpack.HotModuleReplacementPlugin());
         }
 
+        this.webpackConfig.plugins.forEach(function(plugin) {
+            plugins.push(plugin);
+        });
+
         return plugins;
     }
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -14,6 +14,7 @@ const WebpackConfig = require('../lib/WebpackConfig');
 const RuntimeConfig = require('../lib/config/RuntimeConfig');
 const path = require('path');
 const fs = require('fs');
+const webpack = require('webpack');
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -274,6 +275,19 @@ describe('WebpackConfig object', () => {
             expect(() => {
                 config.enableSassLoader({ fake_option: false });
             }).to.throw('Invalid option "fake_option" passed to enableSassLoader()');
+        });
+    });
+
+    describe('addPlugin', () => {
+        it('extends the current registered plugins', () => {
+            const config = createConfig();
+            const nbOfPlugins = config.plugins.length;
+
+            expect(nbOfPlugins).to.equal(0);
+
+            config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
+
+            expect(config.plugins.length).to.equal(1);
         });
     });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -487,4 +487,18 @@ describe('The config-generator function', () => {
             expect(actualConfig.devServer.publicPath).to.equal('/subdirectory/build/');
         });
     });
+
+    describe('test for addPlugin config', () => {
+        it('extra plugin is set correctly', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+            config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
+
+            const actualConfig = configGenerator(config);
+
+            const ignorePlugin = findPlugin(webpack.IgnorePlugin, actualConfig.plugins);
+            expect(ignorePlugin).to.not.be.undefined;
+        });
+    });
 });


### PR DESCRIPTION
Encore does not support adding an extra plugin to the list of registered plugins.
In Symfony demo, we try to reduce the size of one of our entries and have to manually add the plugin to the config by doing this : 

```js
var config = Encore.getWebpackConfig();
config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
```

I propose to update the API of Encore through a new method `addPlugin(plugin)`.

```js
Encore
// ...
    .addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/))
```