### PR TITLE
Relaxed public path requirements with dev-server

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const path = require('path');
 const parseRuntime = require('../lib/config/parse-runtime');
 const context = require('../lib/context');
 const chalk = require('chalk');

--- a/bin/encore.js
+++ b/bin/encore.js
@@ -62,11 +62,14 @@ function showUsageInstructions() {
     console.log('Commands:');
     console.log(`    ${chalk.green('dev')}        : runs webpack for development`);
     console.log('       - Supports any webpack options (e.g. --watch)');
+    console.log();
     console.log(`    ${chalk.green('dev-server')} : runs webpack-dev-server`);
     console.log(`       - ${chalk.yellow('--host')} The hostname/ip address the webpack-dev-server will bind to`);
     console.log(`       - ${chalk.yellow('--port')} The port the webpack-dev-server will bind to`);
     console.log(`       - ${chalk.yellow('--hot')}  Enable HMR on webpack-dev-server`);
+    console.log(`       - ${chalk.yellow('--keep-public-path')} Do not change the public path (it is usually prefixed by the dev server URL)`);
     console.log('       - Supports any webpack-dev-server options');
+    console.log();
     console.log(`    ${chalk.green('production')} : runs webpack for production`);
     console.log('       - Supports any webpack options (e.g. --watch)');
     console.log();

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const configGenerator = require('./lib/config-generator');
 const validator = require('./lib/config/validator');
 const PrettyError = require('pretty-error');
 const runtimeConfig = require('./lib/context').runtimeConfig;
+const logger = require('./lib/logger');
 
 // at this time, the encore executable should have set the runtimeConfig
 if (!runtimeConfig) {
@@ -21,6 +22,9 @@ if (!runtimeConfig) {
 }
 
 let webpackConfig = new WebpackConfig(runtimeConfig);
+if (runtimeConfig.verbose) {
+    logger.verbose();
+}
 
 module.exports = {
     /**

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 
@@ -94,7 +95,8 @@ class WebpackConfig {
          */
         if (publicPath.includes('://')) {
             if (this.useDevServer()) {
-                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. Try using Encore.isProduction() to only configure your absolute publicPath for production.');
+                console.log(chalk.bgYellow.black(' WARNING ') + chalk.yellow(' You should not pass an absolute URL to setPublicPath() and use the dev-server at the same time'));
+                console.log();
             }
         } else {
             if (publicPath.indexOf('/') !== 0) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -131,8 +131,8 @@ class WebpackConfig {
      * @returns {string}
      */
     getRealPublicPath() {
-        // if we're using webpack-dev-server, use it & add the publicPath
-        if (this.useDevServer()) {
+        // if we're using webpack-dev-server and have no absolute url, use it & add the publicPath
+        if (this.useDevServer() && !this.publicPath.includes('://')) {
             // avoid 2 middle slashes
             return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
         }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -93,8 +93,8 @@ class WebpackConfig {
          * is simply used as the default manifestKeyPrefix.
          */
         if (publicPath.includes('://')) {
-            if (this.useDevServer()) {
-                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. Try using Encore.isProduction() to only configure your absolute publicPath for production.');
+            if (this.useDevServer() && false === this.runtimeConfig.devServerKeepPublicPath) {
+                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. This is because the public path is automatically set to point to the dev server. Try using Encore.isProduction() to only configure your absolute publicPath for production. Or, if you want to override this behavior, pass the --keep-public-path option to allow this.');
             }
         } else {
             if (publicPath.indexOf('/') !== 0) {
@@ -130,7 +130,7 @@ class WebpackConfig {
      */
     getRealPublicPath() {
         // if we're using webpack-dev-server, use it & add the publicPath
-        if (this.useDevServer()) {
+        if (this.useDevServer() && false === this.runtimeConfig.devServerKeepPublicPath) {
             // avoid 2 middle slashes
             return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
         }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -86,23 +86,11 @@ class WebpackConfig {
     }
 
     setPublicPath(publicPath) {
-        /*
-         * Do not allow absolute URLs *and* the webpackDevServer
-         * to be used at the same time. The webpackDevServer basically
-         * provides the publicPath (and so in those cases, publicPath)
-         * is simply used as the default manifestKeyPrefix.
-         */
-        if (publicPath.includes('://')) {
-            if (this.useDevServer() && false === this.runtimeConfig.devServerKeepPublicPath) {
-                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. This is because the public path is automatically set to point to the dev server. Try using Encore.isProduction() to only configure your absolute publicPath for production. Or, if you want to override this behavior, pass the --keep-public-path option to allow this.');
-            }
-        } else {
-            if (publicPath.indexOf('/') !== 0) {
-                // technically, not starting with "/" is legal, but not
-                // what you want in most cases. Let's not let the user make
-                // a mistake (and we can always change this later).
-                throw new Error('The value passed to setPublicPath() must start with "/" or be a full URL (http://...)');
-            }
+        if (publicPath.includes('://') === false && publicPath.indexOf('/') !== 0) {
+            // technically, not starting with "/" is legal, but not
+            // what you want in most cases. Let's not let the user make
+            // a mistake (and we can always change this later).
+            throw new Error('The value passed to setPublicPath() must start with "/" or be a full URL (http://...)');
         }
 
         // guarantee a single trailing slash
@@ -129,13 +117,20 @@ class WebpackConfig {
      * @returns {string}
      */
     getRealPublicPath() {
-        // if we're using webpack-dev-server, use it & add the publicPath
-        if (this.useDevServer() && false === this.runtimeConfig.devServerKeepPublicPath) {
-            // avoid 2 middle slashes
-            return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
+        if (!this.useDevServer()) {
+            return this.publicPath;
         }
 
-        return this.publicPath;
+        if (this.runtimeConfig.devServerKeepPublicPath) {
+            return this.publicPath;
+        }
+
+        if (this.publicPath.includes('://')) {
+            return this.publicPath;
+        }
+
+        // if using dev-server, prefix the publicPath with the dev server URL
+        return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
     }
 
     addEntry(name, src) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 
@@ -95,8 +94,7 @@ class WebpackConfig {
          */
         if (publicPath.includes('://')) {
             if (this.useDevServer()) {
-                console.log(chalk.bgYellow.black(' WARNING ') + chalk.yellow(' You should not pass an absolute URL to setPublicPath() and use the dev-server at the same time'));
-                console.log();
+                throw new Error('You cannot pass an absolute URL to setPublicPath() and use the dev-server at the same time. Try using Encore.isProduction() to only configure your absolute publicPath for production.');
             }
         } else {
             if (publicPath.indexOf('/') !== 0) {
@@ -131,8 +129,8 @@ class WebpackConfig {
      * @returns {string}
      */
     getRealPublicPath() {
-        // if we're using webpack-dev-server and have no absolute url, use it & add the publicPath
-        if (this.useDevServer() && !this.publicPath.includes('://')) {
+        // if we're using webpack-dev-server, use it & add the publicPath
+        if (this.useDevServer()) {
             // avoid 2 middle slashes
             return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
         }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -381,7 +381,8 @@ class ConfigGenerator {
 
         return {
             contentBase: contentBase,
-            publicPath: this.webpackConfig.publicPath,
+            // this doesn't appear to be necessary, but here in case
+            publicPath: this.webpackConfig.getRealPublicPath(),
             // avoid CORS concerns trying to load things like fonts from the dev server
             headers: { 'Access-Control-Allow-Origin': '*' },
             hot: this.webpackConfig.useHotModuleReplacementPlugin(),

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -384,8 +384,8 @@ class ConfigGenerator {
             publicPath: this.webpackConfig.publicPath,
             // avoid CORS concerns trying to load things like fonts from the dev server
             headers: { 'Access-Control-Allow-Origin': '*' },
-            // required by FriendlyErrorsWebpackPlugin
             hot: this.webpackConfig.useHotModuleReplacementPlugin(),
+            // required by FriendlyErrorsWebpackPlugin
             quiet: true,
             compress: true,
             historyApiFallback: true,

--- a/lib/config/RuntimeConfig.js
+++ b/lib/config/RuntimeConfig.js
@@ -19,6 +19,7 @@ class RuntimeConfig {
         this.useDevServer = null;
         this.devServerUrl = null;
         this.devServerHttps = null;
+        this.devServerKeepPublicPath = false;
         this.useHotModuleReplacement = null;
 
         this.babelRcFileExists = null;

--- a/lib/config/RuntimeConfig.js
+++ b/lib/config/RuntimeConfig.js
@@ -25,6 +25,7 @@ class RuntimeConfig {
         this.babelRcFileExists = null;
 
         this.helpRequested = false;
+        this.verbose = false;
     }
 }
 

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -40,6 +40,7 @@ module.exports = function(argv, cwd) {
             runtimeConfig.useDevServer = true;
             runtimeConfig.devServerHttps = argv.https;
             runtimeConfig.useHotModuleReplacement = argv.hot || false;
+            runtimeConfig.devServerKeepPublicPath = argv.keepPublicPath || false;
 
             var host = argv.host ? argv.host : 'localhost';
             var port = argv.port ? argv.port : '8080';

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -29,14 +29,18 @@ module.exports = function(argv, cwd) {
         case 'dev':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'dev';
+            runtimeConfig.verbose = true;
             break;
         case 'production':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'production';
+            runtimeConfig.verbose = false;
             break;
         case 'dev-server':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'dev';
+            runtimeConfig.verbose = true;
+
             runtimeConfig.useDevServer = true;
             runtimeConfig.devServerHttps = argv.https;
             runtimeConfig.useHotModuleReplacement = argv.hot || false;

--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const pathUtil = require('./path-util');
+const logger = require('./../logger');
 
 class Validator {
     /**
@@ -46,8 +47,23 @@ class Validator {
     }
 
     _validateDevServer() {
-        if (this.webpackConfig.useVersioning && this.webpackConfig.useDevServer()) {
+        if (!this.webpackConfig.useDevServer()) {
+            return;
+        }
+
+        if (this.webpackConfig.useVersioning) {
             throw new Error('Don\'t enable versioning with the dev-server. A good setting is Encore.enableVersioning(Encore.isProduction()).');
+        }
+
+        /*
+         * An absolute publicPath is incompatible with webpackDevServer.
+         * This is because we want to *change* the publicPath to point
+         * to the webpackDevServer URL (e.g. http://localhost:8080/).
+         * There are some valid use-cases for not wanting this behavior
+         * (see #59), but we want to warn the user.
+         */
+        if (this.webpackConfig.publicPath.includes('://')) {
+            logger.warning(`Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues. Your assets will load from the publicPath (${this.webpackConfig.publicPath}) instead of from the dev server URL (${this.webpackConfig.runtimeConfig.devServerUrl}).`);
         }
     }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const chalk = require('chalk');
+let isVerbose = false;
+let quiet = false;
+let messages = {
+    debug: [],
+    warning: [],
+};
+
+function log(message) {
+    if (quiet) {
+        return;
+    }
+
+    console.log(message);
+}
+
+module.exports = {
+    debug(message) {
+        messages.debug.push(message);
+
+        if (isVerbose) {
+            log(`${chalk.bgBlack.white(' DEBUG ')} ${message}`);
+        }
+    },
+
+    warning(message) {
+        messages.warning.push(message);
+
+        log(`${chalk.bgYellow.black(' WARNING ')} ${chalk.yellow(message)}`);
+    },
+
+    clearMessages() {
+        messages.debug = [];
+        messages.warning = [];
+    },
+
+    getMessages() {
+        return messages;
+    },
+
+    quiet() {
+        quiet = true;
+    },
+
+    verbose() {
+        isVerbose = true;
+    }
+};

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -104,15 +104,6 @@ describe('WebpackConfig object', () => {
                 config.setPublicPath('foo/');
             }).to.throw('The value passed to setPublicPath() must start with "/"');
         });
-
-        it('Setting to a URL when using devServer throws an error', () => {
-            const config = createConfig();
-            config.runtimeConfig.useDevServer = true;
-
-            expect(() => {
-                config.setPublicPath('https://examplecdn.com');
-            }).to.throw('You cannot pass an absolute URL to setPublicPath() and use the dev-server');
-        });
     });
 
     describe('getRealPublicPath', () => {
@@ -142,11 +133,10 @@ describe('WebpackConfig object', () => {
             expect(config.getRealPublicPath()).to.equal('/public/');
         });
 
-        it('devServer & devServerKeepPublicPath option allows absolute publicPath', () => {
+        it('devServer does not prefix if publicPath is absolute', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
-            config.runtimeConfig.devServerKeepPublicPath = true;
             config.setPublicPath('http://coolcdn.com/public');
             config.setManifestKeyPrefix('/public/');
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -105,13 +105,12 @@ describe('WebpackConfig object', () => {
             }).to.throw('The value passed to setPublicPath() must start with "/"');
         });
 
-        it('Setting to a URL when using devServer throws an error', () => {
+        it('You can set to a URL when using devServer', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
+            config.setPublicPath('https://examplecdn.com');
 
-            expect(() => {
-                config.setPublicPath('https://examplecdn.com');
-            }).to.throw('You cannot pass an absolute URL to setPublicPath() and use the dev-server');
+            expect(config.publicPath).to.equal('https://examplecdn.com/');
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -105,12 +105,52 @@ describe('WebpackConfig object', () => {
             }).to.throw('The value passed to setPublicPath() must start with "/"');
         });
 
-        it('You can set to a URL when using devServer', () => {
+        it('Setting to a URL when using devServer throws an error', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
-            config.setPublicPath('https://examplecdn.com');
 
-            expect(config.publicPath).to.equal('https://examplecdn.com/');
+            expect(() => {
+                config.setPublicPath('https://examplecdn.com');
+            }).to.throw('You cannot pass an absolute URL to setPublicPath() and use the dev-server');
+        });
+    });
+
+    describe('getRealPublicPath', () => {
+        it('Returns normal with no dev server', () => {
+            const config = createConfig();
+            config.setPublicPath('/public');
+
+            expect(config.getRealPublicPath()).to.equal('/public/');
+        });
+
+        it('Prefix when using devServer', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.setPublicPath('/public');
+
+            expect(config.getRealPublicPath()).to.equal('http://localhost:8080/public/');
+        });
+
+        it('No prefix with devServer & devServerKeepPublicPath option', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.runtimeConfig.devServerKeepPublicPath = true;
+            config.setPublicPath('/public');
+
+            expect(config.getRealPublicPath()).to.equal('/public/');
+        });
+
+        it('devServer & devServerKeepPublicPath option allows absolute publicPath', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.runtimeConfig.devServerKeepPublicPath = true;
+            config.setPublicPath('http://coolcdn.com/public');
+            config.setManifestKeyPrefix('/public/');
+
+            expect(config.getRealPublicPath()).to.equal('http://coolcdn.com/public');
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -150,7 +150,7 @@ describe('WebpackConfig object', () => {
             config.setPublicPath('http://coolcdn.com/public');
             config.setManifestKeyPrefix('/public/');
 
-            expect(config.getRealPublicPath()).to.equal('http://coolcdn.com/public');
+            expect(config.getRealPublicPath()).to.equal('http://coolcdn.com/public/');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -375,23 +375,6 @@ describe('The config-generator function', () => {
             expect(actualConfig.devServer).to.be.undefined;
         });
 
-        it('devServer and an absolute URL as publicPath', () => {
-            const config = createConfig();
-            config.runtimeConfig.useDevServer = true;
-            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
-            config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
-            config.setManifestKeyPrefix('public');
-            config.setPublicPath('https://cdn.example.com');
-            config.addEntry('main', './main');
-
-            const actualConfig = configGenerator(config);
-            expect(actualConfig.output.publicPath).to.equal('https://cdn.example.com/');
-            expect(actualConfig.devServer).to.not.be.undefined;
-
-            const manifestPlugin = findPlugin(ManifestPlugin, actualConfig.plugins);
-            expect(manifestPlugin.opts.publicPath).to.equal('https://cdn.example.com/');
-        });
-
         it('devServer no hot mode', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -375,6 +375,23 @@ describe('The config-generator function', () => {
             expect(actualConfig.devServer).to.be.undefined;
         });
 
+        it('devServer and an absolute URL as publicPath', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
+            config.setManifestKeyPrefix('public');
+            config.setPublicPath('https://cdn.example.com');
+            config.addEntry('main', './main');
+
+            const actualConfig = configGenerator(config);
+            expect(actualConfig.output.publicPath).to.equal('https://cdn.example.com/');
+            expect(actualConfig.devServer).to.not.be.undefined;
+
+            const manifestPlugin = findPlugin(ManifestPlugin, actualConfig.plugins);
+            expect(manifestPlugin.opts.publicPath).to.equal('https://cdn.example.com/');
+        });
+
         it('devServer no hot mode', () => {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -69,6 +69,7 @@ describe('parse-runtime', () => {
         expect(config.useDevServer).to.be.true;
         expect(config.devServerUrl).to.equal('http://localhost:8080/');
         expect(config.useHotModuleReplacement).to.be.false;
+        expect(config.devServerKeepPublicPath).to.be.false;
     });
 
     it('dev-server command with options', () => {
@@ -113,5 +114,13 @@ describe('parse-runtime', () => {
 
         expect(config.useDevServer).to.be.true;
         expect(config.useHotModuleReplacement).to.be.true;
+    });
+
+    it('dev-server command --keep-public-path', () => {
+        const testDir = createTestDirectory();
+        const config = parseArgv(createArgv(['dev-server', '--keep-public-path']), testDir);
+
+        expect(config.useDevServer).to.be.true;
+        expect(config.devServerKeepPublicPath).to.be.true;
     });
 });

--- a/test/config/validator.js
+++ b/test/config/validator.js
@@ -13,6 +13,9 @@ const expect = require('chai').expect;
 const WebpackConfig = require('../../lib/WebpackConfig');
 const RuntimeConfig = require('../../lib/config/RuntimeConfig');
 const validator = require('../../lib/config/validator');
+const logger = require('../../lib/logger');
+
+logger.quiet();
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -64,5 +67,20 @@ describe('The validator function', () => {
         expect(() => {
             validator(config);
         }).to.throw('Don\'t enable versioning with the dev-server');
+    });
+
+    it('warning with dev-server and absolute publicPath', () => {
+        const config = createConfig();
+        config.outputPath = '/tmp/public/build';
+        config.setPublicPath('https://absoluteurl.com/build');
+        config.setManifestKeyPrefix('build/');
+        config.addEntry('main', './main');
+        config.runtimeConfig.useDevServer = true;
+
+        logger.clearMessages();
+        validator(config);
+
+        expect(logger.getMessages().warning).to.have.lengthOf(1);
+        expect(logger.getMessages().warning[0]).to.include('Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues');
     });
 });


### PR DESCRIPTION
Fixes #59 and finishes #66.

* Adds a new `--keep-public-path` option for `dev-server`. When used, your `publicPath` is not prefixed with the dev server URL. For #59, this means you can use `setPublicPath('/build')` with the dev-server, and your assets will remain local (i.e. `/build/main.js` instead of `http://localhost:8080/build/main.js`).

* It is now possible to pass an absolute URL to `setPublicPath()` without an error when using `dev-server`. But, we issue a big warning, because this means your assets will point to to that absolute URL, instead of to the dev-server (which for most setups, is not what you want).

@samjarrett I'd love to confirm that this would solve your issue in Docker :).