### PR TITLE
Allow to disable the default image and font loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -431,12 +431,24 @@ module.exports = {
 
     /**
      * Call this if you wish to disable the default
-     * assets loaders (images and fonts).
+     * images loader.
      *
      * @returns {exports}
      */
-    disableAssetsLoaders() {
-        webpackConfig.disableAssetsLoaders();
+    disableImagesLoader() {
+        webpackConfig.disableImagesLoader();
+
+        return this;
+    },
+
+    /**
+     * Call this if you wish to disable the default
+     * fonts loader.
+     *
+     * @returns {exports}
+     */
+    disableFontsLoader() {
+        webpackConfig.disableFontsLoader();
 
         return this;
     },

--- a/index.js
+++ b/index.js
@@ -430,6 +430,18 @@ module.exports = {
     },
 
     /**
+     * Call this if you wish to disable the default
+     * assets loaders (images and fonts).
+     *
+     * @returns {exports}
+     */
+    disableAssetsLoaders() {
+        webpackConfig.disableAssetsLoaders();
+
+        return this;
+    },
+
+    /**
      * If enabled, the output directory is emptied between
      * each build (to remove old files).
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -59,7 +59,8 @@ class WebpackConfig {
         this.tsConfigurationCallback = function() {};
         this.useForkedTypeScriptTypeChecking = false;
         this.forkedTypeScriptTypesCheckOptionsCallback = () => {};
-        this.useAssetsLoaders = true;
+        this.useImagesLoader = true;
+        this.useFontsLoader = true;
     }
 
     getContext() {
@@ -269,8 +270,12 @@ class WebpackConfig {
         this.vueLoaderOptionsCallback = vueLoaderOptionsCallback;
     }
 
-    disableAssetsLoaders() {
-        this.useAssetsLoaders = false;
+    disableImagesLoader() {
+        this.useImagesLoader = false;
+    }
+
+    disableFontsLoader() {
+        this.useFontsLoader = false;
     }
 
     cleanupOutputBeforeBuild() {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -59,6 +59,7 @@ class WebpackConfig {
         this.tsConfigurationCallback = function() {};
         this.useForkedTypeScriptTypeChecking = false;
         this.forkedTypeScriptTypesCheckOptionsCallback = () => {};
+        this.useAssetsLoaders = true;
     }
 
     getContext() {
@@ -266,6 +267,10 @@ class WebpackConfig {
         }
 
         this.vueLoaderOptionsCallback = vueLoaderOptionsCallback;
+    }
+
+    disableAssetsLoaders() {
+        this.useAssetsLoaders = false;
     }
 
     cleanupOutputBeforeBuild() {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -122,24 +122,28 @@ class ConfigGenerator {
             {
                 test: /\.css$/,
                 use: extractText.extract(this.webpackConfig, cssLoaderUtil.getLoaders(this.webpackConfig, false))
-            },
-            {
+            }
+        ];
+
+        if (this.webpackConfig.useAssetsLoaders) {
+            rules.push({
                 test: /\.(png|jpg|jpeg|gif|ico|svg)$/,
                 loader: 'file-loader',
                 options: {
                     name: 'images/[name].[hash:8].[ext]',
                     publicPath: this.webpackConfig.getRealPublicPath()
                 }
-            },
-            {
+            });
+
+            rules.push({
                 test: /\.(woff|woff2|ttf|eot|otf)$/,
                 loader: 'file-loader',
                 options: {
                     name: 'fonts/[name].[hash:8].[ext]',
                     publicPath: this.webpackConfig.getRealPublicPath()
                 }
-            },
-        ];
+            });
+        }
 
         if (this.webpackConfig.useSassLoader) {
             rules.push({

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -125,7 +125,7 @@ class ConfigGenerator {
             }
         ];
 
-        if (this.webpackConfig.useAssetsLoaders) {
+        if (this.webpackConfig.useImagesLoader) {
             rules.push({
                 test: /\.(png|jpg|jpeg|gif|ico|svg)$/,
                 loader: 'file-loader',
@@ -134,7 +134,9 @@ class ConfigGenerator {
                     publicPath: this.webpackConfig.getRealPublicPath()
                 }
             });
+        }
 
+        if (this.webpackConfig.useFontsLoader) {
             rules.push({
                 test: /\.(woff|woff2|ttf|eot|otf)$/,
                 loader: 'file-loader',

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -430,4 +430,13 @@ describe('WebpackConfig object', () => {
             expect(config.loaders).to.deep.equals([{ 'test': /\.custom$/, 'loader': 'custom-loader' }]);
         });
     });
+
+    describe('disableAssetsLoaders', () => {
+        it('Disable default assets loaders', () => {
+            const config = createConfig();
+            config.disableAssetsLoaders();
+
+            expect(config.useAssetsLoaders).to.be.false;
+        });
+    });
 });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -431,12 +431,21 @@ describe('WebpackConfig object', () => {
         });
     });
 
-    describe('disableAssetsLoaders', () => {
-        it('Disable default assets loaders', () => {
+    describe('disableImagesLoader', () => {
+        it('Disable default images loader', () => {
             const config = createConfig();
-            config.disableAssetsLoaders();
+            config.disableImagesLoader();
 
-            expect(config.useAssetsLoaders).to.be.false;
+            expect(config.useImagesLoader).to.be.false;
+        });
+    });
+
+    describe('disableFontsLoader', () => {
+        it('Disable default fonts loader', () => {
+            const config = createConfig();
+            config.disableFontsLoader();
+
+            expect(config.useFontsLoader).to.be.false;
         });
     });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -417,33 +417,61 @@ describe('The config-generator function', () => {
         });
     });
 
-    describe('disableAssetsLoaders() removes the default assets loaders', () => {
-        it('without disableAssetsLoaders()', () => {
+    describe('disableImagesLoader() removes the default images loader', () => {
+        it('without disableImagesLoader()', () => {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
-            // do not call disableAssetsLoaders
+            // do not call disableImagesLoader
 
             const actualConfig = configGenerator(config);
 
             expect(function() {
                 findRule(/\.(png|jpg|jpeg|gif|ico|svg)$/, actualConfig.module.rules);
+            }).to.not.throw();
+        });
+
+        it('with disableImagesLoader()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            config.disableImagesLoader();
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
+                findRule(/\.(png|jpg|jpeg|gif|ico|svg)$/, actualConfig.module.rules);
+            }).to.throw();
+        });
+    });
+
+    describe('disableFontsLoader() removes the default fonts loader', () => {
+        it('without disableFontsLoader()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            // do not call disableFontsLoader
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
                 findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules);
             }).to.not.throw();
         });
 
-        it('with disableAssetsLoaders()', () => {
+        it('with disableFontsLoader()', () => {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
-            config.disableAssetsLoaders();
+            config.disableFontsLoader();
 
             const actualConfig = configGenerator(config);
 
             expect(function() {
-                findRule(/\.(png|jpg|jpeg|gif|ico|svg)$/, actualConfig.module.rules);
                 findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules);
             }).to.throw();
         });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -416,4 +416,36 @@ describe('The config-generator function', () => {
             expect(ignorePlugin).to.not.be.undefined;
         });
     });
+
+    describe('disableAssetsLoaders() removes the default assets loaders', () => {
+        it('without disableAssetsLoaders()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            // do not call disableAssetsLoaders
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
+                findRule(/\.(png|jpg|jpeg|gif|ico|svg)$/, actualConfig.module.rules);
+                findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules);
+            }).to.not.throw();
+        });
+
+        it('with disableAssetsLoaders()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            config.disableAssetsLoaders();
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
+                findRule(/\.(png|jpg|jpeg|gif|ico|svg)$/, actualConfig.module.rules);
+                findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules);
+            }).to.throw();
+        });
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -204,10 +204,19 @@ describe('Public API', () => {
 
     });
 
-    describe('disableAssetsLoaders', () => {
+    describe('disableImagesLoader', () => {
 
         it('must return the API object', () => {
-            const returnedValue = api.disableAssetsLoaders();
+            const returnedValue = api.disableImagesLoader();
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
+    describe('disableFontsLoader', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.disableFontsLoader();
             expect(returnedValue).to.equal(api);
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,15 @@ describe('Public API', () => {
 
     });
 
+    describe('disableAssetsLoaders', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.disableAssetsLoaders();
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
     describe('cleanupOutputBeforeBuild', () => {
 
         it('must return the API object', () => {


### PR DESCRIPTION
This PR adds a `disableAssetsLoaders` method to the API, allowing users to disable the default image and font loaders.

Currently these two loaders are always added (with some parts of them being hardcoded) and can't really be overriden which can causes some issues (see #73).

By allowing to disable this behavior, users would be able to replace them by their own loaders.

About the new method:

* **Why a `disableAssetsLoaders` and not an `enableAssetsLoaders` instead**: I still think that these two loaders should be added by default since almost every project will need them. Moreover, keeping them enabled will avoid breaking BC.

* **Why a single method instead of one for the image loader and one for the fonts loader**: I may be wrong there, but I think that if an user disable one of them, it'll probably disable the other one aswell anyway.