### PR TITLE
Warning when manifest key prefix starts with "/"

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -11,6 +11,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const logger = require('./logger');
 
 /**
  * @param {RuntimeConfig} runtimeConfig
@@ -111,12 +112,12 @@ class WebpackConfig {
          * Normally, we make sure that the manifest keys don't start
          * with an opening "/" ever... for consistency. If you need
          * to manually specify the manifest key (e.g. because you're
-         * publicPath is absolute), we're *still* adding this restriction,
-         * to help avoid a user accidentally adding an opening "/"
-         * and changing their keys from what they looked like before.
+         * publicPath is absolute), it's easy to accidentally add
+         * an opening slash (thereby changing your key prefix) without
+         * intending to. Hence, the warning.
          */
         if (manifestKeyPrefix.indexOf('/') === 0) {
-            throw new Error(`For consistency, the value passed to setManifestKeyPrefix() cannot start with "/". Try setManifestKeyPrefix('${manifestKeyPrefix.replace(/^\//, '')}') instead.`);
+            logger.warning(`The value passed to setManifestKeyPrefix "${manifestKeyPrefix}" starts with "/". This is allowed, but since the key prefix does not normally start with a "/", you may have just changed the prefix accidentally.`);
         }
 
         // guarantee a single trailing slash, except for blank strings

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -107,6 +107,18 @@ class WebpackConfig {
     }
 
     setManifestKeyPrefix(manifestKeyPrefix) {
+        /*
+         * Normally, we make sure that the manifest keys don't start
+         * with an opening "/" ever... for consistency. If you need
+         * to manually specify the manifest key (e.g. because you're
+         * publicPath is absolute), we're *still* adding this restriction,
+         * to help avoid a user accidentally adding an opening "/"
+         * and changing their keys from what they looked like before.
+         */
+        if (manifestKeyPrefix.indexOf('/') === 0) {
+            throw new Error(`For consistency, the value passed to setManifestKeyPrefix() cannot start with "/". Try setManifestKeyPrefix('${manifestKeyPrefix.replace(/^\//, '')}') instead.`);
+        }
+
         // guarantee a single trailing slash, except for blank strings
         if (manifestKeyPrefix !== '') {
             manifestKeyPrefix = manifestKeyPrefix.replace(/\/$/, '');

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -148,10 +148,10 @@ describe('WebpackConfig object', () => {
 
         it('You can set it!', () => {
             const config = createConfig();
-            config.setManifestKeyPrefix('/foo');
+            config.setManifestKeyPrefix('foo');
 
             // trailing slash added
-            expect(config.manifestKeyPrefix).to.equal('/foo/');
+            expect(config.manifestKeyPrefix).to.equal('foo/');
         });
 
         it('You can set it blank', () => {
@@ -160,6 +160,14 @@ describe('WebpackConfig object', () => {
 
             // trailing slash not added
             expect(config.manifestKeyPrefix).to.equal('');
+        });
+
+        it('You cannot use an opening slash', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.setManifestKeyPrefix('/foo/');
+            }).to.throw('the value passed to setManifestKeyPrefix() cannot start with "/"');
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -15,6 +15,7 @@ const RuntimeConfig = require('../lib/config/RuntimeConfig');
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
+const logger = require('../lib/logger');
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -162,12 +163,13 @@ describe('WebpackConfig object', () => {
             expect(config.manifestKeyPrefix).to.equal('');
         });
 
-        it('You cannot use an opening slash', () => {
+        it('You can use an opening slash, but get a warning', () => {
             const config = createConfig();
 
-            expect(() => {
-                config.setManifestKeyPrefix('/foo/');
-            }).to.throw('the value passed to setManifestKeyPrefix() cannot start with "/"');
+            logger.reset();
+            logger.quiet();
+            config.setManifestKeyPrefix('/foo/');
+            expect(logger.getMessages().warning).to.have.lengthOf(1);
         });
     });
 


### PR DESCRIPTION
```js
Encore.setManifestKeyPrefix('/public/');
```

This is allowed, and will still be allowed. But after this PR, you will get a warning.

This is to help people from "tripping up" and accidentally changing their manifest key prefix from `public/` to `/public/` when calling `setManifestKeyPrefix()`. I thought this might cause issues, and it did in #96 - https://github.com/symfony/webpack-encore/pull/96#issuecomment-316871049

Cheers!