### PR TITLE
Fix missing comma and lint index

### DIFF
--- a/index.js
+++ b/index.js
@@ -357,7 +357,7 @@ module.exports = {
      */
     enableTypeScriptLoader(callback) {
         webpackConfig.enableTypeScriptLoader(callback);
-    }
+    },
 
     /**
      * If enabled, the Vue.js loader is enabled.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha --reporter spec test --recursive",
-    "lint": "./node_modules/.bin/eslint lib test",
+    "lint": "./node_modules/.bin/eslint lib test index.js",
     "travis:lint": "npm run lint && npm run nsp",
     "nsp": "./node_modules/.bin/nsp check --output summary"
   },


### PR DESCRIPTION
This fix #62 and adds index.js to lint task to avoid such things in future.

Missing comma is related to #50. I believe the merge remove it by accident.