### PR TITLE
Giving the user a nice, default postcss.config.js file

### DIFF
--- a/lib/friendly-errors/formatters/missing-postcss-config.js
+++ b/lib/friendly-errors/formatters/missing-postcss-config.js
@@ -25,8 +25,19 @@ function formatErrors(errors) {
     );
     messages.push('');
     messages.push(`${chalk.bgGreen.black('', 'FIX', '')} Create a ${chalk.yellow('postcss.config.js')} file at the root of your project.`);
+    messages.push('');
+    messages.push('Here is an example to get you started!')
+    messages.push(chalk.yellow(`
+// postcss.config.js
+module.exports = {
+  plugins: {
+    'autoprefixer': {},
+  }
+}
+    `));
 
     messages.push('');
+    messages.push('')
 
     return messages;
 }


### PR DESCRIPTION
<img width="932" alt="screen shot 2017-07-20 at 10 44 46 pm" src="https://user-images.githubusercontent.com/121003/28447140-0ef29372-6d9d-11e7-954a-610d26fd9d75.png">

We make the user create this file to follow the best practice for configuring the postcss-loader. But let's be as helpful as possible.

The `autoprefixer` does not need to be installed by the user, as it's already an indirect dependency of encore (`@symfony/webpack-encore#css-loader#cssnano`).