### PR TITLE
Adding ability to pass options to sass-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## 0.10.0
+
+ * [BC BREAK] If you're using `enableSassLoader()` AND passing an options
+   array, the options now need to be moved to the second argument:
+
+   ```js
+   // before
+   .enableSassLoader({ resolve_url_loader: true });
+
+   // after
+   enableSassLoader(function(sassOptions) {}, {
+       resolve_url_loader: true
+   })
+   ```
+
 ## 0.9.1
 
  * Syntax error fix - #64

--- a/index.js
+++ b/index.js
@@ -282,6 +282,18 @@ module.exports = {
     /**
      * Call this if you plan on loading SASS files.
      *
+     *     Encore.enableSassLoader();
+     *
+     * Or pass options to node-sass
+     *
+     *     Encore.enableSassLoader(function(options) {
+     *         // https://github.com/sass/node-sass#options
+     *         // options.includePaths = [...]
+     *     }, {
+     *         // set optional Encore-specific options
+     *         // resolve_url_loader: true
+     *     });
+     *
      * Supported options:
      *      * {bool} resolve_url_loader (default=true)
      *              Whether or not to use the resolve-url-loader.
@@ -291,11 +303,12 @@ module.exports = {
      *              to the original entry file... not whatever file
      *              the url() appears in.
      *
-     * @param {object} options
+     * @param {function} sassLoaderOptionsCallback
+     * @param {object} encoreOptions
      * @return {exports}
      */
-    enableSassLoader(options = {}) {
-        webpackConfig.enableSassLoader(options);
+    enableSassLoader(sassLoaderOptionsCallback = () => {}, encoreOptions = {}) {
+        webpackConfig.enableSassLoader(sassLoaderOptionsCallback, encoreOptions);
 
         return this;
     },

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -41,6 +41,7 @@ class WebpackConfig {
         this.useSourceMaps = false;
         this.usePostCssLoader = false;
         this.useSassLoader = false;
+        this.sassLoaderOptionsCallback = function() {};
         this.sassOptions = {
             resolve_url_loader: true
         };
@@ -206,8 +207,14 @@ class WebpackConfig {
         this.usePostCssLoader = true;
     }
 
-    enableSassLoader(options = {}) {
+    enableSassLoader(sassLoaderOptionsCallback = () => {}, options = {}) {
         this.useSassLoader = true;
+
+        if (typeof sassLoaderOptionsCallback !== 'function') {
+            throw new Error('Argument 1 to enableSassLoader() must be a callback function.');
+        }
+
+        this.sassLoaderOptionsCallback = sassLoaderOptionsCallback;
 
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.sassOptions)) {

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -35,12 +35,21 @@ module.exports = {
             });
         }
 
+        let config = Object.assign({}, sassOptions, {
+            // needed by the resolve-url-loader
+            sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
+        });
+
+        // allow options to be configured
+        webpackConfig.sassLoaderOptionsCallback.apply(
+            // use config as the this variable
+            config,
+            [config]
+        );
+
         sassLoaders.push({
             loader: 'sass-loader',
-            options: Object.assign({}, sassOptions, {
-                // needed by the resolve-url-loader
-                sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
-            }),
+            options: config,
         });
 
         return sassLoaders;

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -263,7 +263,7 @@ describe('WebpackConfig object', () => {
 
         it('Pass valid config', () => {
             const config = createConfig();
-            config.enableSassLoader({ resolve_url_loader: false });
+            config.enableSassLoader(() => {}, { resolve_url_loader: false });
 
             expect(config.useSassLoader).to.be.true;
             expect(config.sassOptions.resolve_url_loader).to.be.false;
@@ -273,8 +273,16 @@ describe('WebpackConfig object', () => {
             const config = createConfig();
 
             expect(() => {
-                config.enableSassLoader({ fake_option: false });
+                config.enableSassLoader(() => {}, { fake_option: false });
             }).to.throw('Invalid option "fake_option" passed to enableSassLoader()');
+        });
+
+        it('Pass options callback', () => {
+            const config = createConfig();
+            const callback = (sassOptions) => {};
+            config.enableSassLoader(callback);
+
+            expect(config.sassLoaderOptionsCallback).to.equal(callback);
         });
     });
 

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -66,7 +66,7 @@ describe('loaders/sass', () => {
 
     it('getLoaders() without resolve-url-loader', () => {
         const config = createConfig();
-        config.enableSassLoader({
+        config.enableSassLoader(() => {}, {
             resolve_url_loader: false,
         });
         config.enableSourceMaps(false);
@@ -98,6 +98,33 @@ describe('loaders/sass', () => {
         // custom option
         expect(actualLoaders[1].options.custom_option).to.equal('foo');
 
+        cssLoader.getLoaders.restore();
+    });
+
+    it('getLoaders() with options callback', () => {
+        const config = createConfig();
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        config.enableSassLoader(function(sassOptions) {
+            sassOptions.custom_optiona = 'baz';
+            sassOptions.other_option = true;
+        });
+
+        const actualLoaders = sassLoader.getLoaders(config, {
+            custom_optiona: 'foo',
+            custom_optionb: 'bar'
+        });
+
+        expect(actualLoaders[1].options).to.deep.equals({
+            sourceMap: true,
+            // callback wins over passed in options
+            custom_optiona: 'baz',
+            custom_optionb: 'bar',
+            other_option: true
+        });
         cssLoader.getLoaders.restore();
     });
 });


### PR DESCRIPTION
Fixes #14 

This is a BC break, which I want to minimize. But, since we're pre 1.0, BC breaks are allowed. And this will fail clearly the first time you try to run encore.

Docs: https://github.com/symfony/symfony-docs/pull/8108
