### PR TITLE
Removing window.jQuery from autoProvidejQuery

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -244,7 +244,6 @@ class WebpackConfig {
         this.autoProvideVariables({
             $: 'jquery',
             jQuery: 'jquery',
-            'window.jQuery': 'jquery'
         });
     }
 


### PR DESCRIPTION
Fixes #32 

This is because - when this is enabled - it's impossible to expose jQuery as a global
variable on window (without use the expose loader). Specifically, window.jQuery = ...
is re-written in your JS code.

A docs PR also needs to be opened to document how to fix problems if a library depends on `window.jQuery` specifically (is there a good re-world example?)