### PR TITLE
Fix JS query string versioning when using addStyleEntry

### DIFF
--- a/lib/webpack/delete-unused-entries-js-plugin.js
+++ b/lib/webpack/delete-unused-entries-js-plugin.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-const path = require('path');
-
 function DeleteUnusedEntriesJSPlugin(entriesToDelete = []) {
     this.entriesToDelete = entriesToDelete;
 }
@@ -25,7 +23,7 @@ DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
 
                 // loop over the output files and find the 1 that ends in .js
                 chunk.files.forEach((filename) => {
-                    if (path.extname(filename) === '.js') {
+                    if (/\.js(\?[^.]*)?$/.test(filename)) {
                         fileDeleteCount++;
                         // remove the output file
                         delete compilation.assets[filename];

--- a/test/functional.js
+++ b/test/functional.js
@@ -243,30 +243,94 @@ describe('Functional tests using webpack', function() {
             });
         });
 
-        it('addStyleEntry .js files are removed', (done) => {
-            const config = createWebpackConfig('web', 'dev');
-            config.addEntry('main', './js/no_require');
-            config.setPublicPath('/');
-            config.addStyleEntry('styles', './css/h1_style.css');
+        describe('addStyleEntry .js files are removed', () => {
+            it('Without versioning', (done) => {
+                const config = createWebpackConfig('web', 'dev');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/');
+                config.addStyleEntry('styles', './css/h1_style.css');
 
-            testSetup.runWebpack(config, (webpackAssert) => {
-                expect(config.outputPath).to.be.a.directory()
-                    // public.js should not exist
-                    .with.files(['main.js', 'styles.css', 'manifest.json']);
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        // public.js should not exist
+                        .with.files(['main.js', 'styles.css', 'manifest.json']);
 
-                webpackAssert.assertOutputFileContains(
-                    'styles.css',
-                    'font-size: 50px;'
-                );
-                webpackAssert.assertManifestPathDoesNotExist(
-                    'styles.js'
-                );
-                webpackAssert.assertManifestPath(
-                    'styles.css',
-                    '/styles.css'
-                );
+                    webpackAssert.assertOutputFileContains(
+                        'styles.css',
+                        'font-size: 50px;'
+                    );
+                    webpackAssert.assertManifestPathDoesNotExist(
+                        'styles.js'
+                    );
+                    webpackAssert.assertManifestPath(
+                        'styles.css',
+                        '/styles.css'
+                    );
 
-                done();
+                    done();
+                });
+            });
+
+            it('With default versioning', (done) => {
+                const config = createWebpackConfig('web', 'dev');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/');
+                config.addStyleEntry('styles', './css/h1_style.css');
+                config.enableVersioning(true);
+
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        .with.files([
+                            'main.f1e0a9350e13fe3a597e.js',
+                            'styles.c84caea6dd12bba7955dee9fedd5fd03.css',
+                            'manifest.json'
+                        ]);
+
+                    webpackAssert.assertOutputFileContains(
+                        'styles.c84caea6dd12bba7955dee9fedd5fd03.css',
+                        'font-size: 50px;'
+                    );
+                    webpackAssert.assertManifestPathDoesNotExist(
+                        'styles.js'
+                    );
+                    webpackAssert.assertManifestPath(
+                        'styles.css',
+                        '/styles.c84caea6dd12bba7955dee9fedd5fd03.css'
+                    );
+
+                    done();
+                });
+            });
+
+            it('With query string versioning', (done) => {
+                const config = createWebpackConfig('web', 'dev');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/');
+                config.addStyleEntry('styles', './css/h1_style.css');
+                config.enableVersioning(true);
+                config.configureFilenames({
+                    js: '[name].js?[chunkhash:16]',
+                    css: '[name].css?[contenthash:16]'
+                });
+
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        .with.files(['main.js', 'styles.css', 'manifest.json']);
+
+                    webpackAssert.assertOutputFileContains(
+                        'styles.css',
+                        'font-size: 50px;'
+                    );
+                    webpackAssert.assertManifestPathDoesNotExist(
+                        'styles.js'
+                    );
+                    webpackAssert.assertManifestPath(
+                        'styles.css',
+                        '/styles.css?c84caea6dd12bba7'
+                    );
+
+                    done();
+                });
             });
         });
 


### PR DESCRIPTION
This PR fixes an error occuring when calling `addStyleEntry` and using a query string versioning strategy at the same time (closes #160).

Basically, the `delete-unused-entries` part that removes "fake" js files created by the `addStyleEntry` method would only pick filenames ending by `.js` which may not be the case at this point if the chunkhash is appened after the filename as a query string (e.g.: `[name].js?[chunkhash:16]`).