### PR TITLE
Remove duplicate addPlugin test case

### DIFF
--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -375,19 +375,6 @@ describe('WebpackConfig object', () => {
         });
     });
 
-    describe('addPlugin', () => {
-        it('extends the current registered plugins', () => {
-            const config = createConfig();
-            const nbOfPlugins = config.plugins.length;
-
-            expect(nbOfPlugins).to.equal(0);
-
-            config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
-
-            expect(config.plugins.length).to.equal(1);
-        });
-    });
-
     describe('enableVueLoader', () => {
         it('Call with no config', () => {
             const config = createConfig();


### PR DESCRIPTION
This PR removes a duplicate test case in `WebpackConfig.js`:

* [first instance](https://github.com/symfony/webpack-encore/blob/v0.12.0/test/WebpackConfig.js#L335-L346)
* [second instance](https://github.com/symfony/webpack-encore/blob/v0.12.0/test/WebpackConfig.js#L368-L379)