### PR TITLE
Intercept Webpack output during functional tests

### DIFF
--- a/lib/test/setup.js
+++ b/lib/test/setup.js
@@ -60,32 +60,47 @@ function createWebpackConfig(testAppDir, outputDirName = '', command, argv = {})
 }
 
 function runWebpack(webpackConfig, callback, allowCompilationError = false) {
-    validator(webpackConfig);
-    const compiler = webpack(configGenerator(webpackConfig));
-    compiler.run((err, stats) => {
-        if (err) {
-            console.error(err.stack || err);
-            if (err.details) {
-                console.error(err.details);
+    const stdoutWrite = process.stdout.write;
+
+    try {
+        // Mute stdout
+        process.stdout.write = () => {};
+
+        validator(webpackConfig);
+
+        const compiler = webpack(configGenerator(webpackConfig));
+        compiler.run((err, stats) => {
+
+            if (err) {
+                console.error(err.stack || err);
+                if (err.details) {
+                    console.error(err.details);
+                }
+
+                throw new Error('Error running webpack!');
             }
 
-            throw new Error('Error running webpack!');
-        }
+            const info = stats.toJson();
 
-        const info = stats.toJson();
+            if (stats.hasErrors() && !allowCompilationError) {
+                console.error(info.errors);
 
-        if (stats.hasErrors() && !allowCompilationError) {
-            console.error(info.errors);
+                throw new Error('Compilation error running webpack!');
+            }
 
-            throw new Error('Compilation error running webpack!');
-        }
+            if (stats.hasWarnings()) {
+                console.warn(info.warnings);
+            }
 
-        if (stats.hasWarnings()) {
-            console.warn(info.warnings);
-        }
-
-        callback(assertUtil(webpackConfig), stats);
-    });
+            // Restore stdout and then call the callback
+            process.stdout.write = stdoutWrite;
+            callback(assertUtil(webpackConfig), stats);
+        });
+    } catch (e) {
+        // Restore stdout and then re-throw the exception
+        process.stdout.write = stdoutWrite;
+        throw e;
+    }
 }
 
 function emptyTmpDir() {
@@ -158,6 +173,7 @@ function requestTestPage(webRootDir, scriptSrcs, callback) {
     startHttpServer('8090', webRootDir);
 
     const browser = new Browser();
+    browser.silent = true;
     browser.on('error', function(error) {
         throw new Error(`Error when running the browser: ${error}`);
     });


### PR DESCRIPTION
This PR replaces `process.stdout.write` by an empty function when running webpack in each functional test (fixes #47).

It also sets the `silent` option of the Zombie.js browser to true to avoid displaying things like:

```
Download the Vue Devtools extension for a better development experience:
https://github.com/vuejs/vue-devtools
You are running Vue in development mode.
Make sure to turn on production mode when deploying for production.
See more tips at https://vuejs.org/guide/deployment.html
```

The only "noisy" message left should be `DeprecationWarning: Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead` since it is sent to stderr (should be fixed when alexindigo/webpack-chunk-hash#9 is released).