### PR TITLE
Allow usage of devServer combined with an absolute URL as publicPath

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 
@@ -93,7 +94,8 @@ class WebpackConfig {
          */
         if (publicPath.includes('://')) {
             if (this.useDevServer()) {
-                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. Try using Encore.isProduction() to only configure your absolute publicPath for production.');
+                console.log(chalk.bgYellow.black(' WARNING ') + chalk.yellow(' You should not pass an absolute URL to setPublicPath() and use the dev-server at the same time'));
+                console.log();
             }
         } else {
             if (publicPath.indexOf('/') !== 0) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -130,8 +130,8 @@ class WebpackConfig {
      * @returns {string}
      */
     getRealPublicPath() {
-        // if we're using webpack-dev-server, use it & add the publicPath
-        if (this.useDevServer()) {
+        // if we're using webpack-dev-server and have no absolute url, use it & add the publicPath
+        if (this.useDevServer() && !this.publicPath.includes('://')) {
             // avoid 2 middle slashes
             return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
         }

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -105,13 +105,12 @@ describe('WebpackConfig object', () => {
             }).to.throw('The value passed to setPublicPath() must start with "/"');
         });
 
-        it('Setting to a URL when using devServer throws an error', () => {
+        it('You can set to a URL when using devServer', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
+            config.setPublicPath('https://examplecdn.com');
 
-            expect(() => {
-                config.setPublicPath('https://examplecdn.com');
-            }).to.throw('You cannot pass an absolute URL to setPublicPath() and use the dev-server');
+            expect(config.publicPath).to.equal('https://examplecdn.com/');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -375,6 +375,23 @@ describe('The config-generator function', () => {
             expect(actualConfig.devServer).to.be.undefined;
         });
 
+        it('devServer and an absolute URL as publicPath', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
+            config.setManifestKeyPrefix('public');
+            config.setPublicPath('https://cdn.example.com');
+            config.addEntry('main', './main');
+
+            const actualConfig = configGenerator(config);
+            expect(actualConfig.output.publicPath).to.equal('https://cdn.example.com/');
+            expect(actualConfig.devServer).to.not.be.undefined;
+
+            const manifestPlugin = findPlugin(ManifestPlugin, actualConfig.plugins);
+            expect(manifestPlugin.opts.publicPath).to.equal('https://cdn.example.com/');
+        });
+
         it('devServer no hot mode', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;


### PR DESCRIPTION
This fixes #59 when webpack encore is used inside a docker container and webpack-dev-server needs an absolute URL.

I'm not sure about printing and message of warning.
I used console.log for printing analogous to "bin/encore.js" but maybe FriendlyErrorsWebpackPlugin should be used... There aren't any other warnings yet whjch I could take for reference.