### PR TITLE
Add vue loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,6 +327,19 @@ module.exports = {
     },
 
     /**
+     * If enabled, the vue-loader is added:
+     * https://vue-loader.vuejs.org/en/
+     *
+     * @param {object} options see https://vue-loader.vuejs.org/en/configurations/advanced.html
+     * @return {exports}
+     */
+    enableVueLoader(options = {}) {
+        webpackConfig.enableVueLoader(options);
+
+        return this;
+    },
+
+    /**
      * If enabled, the output directory is emptied between
      * each build (to remove old files).
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -44,6 +44,8 @@ class WebpackConfig {
             resolve_url_loader: true
         };
         this.useLessLoader = false;
+        this.useVueLoader = false;
+        this.vueOptions = {};
         this.cleanupOutput = false;
         this.sharedCommonsEntryName = null;
         this.providedVariables = {};
@@ -215,6 +217,11 @@ class WebpackConfig {
 
     enableReactPreset() {
         this.useReact = true;
+    }
+
+    enableVueLoader(options) {
+        this.useVueLoader = true;
+        this.vueOptions = options;
     }
 
     cleanupOutputBeforeBuild() {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -235,6 +235,16 @@ class ConfigGenerator {
             });
         }
 
+        if (this.webpackConfig.useVueLoader) {
+            loaderFeatures.ensureLoaderPackagesExist('vue');
+
+            rules.push({
+                test: /\.vue/,
+                loader: 'vue-loader',
+                options: this.webpackConfig.vueOptions
+            });
+        }
+
         this.webpackConfig.loaders.forEach((loader) => {
             rules.push(loader);
         });

--- a/lib/loader-features.js
+++ b/lib/loader-features.js
@@ -35,6 +35,11 @@ const loaderFeatures = {
         method: 'enableReactPreset()',
         packages: ['babel-preset-react'],
         description: 'process React JS files'
+    },
+    vue: {
+        method: 'enableVueLoader()',
+        packages: ['vue-loader'],
+        description: 'load VUE files'
     }
 };
 

--- a/lib/loader-features.js
+++ b/lib/loader-features.js
@@ -38,7 +38,7 @@ const loaderFeatures = {
     },
     vue: {
         method: 'enableVueLoader()',
-        packages: ['vue-loader'],
+        packages: ['vue-loader', 'vue-template-compiler'],
         description: 'load VUE files'
     }
 };

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -277,6 +277,24 @@ describe('WebpackConfig object', () => {
         });
     });
 
+    describe('enableVueLoader', () => {
+        it('Call with no config', () => {
+            const config = createConfig();
+            config.enableVueLoader();
+
+            expect(config.useVueLoader).to.be.true;
+        });
+
+        it('Pass config', () => {
+            const config = createConfig();
+            config.enableVueLoader({ extractCSS: true });
+
+            expect(config.useVueLoader).to.be.true;
+            expect(config.vueOptions.extractCSS).to.be.true;
+        });
+
+    });
+
     describe('addLoader', () => {
         it('Adds a new loader', () => {
             const config = createConfig();

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -293,6 +293,7 @@ describe('WebpackConfig object', () => {
             expect(config.useVueLoader).to.be.true;
             expect(config.vueOptions.extractCSS).to.be.true;
         });
+    });
 
     describe('addPlugin', () => {
         it('extends the current registered plugins', () => {
@@ -305,7 +306,6 @@ describe('WebpackConfig object', () => {
 
             expect(config.plugins.length).to.equal(1);
         });
-
     });
 
     describe('addLoader', () => {


### PR DESCRIPTION
This PR is a patch to provide a vue.js support

before : 
`
    .addLoader({
        test: /\.vue$/,
        loader: 'vue-loader'
    })
`

After
`
     .enableVueLoader()
`
