### PR TITLE
Fixing a bug where @import CSS files were not put through the autoprexer

### DIFF
--- a/fixtures/css/imports_autoprefixer.css
+++ b/fixtures/css/imports_autoprefixer.css
@@ -1,0 +1,1 @@
+@import "autoprefixer_test.css";

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -18,17 +18,24 @@ const loaderFeatures = require('../loader-features');
  */
 module.exports = {
     getLoaders(webpackConfig, skipPostCssLoader) {
+        const usePostCssLoader = webpackConfig.usePostCssLoader && !skipPostCssLoader;
+
         const cssLoaders = [
             {
                 loader: 'css-loader',
                 options: {
                     minimize: webpackConfig.isProduction(),
-                    sourceMap: webpackConfig.useSourceMaps
+                    sourceMap: webpackConfig.useSourceMaps,
+                    // when using @import, how many loaders *before* css-loader should
+                    // be applied to those imports? This defaults to 0. When postcss-loader
+                    // is used, we set it to 1, so that postcss-loader is applied
+                    // to @import resources.
+                    importLoaders: usePostCssLoader ? 1 : 0
                 }
             },
         ];
 
-        if (webpackConfig.usePostCssLoader && !skipPostCssLoader) {
+        if (usePostCssLoader) {
             loaderFeatures.ensureLoaderPackagesExist('postcss');
 
             cssLoaders.push({

--- a/test/functional.js
+++ b/test/functional.js
@@ -483,7 +483,9 @@ module.exports = {
 
             const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
             config.setPublicPath('/build');
-            config.addStyleEntry('styles', ['./css/autoprefixer_test.css']);
+            // load a file that @import's another file, so that we can
+            // test that @import resources are parsed through postcss
+            config.addStyleEntry('styles', ['./css/imports_autoprefixer.css']);
             config.enablePostCssLoader();
 
             testSetup.runWebpack(config, (webpackAssert) => {


### PR DESCRIPTION
Fixes #98

By default, when you use `@import`, loaders are not applied. This fixes that: using the postcss-loader when it's used. The functional test proves the fix.