### PR TITLE
Feature configure manifest options

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,25 @@ const publicApi = {
     },
 
     /**
+     * Allows to set ManifestPlugin options and override default options
+     * List of available options can be found at https://github.com/danethurber/webpack-manifest-plugin
+     *
+     * For example:
+     *
+     *      .configureManifestPlugin({
+     *          fileName: '../../var/assets/manifest.json'
+     *      })
+     *
+     * @param {Object} options
+     * @returns {publicApi}
+     */
+    configureManifestPlugin(options) {
+        webpackConfig.configureManifestPlugin(options);
+
+        return this;
+    },
+
+    /**
      * Adds a JavaScript file that should be webpacked:
      *
      *      // final output file will be main.js in the output directory
@@ -294,7 +313,8 @@ const publicApi = {
      * @param {function} postCssLoaderOptionsCallback
      * @return {exports}
      */
-    enablePostCssLoader(postCssLoaderOptionsCallback = () => {}) {
+    enablePostCssLoader(postCssLoaderOptionsCallback = () => {
+    }) {
         webpackConfig.enablePostCssLoader(postCssLoaderOptionsCallback);
 
         return this;
@@ -328,7 +348,8 @@ const publicApi = {
      * @param {object} encoreOptions
      * @return {exports}
      */
-    enableSassLoader(sassLoaderOptionsCallback = () => {}, encoreOptions = {}) {
+    enableSassLoader(sassLoaderOptionsCallback = () => {
+    }, encoreOptions = {}) {
         webpackConfig.enableSassLoader(sassLoaderOptionsCallback, encoreOptions);
 
         return this;
@@ -350,7 +371,8 @@ const publicApi = {
      * @param {function} lessLoaderOptionsCallback
      * @return {exports}
      */
-    enableLessLoader(lessLoaderOptionsCallback = () => {}) {
+    enableLessLoader(lessLoaderOptionsCallback = () => {
+    }) {
         webpackConfig.enableLessLoader(lessLoaderOptionsCallback);
 
         return this;
@@ -402,7 +424,8 @@ const publicApi = {
      * @param {function} callback
      * @return {exports}
      */
-    enableTypeScriptLoader(callback = () => {}) {
+    enableTypeScriptLoader(callback = () => {
+    }) {
         webpackConfig.enableTypeScriptLoader(callback);
 
         return this;
@@ -417,7 +440,8 @@ const publicApi = {
      * @param {function} forkedTypeScriptTypesCheckOptionsCallback
      * @return {exports}
      */
-    enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {}) {
+    enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {
+    }) {
         webpackConfig.enableForkedTypeScriptTypesChecking(
             forkedTypeScriptTypesCheckOptionsCallback
         );
@@ -441,7 +465,8 @@ const publicApi = {
      * @param {function} vueLoaderOptionsCallback
      * @returns {exports}
      */
-    enableVueLoader(vueLoaderOptionsCallback = () => {}) {
+    enableVueLoader(vueLoaderOptionsCallback = () => {
+    }) {
         webpackConfig.enableVueLoader(vueLoaderOptionsCallback);
 
         return this;

--- a/index.js
+++ b/index.js
@@ -108,15 +108,15 @@ const publicApi = {
      *
      * For example:
      *
-     *      .configureManifestPlugin({
-     *          fileName: '../../var/assets/manifest.json'
+     *      Encore.configureManifestPlugin(function(options){
+     *          options.fileName: '../../var/assets/manifest.json'
      *      })
      *
-     * @param {Object} options
+     * @param {function} manifestPluginOptionsCallback
      * @returns {exports}
      */
-    configureManifestPlugin(options) {
-        webpackConfig.configureManifestPlugin(options);
+    configureManifestPlugin(manifestPluginOptionsCallback = () => {}) {
+        webpackConfig.configureManifestPlugin(manifestPluginOptionsCallback);
 
         return this;
     },

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const publicApi = {
      *      })
      *
      * @param {Object} options
-     * @returns {publicApi}
+     * @returns {exports}
      */
     configureManifestPlugin(options) {
         webpackConfig.configureManifestPlugin(options);

--- a/index.js
+++ b/index.js
@@ -313,8 +313,7 @@ const publicApi = {
      * @param {function} postCssLoaderOptionsCallback
      * @return {exports}
      */
-    enablePostCssLoader(postCssLoaderOptionsCallback = () => {
-    }) {
+    enablePostCssLoader(postCssLoaderOptionsCallback = () => {}) {
         webpackConfig.enablePostCssLoader(postCssLoaderOptionsCallback);
 
         return this;
@@ -348,8 +347,7 @@ const publicApi = {
      * @param {object} encoreOptions
      * @return {exports}
      */
-    enableSassLoader(sassLoaderOptionsCallback = () => {
-    }, encoreOptions = {}) {
+    enableSassLoader(sassLoaderOptionsCallback = () => {}, encoreOptions = {}) {
         webpackConfig.enableSassLoader(sassLoaderOptionsCallback, encoreOptions);
 
         return this;
@@ -371,8 +369,7 @@ const publicApi = {
      * @param {function} lessLoaderOptionsCallback
      * @return {exports}
      */
-    enableLessLoader(lessLoaderOptionsCallback = () => {
-    }) {
+    enableLessLoader(lessLoaderOptionsCallback = () => {}) {
         webpackConfig.enableLessLoader(lessLoaderOptionsCallback);
 
         return this;
@@ -424,8 +421,7 @@ const publicApi = {
      * @param {function} callback
      * @return {exports}
      */
-    enableTypeScriptLoader(callback = () => {
-    }) {
+    enableTypeScriptLoader(callback = () => {}) {
         webpackConfig.enableTypeScriptLoader(callback);
 
         return this;
@@ -440,8 +436,7 @@ const publicApi = {
      * @param {function} forkedTypeScriptTypesCheckOptionsCallback
      * @return {exports}
      */
-    enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {
-    }) {
+    enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {}) {
         webpackConfig.enableForkedTypeScriptTypesChecking(
             forkedTypeScriptTypesCheckOptionsCallback
         );
@@ -465,8 +460,7 @@ const publicApi = {
      * @param {function} vueLoaderOptionsCallback
      * @returns {exports}
      */
-    enableVueLoader(vueLoaderOptionsCallback = () => {
-    }) {
+    enableVueLoader(vueLoaderOptionsCallback = () => {}) {
         webpackConfig.enableVueLoader(vueLoaderOptionsCallback);
 
         return this;

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -63,6 +63,7 @@ class WebpackConfig {
         this.useImagesLoader = true;
         this.useFontsLoader = true;
         this.configuredFilenames = {};
+        this.manifestPluginOptions = {};
     }
 
     getContext() {
@@ -115,6 +116,14 @@ class WebpackConfig {
         }
 
         this.manifestKeyPrefix = manifestKeyPrefix;
+    }
+
+    configureManifestPlugin(options = {}) {
+        if (typeof options !== 'object') {
+            throw new Error('Argument 1 to configureManifestPlugin() must be an object');
+        }
+
+        this.manifestPluginOptions = options;
     }
 
     /**

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -119,10 +119,8 @@ class WebpackConfig {
     }
 
     configureManifestPlugin(manifestPluginOptionsCallback = () => {}) {
-        this.usePostCssLoader = true;
-
         if (typeof manifestPluginOptionsCallback !== 'function') {
-            throw new Error('Argument 1 to enablePostCssLoader() must be a callback function.');
+            throw new Error('Argument 1 to configureManifestPlugin() must be a callback function');
         }
 
         this.manifestPluginOptionsCallback = manifestPluginOptionsCallback;

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -63,7 +63,7 @@ class WebpackConfig {
         this.useImagesLoader = true;
         this.useFontsLoader = true;
         this.configuredFilenames = {};
-        this.manifestPluginOptions = {};
+        this.manifestPluginOptionsCallback = function() {};
     }
 
     getContext() {
@@ -118,12 +118,14 @@ class WebpackConfig {
         this.manifestKeyPrefix = manifestKeyPrefix;
     }
 
-    configureManifestPlugin(options = {}) {
-        if (typeof options !== 'object') {
-            throw new Error('Argument 1 to configureManifestPlugin() must be an object');
+    configureManifestPlugin(manifestPluginOptionsCallback = () => {}) {
+        this.usePostCssLoader = true;
+
+        if (typeof manifestPluginOptionsCallback !== 'function') {
+            throw new Error('Argument 1 to enablePostCssLoader() must be a callback function.');
         }
 
-        this.manifestPluginOptions = options;
+        this.manifestPluginOptionsCallback = manifestPluginOptionsCallback;
     }
 
     /**

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -210,7 +210,7 @@ class ConfigGenerator {
         deleteUnusedEntriesPluginUtil(plugins, this.webpackConfig);
 
         // Dump the manifest.json file
-        manifestPluginUtil(plugins, this.webpackConfig, this.webpackConfig.manifestPluginOptions);
+        manifestPluginUtil(plugins, this.webpackConfig);
 
         loaderOptionsPluginUtil(plugins, this.webpackConfig);
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -210,7 +210,7 @@ class ConfigGenerator {
         deleteUnusedEntriesPluginUtil(plugins, this.webpackConfig);
 
         // Dump the manifest.json file
-        manifestPluginUtil(plugins, this.webpackConfig);
+        manifestPluginUtil(plugins, this.webpackConfig, this.webpackConfig.manifestPluginOptions);
 
         loaderOptionsPluginUtil(plugins, this.webpackConfig);
 

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -14,10 +14,9 @@ const ManifestPlugin = require('../webpack/webpack-manifest-plugin');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @param {Object} manifestPluginOptions
  * @return {void}
  */
-module.exports = function(plugins, webpackConfig, manifestPluginOptions) {
+module.exports = function(plugins, webpackConfig) {
 
     let manifestPrefix = webpackConfig.manifestKeyPrefix;
     if (null === manifestPrefix) {
@@ -32,7 +31,7 @@ module.exports = function(plugins, webpackConfig, manifestPluginOptions) {
         // always write a manifest.json file, even with webpack-dev-server
         writeToFileEmit: true,
     };
-    let manifestConfig = Object.assign(defaultConfig, manifestPluginOptions);
+    let manifestConfig = Object.assign(defaultConfig, webpackConfig.manifestPluginOptions);
 
     plugins.push(new ManifestPlugin(manifestConfig));
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -24,14 +24,18 @@ module.exports = function(plugins, webpackConfig) {
         manifestPrefix = webpackConfig.publicPath.replace(/^\//, '');
     }
 
-    const defaultConfig = {
+    const manifestPluginOptions = {
         basePath: manifestPrefix,
         // guarantee the value uses the public path (or CDN public path)
         publicPath: webpackConfig.getRealPublicPath(),
         // always write a manifest.json file, even with webpack-dev-server
         writeToFileEmit: true,
     };
-    const manifestConfig = Object.assign({}, defaultConfig, webpackConfig.manifestPluginOptions);
 
-    plugins.push(new ManifestPlugin(manifestConfig));
+    webpackConfig.manifestPluginOptionsCallback.apply(
+        manifestPluginOptions,
+        [manifestPluginOptions]
+    );
+
+    plugins.push(new ManifestPlugin(manifestPluginOptions));
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -14,9 +14,10 @@ const ManifestPlugin = require('../webpack/webpack-manifest-plugin');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
+ * @param {Object} manifestPluginOptions
  * @return {void}
  */
-module.exports = function(plugins, webpackConfig) {
+module.exports = function(plugins, webpackConfig, manifestPluginOptions) {
 
     let manifestPrefix = webpackConfig.manifestKeyPrefix;
     if (null === manifestPrefix) {
@@ -24,11 +25,14 @@ module.exports = function(plugins, webpackConfig) {
         manifestPrefix = webpackConfig.publicPath.replace(/^\//, '');
     }
 
-    plugins.push(new ManifestPlugin({
+    let defaultConfig = {
         basePath: manifestPrefix,
         // guarantee the value uses the public path (or CDN public path)
         publicPath: webpackConfig.getRealPublicPath(),
         // always write a manifest.json file, even with webpack-dev-server
         writeToFileEmit: true,
-    }));
+    };
+    let manifestConfig = Object.assign(defaultConfig, manifestPluginOptions);
+
+    plugins.push(new ManifestPlugin(manifestConfig));
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -24,14 +24,14 @@ module.exports = function(plugins, webpackConfig) {
         manifestPrefix = webpackConfig.publicPath.replace(/^\//, '');
     }
 
-    let defaultConfig = {
+    const defaultConfig = {
         basePath: manifestPrefix,
         // guarantee the value uses the public path (or CDN public path)
         publicPath: webpackConfig.getRealPublicPath(),
         // always write a manifest.json file, even with webpack-dev-server
         writeToFileEmit: true,
     };
-    let manifestConfig = Object.assign(defaultConfig, webpackConfig.manifestPluginOptions);
+    const manifestConfig = Object.assign({}, defaultConfig, webpackConfig.manifestPluginOptions);
 
     plugins.push(new ManifestPlugin(manifestConfig));
 };

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -171,7 +171,7 @@ describe('WebpackConfig object', () => {
             });
 
             // fileName option overridden
-            expect(config.manifestOptions.fileName).to.equal('../../var/assets/manifest.json');
+            expect(config.manifestPluginOptions.fileName).to.equal('../../var/assets/manifest.json');
         });
 
         it('Setting a non object argument', () => {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -166,20 +166,11 @@ describe('WebpackConfig object', () => {
     describe('configureManifestPlugin', () => {
         it('Setting custom options', () => {
             const config = createConfig();
-            config.configureManifestPlugin({
-                fileName: '../../var/assets/manifest.json',
-            });
+            const callback = () => {};
+            config.configureManifestPlugin(callback);
 
             // fileName option overridden
-            expect(config.manifestPluginOptions.fileName).to.equal('../../var/assets/manifest.json');
-        });
-
-        it('Setting a non object argument', () => {
-            const config = createConfig();
-
-            expect(() => {
-                config.configureManifestPlugin('../../var/assets/manifest.json');
-            }).to.throw('Argument 1 to configureManifestPlugin() must be an object');
+            expect(config.manifestPluginOptionsCallback).to.equal(callback);
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -163,6 +163,26 @@ describe('WebpackConfig object', () => {
         });
     });
 
+    describe('configureManifestPlugin', () => {
+        it('Setting custom options', () => {
+            const config = createConfig();
+            config.configureManifestPlugin({
+                fileName: '../../var/assets/manifest.json',
+            });
+
+            // fileName option overridden
+            expect(config.manifestOptions.fileName).to.equal('../../var/assets/manifest.json');
+        });
+
+        it('Setting a non object argument', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureManifestPlugin('../../var/assets/manifest.json');
+            }).to.throw('Argument 1 to configureManifestPlugin() must be an object');
+        });
+    });
+
     describe('addEntry', () => {
         it('Calling with a duplicate name throws an error', () => {
             const config = createConfig();

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -172,6 +172,15 @@ describe('WebpackConfig object', () => {
             // fileName option overridden
             expect(config.manifestPluginOptionsCallback).to.equal(callback);
         });
+
+        it('Setting invalid custom options argument', () => {
+            const config = createConfig();
+            const callback = 'invalid';
+
+            expect(() => {
+                config.configureManifestPlugin(callback);
+            }).to.throw('Argument 1 to configureManifestPlugin() must be a callback function');
+        });
     });
 
     describe('addEntry', () => {


### PR DESCRIPTION
This PR adds `configureManifestPlugin()` as discussed in #125 

**Example:**
```javascript
Encore.configureManifestPlugin({
    fileName: '../../var/assets/manifest.json'
})
```

These options will override any default option.