### PR TITLE
Refactoring loaders into re-usable modules

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -22,10 +22,10 @@ const missingLoaderFormatter = require('./friendly-errors/formatters/missing-loa
 const missingPostCssConfigTransformer = require('./friendly-errors/transformers/missing-postcss-config');
 const missingPostCssConfigFormatter = require('./friendly-errors/formatters/missing-postcss-config');
 const pathUtil = require('./config/path-util');
-const cssLoaders = require('./loaders/css');
-const sassLoaders = require('./loaders/sass');
-const lessLoaders = require('./loaders/less');
-const babelLoaders = require('./loaders/babel');
+const cssLoaderUtil = require('./loaders/css');
+const sassLoaderUtil = require('./loaders/sass');
+const lessLoaderUtil = require('./loaders/less');
+const babelLoaderUtil = require('./loaders/babel');
 
 class ConfigGenerator {
     /**
@@ -107,13 +107,13 @@ class ConfigGenerator {
                 // match .js and .jsx
                 test: /\.jsx?$/,
                 exclude: /(node_modules|bower_components)/,
-                use: babelLoaders(this.webpackConfig)
+                use: babelLoaderUtil.getLoaders(this.webpackConfig)
             },
             {
                 test: /\.css$/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: cssLoaders(this.webpackConfig)
+                    use: cssLoaderUtil.getLoaders(this.webpackConfig)
                 })
             },
             {
@@ -139,7 +139,7 @@ class ConfigGenerator {
                 test: /\.s[ac]ss$/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: sassLoaders(this.webpackConfig)
+                    use: sassLoaderUtil.getLoaders(this.webpackConfig)
                 })
             });
         }
@@ -149,7 +149,7 @@ class ConfigGenerator {
                 test: /\.less/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: lessLoaders(this.webpackConfig)
+                    use: lessLoaderUtil.getLoaders(this.webpackConfig)
                 })
             });
         }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -14,7 +14,6 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('./webpack/webpack-manifest-plugin');
 const DeleteUnusedEntriesJSPlugin = require('./webpack/delete-unused-entries-js-plugin');
 const AssetOutputDisplayPlugin = require('./friendly-errors/asset-output-display-plugin');
-const loaderFeatures = require('./loader-features');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const WebpackChunkHash = require('webpack-chunk-hash');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
@@ -23,6 +22,10 @@ const missingLoaderFormatter = require('./friendly-errors/formatters/missing-loa
 const missingPostCssConfigTransformer = require('./friendly-errors/transformers/missing-postcss-config');
 const missingPostCssConfigFormatter = require('./friendly-errors/formatters/missing-postcss-config');
 const pathUtil = require('./config/path-util');
+const cssLoaders = require('./loaders/css');
+const sassLoaders = require('./loaders/sass');
+const lessLoaders = require('./loaders/less');
+const babelLoaders = require('./loaders/babel');
 
 class ConfigGenerator {
     /**
@@ -99,76 +102,18 @@ class ConfigGenerator {
     }
 
     buildRulesConfig() {
-        const cssLoaders = [
+        let rules = [
             {
-                loader: 'css-loader' + this.getSourceMapOption() + (this.webpackConfig.isProduction() ? '?minimize=1' : ''),
+                // match .js and .jsx
+                test: /\.jsx?$/,
+                exclude: /(node_modules|bower_components)/,
+                use: babelLoaders(this.webpackConfig)
             },
-        ];
-        if (this.webpackConfig.usePostCssLoader) {
-            loaderFeatures.ensureLoaderPackagesExist('postcss');
-
-            cssLoaders.push({
-                loader: 'postcss-loader' + this.getSourceMapOption(),
-            });
-        }
-
-        let babelConfig = {
-            // improves performance by caching babel compiles
-            // we add this option ALWAYS
-            // https://github.com/babel/babel-loader#options
-            cacheDirectory: true
-        };
-
-        // configure babel (unless the user is specifying .babelrc)
-        // todo - add a sanity check for their babelrc contents
-        if (!this.webpackConfig.doesBabelRcFileExist()) {
-            Object.assign(babelConfig, {
-                presets: [
-                    ['env', {
-                        // modules don't need to be transformed - webpack will parse
-                        // the modules for us. This is a performance improvement
-                        // https://babeljs.io/docs/plugins/preset-env/#optionsmodules
-                        modules: false,
-                        targets: {
-                            browsers: '> 1%',
-                            uglify: true
-                        },
-                        useBuiltIns: true
-                    }]
-                ],
-            });
-
-            if (this.webpackConfig.useReact) {
-                loaderFeatures.ensureLoaderPackagesExist('react');
-
-                babelConfig.presets.push('react');
-            }
-
-            // allow for babel config to be controlled
-            this.webpackConfig.babelConfigurationCallback.apply(
-                // use babelConfig as the this variable
-                babelConfig,
-                [babelConfig]
-            );
-        }
-
-        let rules = [];
-        rules.push({
-            // match .js and .jsx
-            test: /\.jsx?$/,
-            exclude: /(node_modules|bower_components)/,
-            use: {
-                loader: 'babel-loader',
-                options: babelConfig
-            }
-        });
-
-        rules = rules.concat([
             {
                 test: /\.css$/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: cssLoaders
+                    use: cssLoaders(this.webpackConfig)
                 })
             },
             {
@@ -187,51 +132,24 @@ class ConfigGenerator {
                     publicPath: this.webpackConfig.getRealPublicPath()
                 }
             },
-        ]);
+        ];
 
         if (this.webpackConfig.useSassLoader) {
-            loaderFeatures.ensureLoaderPackagesExist('sass');
-
-            const sassLoaders = [...cssLoaders];
-            if (true === this.webpackConfig.sassOptions.resolve_url_loader) {
-                // responsible for resolving SASS url() paths
-                // without this, all url() paths must be relative to the
-                // entry file, not the file that contains the url()
-                sassLoaders.push({
-                    loader: 'resolve-url-loader' + this.getSourceMapOption(),
-                });
-            }
-
-            sassLoaders.push({
-                loader: 'sass-loader',
-                options: {
-                    // needed by the resolve-url-loader
-                    sourceMap: (true === this.webpackConfig.sassOptions.resolve_url_loader) || this.webpackConfig.useSourceMaps
-                }
-            });
-
             rules.push({
                 test: /\.s[ac]ss$/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: sassLoaders
+                    use: sassLoaders(this.webpackConfig)
                 })
             });
         }
 
         if (this.webpackConfig.useLessLoader) {
-            loaderFeatures.ensureLoaderPackagesExist('less');
-
             rules.push({
                 test: /\.less/,
                 use: ExtractTextPlugin.extract({
                     fallback: 'style-loader' + this.getSourceMapOption(),
-                    use: [
-                        ...cssLoaders,
-                        {
-                            loader: 'less-loader' + this.getSourceMapOption()
-                        },
-                    ]
+                    use: lessLoaders(this.webpackConfig)
                 })
             });
         }

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const loaderFeatures = require('../loader-features');
+
+/**
+ * @param {WebpackConfig} webpackConfig
+ * @return {Array} of loaders to use for Babel
+ */
+module.exports = function(webpackConfig) {
+    let babelConfig = {
+        // improves performance by caching babel compiles
+        // we add this option ALWAYS
+        // https://github.com/babel/babel-loader#options
+        cacheDirectory: true
+    };
+
+    // configure babel (unless the user is specifying .babelrc)
+    // todo - add a sanity check for their babelrc contents
+    if (!webpackConfig.doesBabelRcFileExist()) {
+        Object.assign(babelConfig, {
+            presets: [
+                ['env', {
+                    // modules don't need to be transformed - webpack will parse
+                    // the modules for us. This is a performance improvement
+                    // https://babeljs.io/docs/plugins/preset-env/#optionsmodules
+                    modules: false,
+                    targets: {
+                        browsers: '> 1%',
+                        uglify: true
+                    },
+                    useBuiltIns: true
+                }]
+            ],
+        });
+
+        if (webpackConfig.useReact) {
+            loaderFeatures.ensureLoaderPackagesExist('react');
+
+            babelConfig.presets.push('react');
+        }
+
+        // allow for babel config to be controlled
+        webpackConfig.babelConfigurationCallback.apply(
+            // use babelConfig as the this variable
+            babelConfig,
+            [babelConfig]
+        );
+    }
+
+    return [
+        {
+            loader: 'babel-loader',
+            options: babelConfig
+        }
+    ];
+};

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -15,51 +15,53 @@ const loaderFeatures = require('../loader-features');
  * @param {WebpackConfig} webpackConfig
  * @return {Array} of loaders to use for Babel
  */
-module.exports = function(webpackConfig) {
-    let babelConfig = {
-        // improves performance by caching babel compiles
-        // we add this option ALWAYS
-        // https://github.com/babel/babel-loader#options
-        cacheDirectory: true
-    };
+module.exports = {
+    getLoaders(webpackConfig) {
+        let babelConfig = {
+            // improves performance by caching babel compiles
+            // we add this option ALWAYS
+            // https://github.com/babel/babel-loader#options
+            cacheDirectory: true
+        };
 
-    // configure babel (unless the user is specifying .babelrc)
-    // todo - add a sanity check for their babelrc contents
-    if (!webpackConfig.doesBabelRcFileExist()) {
-        Object.assign(babelConfig, {
-            presets: [
-                ['env', {
-                    // modules don't need to be transformed - webpack will parse
-                    // the modules for us. This is a performance improvement
-                    // https://babeljs.io/docs/plugins/preset-env/#optionsmodules
-                    modules: false,
-                    targets: {
-                        browsers: '> 1%',
-                        uglify: true
-                    },
-                    useBuiltIns: true
-                }]
-            ],
-        });
+        // configure babel (unless the user is specifying .babelrc)
+        // todo - add a sanity check for their babelrc contents
+        if (!webpackConfig.doesBabelRcFileExist()) {
+            Object.assign(babelConfig, {
+                presets: [
+                    ['env', {
+                        // modules don't need to be transformed - webpack will parse
+                        // the modules for us. This is a performance improvement
+                        // https://babeljs.io/docs/plugins/preset-env/#optionsmodules
+                        modules: false,
+                        targets: {
+                            browsers: '> 1%',
+                            uglify: true
+                        },
+                        useBuiltIns: true
+                    }]
+                ],
+            });
 
-        if (webpackConfig.useReact) {
-            loaderFeatures.ensureLoaderPackagesExist('react');
+            if (webpackConfig.useReact) {
+                loaderFeatures.ensureLoaderPackagesExist('react');
 
-            babelConfig.presets.push('react');
+                babelConfig.presets.push('react');
+            }
+
+            // allow for babel config to be controlled
+            webpackConfig.babelConfigurationCallback.apply(
+                // use babelConfig as the this variable
+                babelConfig,
+                [babelConfig]
+            );
         }
 
-        // allow for babel config to be controlled
-        webpackConfig.babelConfigurationCallback.apply(
-            // use babelConfig as the this variable
-            babelConfig,
-            [babelConfig]
-        );
+        return [
+            {
+                loader: 'babel-loader',
+                options: babelConfig
+            }
+        ];
     }
-
-    return [
-        {
-            loader: 'babel-loader',
-            options: babelConfig
-        }
-    ];
 };

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -15,27 +15,29 @@ const loaderFeatures = require('../loader-features');
  * @param {WebpackConfig} webpackConfig
  * @return {Array} of loaders to use for CSS files
  */
-module.exports = function(webpackConfig) {
-    const cssLoaders = [
-        {
-            loader: 'css-loader',
-            options: {
-                minimize: webpackConfig.isProduction(),
-                sourceMap: webpackConfig.useSourceMaps
-            }
-        },
-    ];
+module.exports = {
+    getLoaders(webpackConfig) {
+        const cssLoaders = [
+            {
+                loader: 'css-loader',
+                options: {
+                    minimize: webpackConfig.isProduction(),
+                    sourceMap: webpackConfig.useSourceMaps
+                }
+            },
+        ];
 
-    if (webpackConfig.usePostCssLoader) {
-        loaderFeatures.ensureLoaderPackagesExist('postcss');
+        if (webpackConfig.usePostCssLoader) {
+            loaderFeatures.ensureLoaderPackagesExist('postcss');
 
-        cssLoaders.push({
-            loader: 'postcss-loader',
-            options: {
-                sourceMap: webpackConfig.useSourceMaps
-            }
-        });
+            cssLoaders.push({
+                loader: 'postcss-loader',
+                options: {
+                    sourceMap: webpackConfig.useSourceMaps
+                }
+            });
+        }
+
+        return cssLoaders;
     }
-
-    return cssLoaders;
 };

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const loaderFeatures = require('../loader-features');
+
+/**
+ * @param {WebpackConfig} webpackConfig
+ * @return {Array} of loaders to use for CSS files
+ */
+module.exports = function(webpackConfig) {
+    const cssLoaders = [
+        {
+            loader: 'css-loader',
+            options: {
+                minimize: webpackConfig.isProduction(),
+                sourceMap: webpackConfig.useSourceMaps
+            }
+        },
+    ];
+
+    if (webpackConfig.usePostCssLoader) {
+        loaderFeatures.ensureLoaderPackagesExist('postcss');
+
+        cssLoaders.push({
+            loader: 'postcss-loader',
+            options: {
+                sourceMap: webpackConfig.useSourceMaps
+            }
+        });
+    }
+
+    return cssLoaders;
+};

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -10,22 +10,24 @@
 'use strict';
 
 const loaderFeatures = require('../loader-features');
-const cssLoaders = require('./css');
+const cssLoader = require('./css');
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @return {Array} of loaders to use for Less files
  */
-module.exports = function(webpackConfig) {
-    loaderFeatures.ensureLoaderPackagesExist('less');
+module.exports = {
+    getLoaders(webpackConfig) {
+        loaderFeatures.ensureLoaderPackagesExist('less');
 
-    return [
-        ...cssLoaders(webpackConfig),
-        {
-            loader: 'less-loader',
-            options: {
-                sourceMap: webpackConfig.useSourceMaps
-            }
-        },
-    ];
+        return [
+            ...cssLoader.getLoaders(webpackConfig),
+            {
+                loader: 'less-loader',
+                options: {
+                    sourceMap: webpackConfig.useSourceMaps
+                }
+            },
+        ];
+    }
 };

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const loaderFeatures = require('../loader-features');
+const cssLoaders = require('./css');
+
+/**
+ * @param {WebpackConfig} webpackConfig
+ * @return {Array} of loaders to use for Less files
+ */
+module.exports = function(webpackConfig) {
+    loaderFeatures.ensureLoaderPackagesExist('less');
+
+    return [
+        ...cssLoaders(webpackConfig),
+        {
+            loader: 'less-loader',
+            options: {
+                sourceMap: webpackConfig.useSourceMaps
+            }
+        },
+    ];
+};

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const loaderFeatures = require('../loader-features');
+const cssLoaders = require('./css');
+
+/**
+ * @param {WebpackConfig} webpackConfig
+ * @return {Array} of loaders to use for Sass files
+ */
+module.exports = function(webpackConfig) {
+    loaderFeatures.ensureLoaderPackagesExist('sass');
+
+    const sassLoaders = [...cssLoaders(webpackConfig)];
+    if (true === webpackConfig.sassOptions.resolve_url_loader) {
+        // responsible for resolving SASS url() paths
+        // without this, all url() paths must be relative to the
+        // entry file, not the file that contains the url()
+        sassLoaders.push({
+            loader: 'resolve-url-loader',
+            options: {
+                sourceMap: webpackConfig.useSourceMaps
+            }
+        });
+    }
+
+    sassLoaders.push({
+        loader: 'sass-loader',
+        options: {
+            // needed by the resolve-url-loader
+            sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
+        }
+    });
+
+    return sassLoaders;
+};

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -10,35 +10,37 @@
 'use strict';
 
 const loaderFeatures = require('../loader-features');
-const cssLoaders = require('./css');
+const cssLoader = require('./css');
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @return {Array} of loaders to use for Sass files
  */
-module.exports = function(webpackConfig) {
-    loaderFeatures.ensureLoaderPackagesExist('sass');
+module.exports = {
+    getLoaders(webpackConfig) {
+        loaderFeatures.ensureLoaderPackagesExist('sass');
 
-    const sassLoaders = [...cssLoaders(webpackConfig)];
-    if (true === webpackConfig.sassOptions.resolve_url_loader) {
-        // responsible for resolving SASS url() paths
-        // without this, all url() paths must be relative to the
-        // entry file, not the file that contains the url()
+        const sassLoaders = [...cssLoader.getLoaders(webpackConfig)];
+        if (true === webpackConfig.sassOptions.resolve_url_loader) {
+            // responsible for resolving SASS url() paths
+            // without this, all url() paths must be relative to the
+            // entry file, not the file that contains the url()
+            sassLoaders.push({
+                loader: 'resolve-url-loader',
+                options: {
+                    sourceMap: webpackConfig.useSourceMaps
+                }
+            });
+        }
+
         sassLoaders.push({
-            loader: 'resolve-url-loader',
+            loader: 'sass-loader',
             options: {
-                sourceMap: webpackConfig.useSourceMaps
+                // needed by the resolve-url-loader
+                sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
             }
         });
+
+        return sassLoaders;
     }
-
-    sassLoaders.push({
-        loader: 'sass-loader',
-        options: {
-            // needed by the resolve-url-loader
-            sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
-        }
-    });
-
-    return sassLoaders;
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nsp": "^2.6.3",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",
+    "sinon": "^2.3.4",
     "zombie": "^5.0.5"
   }
 }

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -254,32 +254,6 @@ describe('The config-generator function', () => {
         });
     });
 
-    describe('enablePostCssLoader() adds the postcss-loader', () => {
-        it('without enablePostCssLoader()', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-            //config.enablePostCssLoader();
-
-            const actualConfig = configGenerator(config);
-
-            expect(JSON.stringify(actualConfig.module.rules)).to.not.contain('postcss-loader');
-        });
-
-        it('enablePostCssLoader()', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-            config.enablePostCssLoader();
-
-            const actualConfig = configGenerator(config);
-
-            expect(JSON.stringify(actualConfig.module.rules)).to.contain('postcss-loader');
-        });
-    });
-
     describe('enableSassLoader() adds the sass-loader', () => {
         it('without enableSassLoader()', () => {
             const config = createConfig();
@@ -303,22 +277,6 @@ describe('The config-generator function', () => {
             const actualConfig = configGenerator(config);
 
             expect(JSON.stringify(actualConfig.module.rules)).to.contain('sass-loader');
-            expect(JSON.stringify(actualConfig.module.rules)).to.contain('resolve-url-loader');
-            // sourceMap option is needed for resolve-url-loader
-            expect(JSON.stringify(actualConfig.module.rules)).to.contain('"sourceMap":true');
-        });
-
-        it('enableSassLoader() without resolve_url_loader', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-            config.enableSassLoader({ resolve_url_loader: false });
-
-            const actualConfig = configGenerator(config);
-
-            expect(JSON.stringify(actualConfig.module.rules)).to.not.contain('resolve-url-loader');
-            expect(JSON.stringify(actualConfig.module.rules)).to.contain('"sourceMap":false');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -373,7 +373,7 @@ describe('The config-generator function', () => {
             const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
 
             // check for the default env preset only
-            expect(JSON.stringify(jsRule.use.options.presets)).contains('env');
+            expect(JSON.stringify(jsRule.use[0].options.presets)).contains('env');
         });
 
         it('If .babelrc is present, we pass *no* config', () => {
@@ -389,7 +389,7 @@ describe('The config-generator function', () => {
             const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
 
             // the options should only contain the cacheDirectory option
-            expect(JSON.stringify(jsRule.use.options)).to.equal(JSON.stringify({ 'cacheDirectory': true }));
+            expect(JSON.stringify(jsRule.use[0].options)).to.equal(JSON.stringify({ 'cacheDirectory': true }));
         });
 
         it('configureBabel() passes babel options', () => {
@@ -405,7 +405,7 @@ describe('The config-generator function', () => {
 
             const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
 
-            expect(jsRule.use.options.presets).to.include('foo');
+            expect(jsRule.use[0].options.presets).to.include('foo');
         });
 
         it('enableReactPreset() passes react preset to babel', () => {
@@ -422,9 +422,9 @@ describe('The config-generator function', () => {
 
             const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
 
-            expect(jsRule.use.options.presets).to.include('react');
+            expect(jsRule.use[0].options.presets).to.include('react');
             // foo is also still there, not overridden
-            expect(jsRule.use.options.presets).to.include('foo');
+            expect(jsRule.use[0].options.presets).to.include('foo');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -375,57 +375,6 @@ describe('The config-generator function', () => {
             // check for the default env preset only
             expect(JSON.stringify(jsRule.use[0].options.presets)).contains('env');
         });
-
-        it('If .babelrc is present, we pass *no* config', () => {
-            const runtimeConfig = new RuntimeConfig();
-            runtimeConfig.babelRcFileExists = true;
-            const config = createConfig(runtimeConfig);
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-
-            const actualConfig = configGenerator(config);
-
-            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
-
-            // the options should only contain the cacheDirectory option
-            expect(JSON.stringify(jsRule.use[0].options)).to.equal(JSON.stringify({ 'cacheDirectory': true }));
-        });
-
-        it('configureBabel() passes babel options', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-            config.configureBabel(function(babelConfig) {
-                babelConfig.presets.push('foo');
-            });
-
-            const actualConfig = configGenerator(config);
-
-            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
-
-            expect(jsRule.use[0].options.presets).to.include('foo');
-        });
-
-        it('enableReactPreset() passes react preset to babel', () => {
-            const config = createConfig();
-            config.outputPath = '/tmp/output/public-path';
-            config.publicPath = '/public-path';
-            config.addEntry('main', './main');
-            config.enableReactPreset();
-            config.configureBabel(function(babelConfig) {
-                babelConfig.presets.push('foo');
-            });
-
-            const actualConfig = configGenerator(config);
-
-            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
-
-            expect(jsRule.use[0].options.presets).to.include('react');
-            // foo is also still there, not overridden
-            expect(jsRule.use[0].options.presets).to.include('foo');
-        });
     });
 
     describe('cleanupOutputBeforeBuild() adds CleanWebpackPlugin', () => {

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const WebpackConfig = require('../../lib/WebpackConfig');
+const RuntimeConfig = require('../../lib/config/RuntimeConfig');
+const babelLoader = require('../../lib/loaders/babel');
+
+function createConfig() {
+    const runtimeConfig = new RuntimeConfig();
+    runtimeConfig.context = __dirname;
+    runtimeConfig.babelRcFileExists = false;
+
+    return new WebpackConfig(runtimeConfig);
+}
+
+describe('loaders/babel', () => {
+    it('getLoaders() basic usage', () => {
+        const config = createConfig();
+        config.runtimeConfig.babelRcFileExists = false;
+        config.configureBabel(function(config) {
+            config.foo = 'bar';
+        });
+
+        const actualLoaders = babelLoader.getLoaders(config);
+        expect(actualLoaders).to.have.lengthOf(1);
+        // the env preset is enabled by default
+        expect(actualLoaders[0].options.presets).to.have.lengthOf(1);
+        // callback is used
+        expect(actualLoaders[0].options.foo).to.equal('bar');
+    });
+
+    it('getLoaders() when .babelrc IS present', () => {
+        const config = createConfig();
+        config.runtimeConfig.babelRcFileExists = true;
+
+        const actualLoaders = babelLoader.getLoaders(config);
+        // we only add cacheDirectory
+        expect(actualLoaders[0].options).to.deep.equal({
+            cacheDirectory: true
+        });
+    });
+
+    it('getLoaders() with react', () => {
+        const config = createConfig();
+        config.enableReactPreset();
+
+        config.configureBabel(function(babelConfig) {
+            babelConfig.presets.push('foo');
+        });
+
+        const actualLoaders = babelLoader.getLoaders(config);
+
+        // env, react & foo
+        expect(actualLoaders[0].options.presets).to.have.lengthOf(3);
+        expect(actualLoaders[0].options.presets).to.include('react');
+        // foo is also still there, not overridden
+        expect(actualLoaders[0].options.presets).to.include('foo');
+    });
+});

--- a/test/loaders/css.js
+++ b/test/loaders/css.js
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const WebpackConfig = require('../../lib/WebpackConfig');
+const RuntimeConfig = require('../../lib/config/RuntimeConfig');
+const cssLoader = require('../../lib/loaders/css');
+
+function createConfig() {
+    const runtimeConfig = new RuntimeConfig();
+    runtimeConfig.context = __dirname;
+    runtimeConfig.babelRcFileExists = false;
+
+    return new WebpackConfig(runtimeConfig);
+}
+
+describe('loaders/css', () => {
+    it('getLoaders() basic usage', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        const actualLoaders = cssLoader.getLoaders(config);
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options.sourceMap).to.be.true;
+        expect(actualLoaders[0].options.minimize).to.be.false;
+    });
+
+    it('getLoaders() for production', () => {
+        const config = createConfig();
+        config.enableSourceMaps(false);
+        config.runtimeConfig.environment = 'production';
+
+        const actualLoaders = cssLoader.getLoaders(config);
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options.sourceMap).to.be.false;
+        expect(actualLoaders[0].options.minimize).to.be.true;
+    });
+
+    it('getLoaders() with PostCSS', () => {
+        const config = createConfig();
+        config.enableSourceMaps();
+        config.enablePostCssLoader();
+
+        const actualLoaders = cssLoader.getLoaders(config);
+        // css-loader & postcss-loader
+        expect(actualLoaders).to.have.lengthOf(2);
+        expect(actualLoaders[1].options.sourceMap).to.be.true;
+    });
+});

--- a/test/loaders/less.js
+++ b/test/loaders/less.js
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const WebpackConfig = require('../../lib/WebpackConfig');
+const RuntimeConfig = require('../../lib/config/RuntimeConfig');
+const lessLoader = require('../../lib/loaders/less');
+const cssLoader = require('../../lib/loaders/css');
+const sinon = require('sinon');
+
+function createConfig() {
+    const runtimeConfig = new RuntimeConfig();
+    runtimeConfig.context = __dirname;
+    runtimeConfig.babelRcFileExists = false;
+
+    return new WebpackConfig(runtimeConfig);
+}
+
+describe('loaders/less', () => {
+    it('getLoaders() basic usage', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        const actualLoaders = lessLoader.getLoaders(config);
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options.sourceMap).to.be.true;
+
+        cssLoader.getLoaders.restore();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,7 +1648,7 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -2230,6 +2230,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -3231,6 +3237,10 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3453,6 +3463,10 @@ mute-stream@0.0.5:
 nan@^2.3.0, nan@^2.3.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3846,6 +3860,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4664,6 +4684,10 @@ safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 sass-graph@^2.1.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -4799,6 +4823,19 @@ shelljs@^0.7.5:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.4.tgz#466ad8d1bae86d6db51aa218b92e997bc3e5db88"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -5129,6 +5166,10 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -5210,6 +5251,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.15:
   version "1.6.15"


### PR DESCRIPTION
This is intended to be an internal cosmetic change. The purpose (other than organization) is to help enable the Vue.js loader... which needs to be able to re-use most of this configuration.
