### PR TITLE
Re-adding window.jQuery to autoProvidejQuery

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -244,6 +244,7 @@ class WebpackConfig {
         this.autoProvideVariables({
             $: 'jquery',
             jQuery: 'jquery',
+            'window.jQuery': 'jquery',
         });
     }
 


### PR DESCRIPTION
By adding `window.jQuery` to `autoProvidejQuery()`, it caused problems by making `window.jQuery = require('jquery')` not work (#32). But, *not* having it causes other obvious problems (see #52).

This re-adds `window.jQuery` back. As a fix, we would document exposing jQuery as a global variable by doing this:

```js
global.$ = global.jQuery = require('jquery');
```

ping @alOneh 