### PR TITLE
Replace "resolve_url_loader" by "resolveUrlLoader"

### DIFF
--- a/index.js
+++ b/index.js
@@ -429,11 +429,11 @@ const publicApi = {
      *         // options.includePaths = [...]
      *     }, {
      *         // set optional Encore-specific options
-     *         // resolve_url_loader: true
+     *         // resolveUrlLoader: true
      *     });
      *
      * Supported options:
-     *      * {bool} resolve_url_loader (default=true)
+     *      * {bool} resolveUrlLoader (default=true)
      *              Whether or not to use the resolve-url-loader.
      *              Setting to false can increase performance in some
      *              cases, especially when using bootstrap_sass. But,

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -57,16 +57,16 @@ class WebpackConfig {
         this.useSassLoader = false;
         this.useReact = false;
         this.usePreact = false;
-        this.preactOptions = {
-            preactCompat: false
-        };
         this.useVueLoader = false;
         this.useTypeScriptLoader = false;
         this.useForkedTypeScriptTypeChecking = false;
 
         // Features/Loaders options
         this.sassOptions = {
-            resolve_url_loader: true
+            resolveUrlLoader: true
+        };
+        this.preactOptions = {
+            preactCompat: false
         };
 
         // Features/Loaders options callbacks
@@ -311,11 +311,17 @@ class WebpackConfig {
         this.sassLoaderOptionsCallback = sassLoaderOptionsCallback;
 
         for (const optionKey of Object.keys(options)) {
-            if (!(optionKey in this.sassOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to enableSassLoader(). Valid keys are ${Object.keys(this.sassOptions).join(', ')}`);
+            let normalizedOptionKey = optionKey;
+            if (optionKey === 'resolve_url_loader') {
+                logger.warning('enableSassLoader: "resolve_url_loader" is deprecated. Please use "resolveUrlLoader" instead.');
+                normalizedOptionKey = 'resolveUrlLoader';
             }
 
-            this.sassOptions[optionKey] = options[optionKey];
+            if (!(normalizedOptionKey in this.sassOptions)) {
+                throw new Error(`Invalid option "${normalizedOptionKey}" passed to enableSassLoader(). Valid keys are ${Object.keys(this.sassOptions).join(', ')}`);
+            }
+
+            this.sassOptions[normalizedOptionKey] = options[optionKey];
         }
     }
 

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -313,7 +313,7 @@ class WebpackConfig {
         for (const optionKey of Object.keys(options)) {
             let normalizedOptionKey = optionKey;
             if (optionKey === 'resolve_url_loader') {
-                logger.warning('enableSassLoader: "resolve_url_loader" is deprecated. Please use "resolveUrlLoader" instead.');
+                logger.deprecation('enableSassLoader: "resolve_url_loader" is deprecated. Please use "resolveUrlLoader" instead.');
                 normalizedOptionKey = 'resolveUrlLoader';
             }
 

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -23,7 +23,7 @@ module.exports = {
         loaderFeatures.ensurePackagesExist('sass');
 
         const sassLoaders = [...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader)];
-        if (true === webpackConfig.sassOptions.resolve_url_loader) {
+        if (true === webpackConfig.sassOptions.resolveUrlLoader) {
             // responsible for resolving SASS url() paths
             // without this, all url() paths must be relative to the
             // entry file, not the file that contains the url()
@@ -37,7 +37,7 @@ module.exports = {
 
         let config = Object.assign({}, sassOptions, {
             // needed by the resolve-url-loader
-            sourceMap: (true === webpackConfig.sassOptions.resolve_url_loader) || webpackConfig.useSourceMaps
+            sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps
         });
 
         // allow options to be configured

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,6 +15,7 @@ const messagesKeys = [
     'debug',
     'recommendation',
     'warning',
+    'deprecation',
 ];
 const defaultConfig = {
     isVerbose: false,
@@ -60,6 +61,12 @@ module.exports = {
         messages.warning.push(message);
 
         log(`${chalk.bgYellow.black('  WARNING  ')} ${chalk.yellow(message)}`);
+    },
+
+    deprecation(message) {
+        messages.deprecation.push(message);
+
+        log(`${chalk.bgYellow.black('DEPRECATION')} ${chalk.yellow(message)}`);
     },
 
     getMessages() {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -471,10 +471,10 @@ describe('WebpackConfig object', () => {
 
         it('Pass valid config', () => {
             const config = createConfig();
-            config.enableSassLoader(() => {}, { resolve_url_loader: false });
+            config.enableSassLoader(() => {}, { resolveUrlLoader: false });
 
             expect(config.useSassLoader).to.be.true;
-            expect(config.sassOptions.resolve_url_loader).to.be.false;
+            expect(config.sassOptions.resolveUrlLoader).to.be.false;
         });
 
         it('Pass invalid config', () => {

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -67,7 +67,7 @@ describe('loaders/sass', () => {
     it('getLoaders() without resolve-url-loader', () => {
         const config = createConfig();
         config.enableSassLoader(() => {}, {
-            resolve_url_loader: false,
+            resolveUrlLoader: false,
         });
         config.enableSourceMaps(false);
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -28,12 +28,14 @@ describe('logger', () => {
             'debug',
             'recommendation',
             'warning',
+            'deprecation',
         ];
         const testString = 'TEST MESSAGE';
         const expectedMessages = {
             debug: [testString],
             recommendation: [testString],
             warning: [testString],
+            deprecation: [testString],
         };
 
         logger.quiet();


### PR DESCRIPTION
This PR deprecates the `resolve_url_loader` option used by the `enableSassLoader` and replaces it by `resolveUrlLoader`.

This is done to be consistent with other methods that use camel-case instead of snake-case (see [#152](https://github.com/symfony/webpack-encore/pull/152#issuecomment-329266198)).

`resolve_url_loader` will still work for now but will display the following deprecation message:

![2017-09-13_23-38-56](https://user-images.githubusercontent.com/850046/30402523-4c736d86-98de-11e7-97c1-81a216912fb7.png)
