### PR TITLE
Making enableTypeScriptLoader() options callback optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,17 +345,19 @@ module.exports = {
     /**
      * Call this if you plan on loading TypeScript files.
      *
-     * Encore.enableTypeScriptLoader(function(tsConfig) {
-     *      // change the tsConfig
-     * });
+     * Encore.enableTypeScriptLoader()
      *
-     * Supported configuration options:
-     * @see https://github.com/TypeStrong/ts-loader/blob/master/README.md#available-options
+     * Or, configure the ts-loader options:
+     *
+     * Encore.enableTypeScriptLoader(function(tsConfig) {
+     *      // https://github.com/TypeStrong/ts-loader/blob/master/README.md#loader-options
+     *      // tsConfig.silent = false;
+     * });
      *
      * @param {function} callback
      * @return {exports}
      */
-    enableTypeScriptLoader(callback) {
+    enableTypeScriptLoader(callback = () => {}) {
         webpackConfig.enableTypeScriptLoader(callback);
     },
 

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -226,7 +226,7 @@ class WebpackConfig {
         this.useReact = true;
     }
 
-    enableTypeScriptLoader(callback) {
+    enableTypeScriptLoader(callback = () => {}) {
         this.useTypeScriptLoader = true;
 
         if (typeof callback !== 'function') {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -292,10 +292,6 @@ describe('WebpackConfig object', () => {
             expect(() => {
                 config.enableTypeScriptLoader('FOO');
             }).to.throw('must be a callback function');
-
-            expect(() => {
-                config.enableTypeScriptLoader();
-            }).to.throw('must be a callback function');
         });
     });
 


### PR DESCRIPTION
The `enableTypeScriptLoader()` should allow for no callback function - it's probably not needed in most cases.

Ping @davidmpaz 
