### PR TITLE
Reversing pathinfo logic to avoid extra comments

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -107,7 +107,7 @@ class ConfigGenerator {
             // will use the CDN path (if one is available) so that split
             // chunks load internally through the CDN.
             publicPath: this.webpackConfig.getRealPublicPath(),
-            pathinfo: this.webpackConfig.isProduction()
+            pathinfo: !this.webpackConfig.isProduction()
         };
     }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -505,6 +505,11 @@ describe('Functional tests using webpack', function() {
                     'main.js',
                     '// comments in no_require.js'
                 );
+                // check for any webpack-added comments
+                webpackAssert.assertOutputFileDoesNotContain(
+                    'main.js',
+                    '/*!'
+                );
                 // extra spaces should not live in the CSS file
                 webpackAssert.assertOutputFileDoesNotContain(
                     'styles.css',


### PR DESCRIPTION
This creates extra comments in the final .js files, to help debugging. This was a mistake when originally added - the logic was reversed.

Fixes #120 