### PR TITLE
Modify file headers to 'Symfony Webpack Encore package'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         "node/no-unpublished-bin": "error",
         "node/no-unpublished-require": "error",
         "node/process-exit-as-throw": "error",
-        "header/header": [2, "block", {"pattern": "This file is part of the Symfony package"}]
+        "header/header": [2, "block", {"pattern": "This file is part of the Symfony Webpack Encore package"}]
     }
 };
 

--- a/bin/encore.js
+++ b/bin/encore.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/config/RuntimeConfig.js
+++ b/lib/config/RuntimeConfig.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/config/path-util.js
+++ b/lib/config/path-util.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/features.js
+++ b/lib/features.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/asset-output-display-plugin.js
+++ b/lib/friendly-errors/asset-output-display-plugin.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/formatters/missing-loader.js
+++ b/lib/friendly-errors/formatters/missing-loader.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/formatters/missing-postcss-config.js
+++ b/lib/friendly-errors/formatters/missing-postcss-config.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
@@ -26,7 +26,7 @@ function formatErrors(errors) {
     messages.push('');
     messages.push(`${chalk.bgGreen.black('', 'FIX', '')} Create a ${chalk.yellow('postcss.config.js')} file at the root of your project.`);
     messages.push('');
-    messages.push('Here is an example to get you started!')
+    messages.push('Here is an example to get you started!');
     messages.push(chalk.yellow(`
 // postcss.config.js
 module.exports = {
@@ -37,7 +37,7 @@ module.exports = {
     `));
 
     messages.push('');
-    messages.push('')
+    messages.push('');
 
     return messages;
 }

--- a/lib/friendly-errors/formatters/vue-unactivated-loader-error.js
+++ b/lib/friendly-errors/formatters/vue-unactivated-loader-error.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/transformers/missing-loader.js
+++ b/lib/friendly-errors/transformers/missing-loader.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/transformers/missing-postcss-config.js
+++ b/lib/friendly-errors/transformers/missing-postcss-config.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/friendly-errors/transformers/vue-unactivated-loader-error.js
+++ b/lib/friendly-errors/transformers/vue-unactivated-loader-error.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/extract-text.js
+++ b/lib/loaders/extract-text.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/vue-unactivated-loader.js
+++ b/lib/loaders/vue-unactivated-loader.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/package-helper.js
+++ b/lib/package-helper.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/asset-output-display.js
+++ b/lib/plugins/asset-output-display.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/common-chunks.js
+++ b/lib/plugins/common-chunks.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/delete-unused-entries.js
+++ b/lib/plugins/delete-unused-entries.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/extract-text.js
+++ b/lib/plugins/extract-text.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/loader-options.js
+++ b/lib/plugins/loader-options.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/uglify.js
+++ b/lib/plugins/uglify.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/variable-provider.js
+++ b/lib/plugins/variable-provider.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/plugins/versioning.js
+++ b/lib/plugins/versioning.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/test/assert.js
+++ b/lib/test/assert.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/test/setup.js
+++ b/lib/test/setup.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/lib/webpack/delete-unused-entries-js-plugin.js
+++ b/lib/webpack/delete-unused-entries-js-plugin.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/config/path-util.js
+++ b/test/config/path-util.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/config/validator.js
+++ b/test/config/validator.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/friendly-errors/formatters/missing-loader.js
+++ b/test/friendly-errors/formatters/missing-loader.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/friendly-errors/transformers/missing-loader.js
+++ b/test/friendly-errors/transformers/missing-loader.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/functional.js
+++ b/test/functional.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/css.js
+++ b/test/loaders/css.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/less.js
+++ b/test/loaders/less.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/typescript.js
+++ b/test/loaders/typescript.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/loaders/vue.js
+++ b/test/loaders/vue.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *

--- a/test/plugins/forked-ts-types.js
+++ b/test/plugins/forked-ts-types.js
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Symfony package.
+ * This file is part of the Symfony Webpack Encore package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *


### PR DESCRIPTION
This PR changes file headers from `This file is part of the Symfony package.` to `This file is part of the Symfony Webpack Encore package.` (fixes #84).

Since there are not many open PRs right now it may be a good time to do it.