### PR TITLE
Fix inability to use scss loader with Vue.js

### DIFF
--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -107,7 +107,7 @@ module.exports = {
                 true
             );
         } else {
-            loaders.scss = {
+            loaders.less = {
                 loader: require.resolve('./vue-unactivated-loader'),
                 options: {
                     lang: 'less',

--- a/test/functional.js
+++ b/test/functional.js
@@ -726,7 +726,9 @@ module.exports = {
             config.enableVueLoader();
 
             testSetup.runWebpack(config, (webpackAssert, stats) => {
-                expect(stats.toJson().errors[0]).to.contain('Cannot process lang="less" inside');
+                expect(stats.toJson().errors[0]).to.contain('Cannot process lang="scss" inside');
+                expect(stats.toJson().errors[1]).to.contain('Cannot process lang="sass" inside');
+                expect(stats.toJson().errors[2]).to.contain('Cannot process lang="less" inside');
                 done();
             }, true);
         });


### PR DESCRIPTION
Prior to this fix when the less loader isn't enabled, the scss loader config is rewritten by mistake, leading to this error:

> Module build failed: Error: Cannot process lang="less" inside src/js/Player.vue: the less-loader is not activated.

I also fix a functional test case for Vue.js. Actually, the tests check if the first error thrown by webpack is about missing less loader. But the fixtures needs these loaders in the following order: scss, sass and finally less. Since there's no other loader than the VueJs one loaded in this test case, errors should be in the same order.