### PR TITLE
Add a 'Did you mean ...' error message in case of an unrecognized API property

### DIFF
--- a/index.js
+++ b/index.js
@@ -645,7 +645,7 @@ const publicApiProxy = new Proxy(publicApi, {
                 }
             }
 
-            const error = new Error(`${chalk.red(`Encore.${prop}`)} is not a recognized property, did you mean ${chalk.green(`Encore.${similarProperty}`)}?`);
+            const error = new Error(`${chalk.red(`Encore.${prop}`)} is not a recognized property or method, did you mean ${chalk.green(`Encore.${similarProperty}`)}?`);
             console.log(new PrettyError().render(error));
             process.exit(1); // eslint-disable-line
         }

--- a/index.js
+++ b/index.js
@@ -633,7 +633,9 @@ const publicApiProxy = new Proxy(publicApi, {
                     process.exit(1); // eslint-disable-line
                 }
             };
-        } else if (typeof target[prop] === 'undefined') {
+        }
+
+        if (typeof target[prop] === 'undefined') {
             // Find the property with the closest Levenshtein distance
             let similarProperty;
             let minDistance = Number.MAX_VALUE;
@@ -645,7 +647,12 @@ const publicApiProxy = new Proxy(publicApi, {
                 }
             }
 
-            const error = new Error(`${chalk.red(`Encore.${prop}`)} is not a recognized property or method, did you mean ${chalk.green(`Encore.${similarProperty}`)}?`);
+            let errorMessage = `${chalk.red(`Encore.${prop}`)} is not a recognized property or method.`;
+            if (minDistance < 3) {
+                errorMessage += ` Did you mean ${chalk.green(`Encore.${similarProperty}`)}?`;
+            }
+
+            const error = new Error(errorMessage);
             console.log(new PrettyError().render(error));
             process.exit(1); // eslint-disable-line
         }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "css-loader": "^0.26.2",
     "extract-text-webpack-plugin": "^3.0.0",
+    "fast-levenshtein": "^2.0.6",
     "file-loader": "^0.10.1",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "fs-extra": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,7 +2156,7 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 


### PR DESCRIPTION
This PR aims to improve the error message displayed when an user makes a typo in the name of one of the API methods he's trying to use.

Since pictures speak louder than words:

**Before**
![2017-08-30_19-01-27](https://user-images.githubusercontent.com/850046/29885253-724d45a0-8db6-11e7-8ec5-9e63fa9d786e.png)

**After**
![2017-08-30_19-03-44](https://user-images.githubusercontent.com/850046/29885266-7a0f3d0c-8db6-11e7-9af8-d9aad52917c2.png)

Note that the error is triggered when trying to access the property, not when the method is called (since it doesn't exist), hence the "is not a recognized property" message. I'm aware that the use of the "property" word in it may not be ideal, but using "method" instead feels wrong too since we could theoretically have other things than methods in the API object.
