### PR TITLE
Initializing the plugins key on babel, so you can call babelConfig.plugins.push()

### DIFF
--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -41,6 +41,7 @@ module.exports = {
                         useBuiltIns: true
                     }]
                 ],
+                plugins: []
             });
 
             if (webpackConfig.useReact) {


### PR DESCRIPTION
See https://github.com/symfony/webpack-encore/issues/100#issuecomment-316883728

It just makes adding a custom plugin a bit less error-prone for the user.