### PR TITLE
Remove comments from javascript files in production environment

### DIFF
--- a/lib/plugins/uglify.js
+++ b/lib/plugins/uglify.js
@@ -24,7 +24,10 @@ module.exports = function(plugins, webpackConfig, uglifyOptions = {}) {
     }
 
     let uglifyConfig = Object.assign({}, uglifyOptions, {
-        sourceMap: webpackConfig.useSourceMaps
+        sourceMap: webpackConfig.useSourceMaps,
+        output: {
+            comments: false,
+        }
     });
     let uglify = new webpack.optimize.UglifyJsPlugin(uglifyConfig);
 


### PR DESCRIPTION
This PR removes comments from compiled javascript files in production

Please let me know if this was intended to be the default behaviour I will work on implementing a method to allow default options to be overridden