### PR TITLE
Fix missing tsloader return statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,6 +372,8 @@ module.exports = {
      */
     enableTypeScriptLoader(callback = () => {}) {
         webpackConfig.enableTypeScriptLoader(callback);
+
+        return this;
     },
 
     /**

--- a/test/api.js
+++ b/test/api.js
@@ -30,7 +30,7 @@ describe('Public API', () => {
             const returnedValue = api.setPublicPath('/');
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('setManifestKeyPrefix', () => {
@@ -39,7 +39,7 @@ describe('Public API', () => {
             const returnedValue = api.setManifestKeyPrefix('/build');
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('addEntry', () => {
@@ -48,7 +48,7 @@ describe('Public API', () => {
             const returnedValue = api.addEntry('entry', 'main.js');
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('addStyleEntry', () => {
@@ -57,7 +57,7 @@ describe('Public API', () => {
             const returnedValue = api.addStyleEntry('styleEntry', 'main.css');
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('addPlugin', () => {
@@ -66,7 +66,7 @@ describe('Public API', () => {
             const returnedValue = api.addPlugin(null);
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('addLoader', () => {
@@ -75,7 +75,7 @@ describe('Public API', () => {
             const returnedValue = api.addLoader(null);
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('addRule', () => {
@@ -84,7 +84,7 @@ describe('Public API', () => {
             const returnedValue = api.addRule(null);
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableVersioning', () => {
@@ -93,7 +93,7 @@ describe('Public API', () => {
             const returnedValue = api.enableVersioning();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableSourceMaps', () => {
@@ -102,7 +102,7 @@ describe('Public API', () => {
             const returnedValue = api.enableSourceMaps();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('createSharedEntry', () => {
@@ -111,7 +111,7 @@ describe('Public API', () => {
             const returnedValue = api.createSharedEntry('sharedEntry', 'vendor.js');
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('autoProvideVariables', () => {
@@ -120,7 +120,7 @@ describe('Public API', () => {
             const returnedValue = api.autoProvideVariables({});
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('autoProvidejQuery', () => {
@@ -129,7 +129,7 @@ describe('Public API', () => {
             const returnedValue = api.autoProvidejQuery();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enablePostCssLoader', () => {
@@ -138,7 +138,7 @@ describe('Public API', () => {
             const returnedValue = api.enablePostCssLoader();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableSassLoader', () => {
@@ -147,7 +147,7 @@ describe('Public API', () => {
             const returnedValue = api.enableSassLoader();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableLessLoader', () => {
@@ -156,7 +156,7 @@ describe('Public API', () => {
             const returnedValue = api.enableLessLoader();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('setOutputPath', () => {
@@ -165,7 +165,7 @@ describe('Public API', () => {
             const returnedValue = api.configureBabel(() => {});
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableReactPreset', () => {
@@ -174,7 +174,7 @@ describe('Public API', () => {
             const returnedValue = api.enableReactPreset();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableTypeScriptLoader', () => {
@@ -183,7 +183,7 @@ describe('Public API', () => {
             const returnedValue = api.enableTypeScriptLoader();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('enableVueLoader', () => {
@@ -192,7 +192,7 @@ describe('Public API', () => {
             const returnedValue = api.enableVueLoader();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 
     describe('cleanupOutputBeforeBuild', () => {
@@ -201,6 +201,6 @@ describe('Public API', () => {
             const returnedValue = api.cleanupOutputBeforeBuild();
             expect(returnedValue).to.equal(api);
         });
-        
+
     });
 });

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,206 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+require('../lib/context').runtimeConfig = {};
+const api = require('../index.js');
+
+describe('Public API', () => {
+
+    describe('setOutputPath', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.setOutputPath('/');
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
+    describe('setPublicPath', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.setPublicPath('/');
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('setManifestKeyPrefix', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.setManifestKeyPrefix('/build');
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('addEntry', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.addEntry('entry', 'main.js');
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('addStyleEntry', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.addStyleEntry('styleEntry', 'main.css');
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('addPlugin', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.addPlugin(null);
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('addLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.addLoader(null);
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('addRule', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.addRule(null);
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableVersioning', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableVersioning();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableSourceMaps', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableSourceMaps();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('createSharedEntry', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.createSharedEntry('sharedEntry', 'vendor.js');
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('autoProvideVariables', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.autoProvideVariables({});
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('autoProvidejQuery', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.autoProvidejQuery();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enablePostCssLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enablePostCssLoader();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableSassLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableSassLoader();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableLessLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableLessLoader();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('setOutputPath', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.configureBabel(() => {});
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableReactPreset', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableReactPreset();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableTypeScriptLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableTypeScriptLoader();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('enableVueLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.enableVueLoader();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+
+    describe('cleanupOutputBeforeBuild', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.cleanupOutputBeforeBuild();
+            expect(returnedValue).to.equal(api);
+        });
+        
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@
 
 const expect = require('chai').expect;
 require('../lib/context').runtimeConfig = {};
-const api = require('../index.js');
+const api = require('../index');
 
 describe('Public API', () => {
 


### PR DESCRIPTION
This commit (https://github.com/symfony/webpack-encore/commit/35d9e6f5c24f88ba2660d4e58407b1330aeb2640#diff-168726dbe96b3ce427e7fedce31bb0bc) removed inadvertently the `return this;` statement from the `enableTypeScriptLoader` function.

This prevents calling another function chained on `enableTypeScriptLoader` in a `webpack.config.js` file.

This PR just puts the `return this;` statement back.