### PR TITLE
Fixing a bug with webpack 3.4.0 with extra arg as an entry

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -15,7 +15,7 @@ const context = require('../lib/context');
 const chalk = require('chalk');
 
 const runtimeConfig = parseRuntime(
-    require('yargs').argv,
+    require('yargs/yargs')(process.argv.slice(2)).argv,
     process.cwd()
 );
 context.runtimeConfig = runtimeConfig;

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -29,7 +29,7 @@ describe('bin/encore.js', function() {
             `
 const Encore = require('../../index.js');
 Encore
-    .setOutputPath('${testDir}/build')
+    .setOutputPath('/build')
     .setPublicPath('/build')
     .addEntry('main', './js/no_require')
 ;

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -29,7 +29,7 @@ describe('bin/encore.js', function() {
             `
 const Encore = require('../../index.js');
 Encore
-    .setOutputPath('/build')
+    .setOutputPath('build/')
     .setPublicPath('/build')
     .addEntry('main', './js/no_require')
 ;

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const chai = require('chai');
+chai.use(require('chai-fs'));
+const path = require('path');
+const testSetup = require('../../lib/test/setup');
+const fs = require('fs-extra');
+const exec = require('child_process').exec;
+
+describe('bin/encore.js', function() {
+    // being functional tests, these can take quite long
+    this.timeout(8000);
+
+    it('Basic smoke test', (done) => {
+        testSetup.emptyTmpDir();
+        const testDir = testSetup.createTestAppDir();
+
+        fs.writeFileSync(
+            path.join(testDir, 'webpack.config.js'),
+            `
+const Encore = require('../../index.js');
+Encore
+    .setOutputPath('${testDir}/build')
+    .setPublicPath('/build')
+    .addEntry('main', './js/no_require')
+;
+
+module.exports = Encore.getWebpackConfig();
+            `
+        );
+
+        const binPath = path.resolve(__dirname, '../', '../', 'bin', 'encore.js');
+        exec(`node ${binPath} dev --context=${testDir}`, { cwd: testDir }, (err, stdout, stderr) => {
+            if (err) {
+                throw new Error(`Error executing encore: ${err} ${stderr} ${stdout}`);
+            }
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #112 

The updated way avoids triggering the "singleton" behavior or yargs. This is important so that later, when webpack uses yargs, it uses the updated `process.argv` (because we remove our extra "command" argument so that webpack doesn't see it).

I'm not sure exactly which dep/commit caused the issue, but this a more proper solution anyways.

Also added a smoke test for the encore binary.