### PR TITLE
Add Encore.sortPlugins() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,6 +279,37 @@ const publicApi = {
     },
 
     /**
+     * Sorts plugins so they are added to Webpack in the given order.
+     *
+     * This method takes an array of the constructor functions used to
+     * initialize the plugins you want to sort.
+     *
+     * You only need to provide the plugins that need to be sorted:
+     * the other ones will keep their default position or respect
+     * the order in which the Encore.addPlugin() method has been called.
+     *
+     * For example:
+     *
+     *      const webpack = require('webpack');
+     *      const Plugin1 = require('plugin1');
+     *      const Plugin2 = require('plugin2');
+     *
+     *      Encore.sortPlugins([
+     *          Plugin2,
+     *          webpack.optimize.UglifyJsPlugin,
+     *          Plugin1
+     *      ])
+     *
+     * @param {Array} sortOrder
+     * @return {exports}
+     */
+    sortPlugins(sortOrder) {
+        webpackConfig.sortPlugins(sortOrder);
+
+        return this;
+    },
+
+    /**
      * Adds a custom loader config
      *
      * @param {object} loader The loader config object

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -45,6 +45,7 @@ class WebpackConfig {
         this.sharedCommonsEntryName = null;
         this.providedVariables = {};
         this.configuredFilenames = {};
+        this.sortPluginsOrder = [];
 
         // Features/Loaders flags
         this.useVersioning = false;
@@ -254,6 +255,14 @@ class WebpackConfig {
 
     addPlugin(plugin) {
         this.plugins.push(plugin);
+    }
+
+    sortPlugins(sortOrder = []) {
+        if (!Array.isArray(sortOrder)) {
+            throw new Error('Argument 1 to sortPlugins() must be an Array of constructor functions (e.g.: [ExtractTextPlugin, CleanWebpackPlugin])');
+        }
+
+        this.sortPluginsOrder = sortOrder;
     }
 
     addLoader(loader) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -250,19 +250,17 @@ class ConfigGenerator {
             const currentPlugin = plugins.shift();
             const sortedIndex = sortOrder.findIndex((type) => currentPlugin instanceof type);
 
-            if (sortedIndex >= 0) {
-                // If the current plugin type has been found in the sortOrder array
-                // we move every instances of the types that are supposed to be placed
-                // before it.
-                for (let i = 0; i < sortedIndex; i++) {
-                    const currentType = sortOrder.shift();
+            // If the current plugin type has been found in the sortOrder array
+            // we move every instances of the types that are supposed to be placed
+            // before it.
+            for (let i = 0; i < sortedIndex; i++) {
+                const currentType = sortOrder.shift();
 
-                    // Add plugins of the current type to the sorted array
-                    sortedPlugins.push(...plugins.filter((plugin) => plugin instanceof currentType));
+                // Add plugins of the current type to the sorted array
+                sortedPlugins.push(...plugins.filter((plugin) => plugin instanceof currentType));
 
-                    // Remove plugins of the current type from the unsorted array
-                    plugins = plugins.filter((plugin) => !(plugin instanceof currentType));
-                }
+                // Remove plugins of the current type from the unsorted array
+                plugins = plugins.filter((plugin) => !(plugin instanceof currentType));
             }
 
             sortedPlugins.push(currentPlugin);

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -214,9 +214,6 @@ class ConfigGenerator {
         // register the pure-style entries that should be deleted
         deleteUnusedEntriesPluginUtil(plugins, this.webpackConfig);
 
-        // Dump the manifest.json file
-        manifestPluginUtil(plugins, this.webpackConfig);
-
         loaderOptionsPluginUtil(plugins, this.webpackConfig);
 
         versioningPluginUtil(plugins, this.webpackConfig);
@@ -236,11 +233,42 @@ class ConfigGenerator {
 
         assetOutputDisplay(plugins, this.webpackConfig, friendlyErrorPlugin);
 
+        // Custom plugins
         this.webpackConfig.plugins.forEach(function(plugin) {
             plugins.push(plugin);
         });
 
-        return plugins;
+        // Dump the manifest.json file last so it includes all
+        // emitted assets.
+        manifestPluginUtil(plugins, this.webpackConfig);
+
+        // Sort plugins based on the order given to Encore.sortPlugins()
+        const sortOrder = [...this.webpackConfig.sortPluginsOrder];
+        const sortedPlugins = [];
+
+        while (plugins.length) {
+            const currentPlugin = plugins.shift();
+            const sortedIndex = sortOrder.findIndex((type) => currentPlugin instanceof type);
+
+            if (sortedIndex >= 0) {
+                // If the current plugin type has been found in the sortOrder array
+                // we move every instances of the types that are supposed to be placed
+                // before it.
+                for (let i = 0; i < sortedIndex; i++) {
+                    const currentType = sortOrder.shift();
+
+                    // Add plugins of the current type to the sorted array
+                    sortedPlugins.push(...plugins.filter((plugin) => plugin instanceof currentType));
+
+                    // Remove plugins of the current type from the unsorted array
+                    plugins = plugins.filter((plugin) => !(plugin instanceof currentType));
+                }
+            }
+
+            sortedPlugins.push(currentPlugin);
+        }
+
+        return sortedPlugins;
     }
 
     buildStatsConfig() {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -617,6 +617,29 @@ describe('WebpackConfig object', () => {
         });
     });
 
+    describe('sortPlugins', () => {
+        it('Calling method sets it', () => {
+            const config = createConfig();
+
+            expect(config.sortPluginsOrder.length).to.equal(0);
+
+            config.sortPlugins([
+                new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+                new webpack.optimize.UglifyJsPlugin()
+            ]);
+
+            expect(config.sortPluginsOrder.length).to.equal(2);
+        });
+
+        it('Calling with non-array throws an error', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.sortPlugins('foo');
+            }).to.throw('must be an Array');
+        });
+    });
+
     describe('addLoader', () => {
         it('Adds a new loader', () => {
             const config = createConfig();

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,15 @@ describe('Public API', () => {
 
     });
 
+    describe('sortPlugins', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.sortPlugins([]);
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
     describe('addLoader', () => {
 
         it('must return the API object', () => {


### PR DESCRIPTION
This PR tries to solve #163 (ping @stof) by adding a `sortPlugins` method to the public API.

Usage:
```js
const webpack = require('webpack');
const Plugin1 = require('plugin1');
const Plugin2 = require('plugin2');

Encore.sortPlugins([
    Plugin2,
    webpack.optimize.UglifyJsPlugin,
    Plugin1
])
```

Since it relies on `instanceof` checks it won't allow to sort two instances of a given plugin relatively to eachother but I'm not sure that case needs to be handled anyway...

I also changed the default position of the `ManifestPlugin` so it is added after custom plugins. This is done in order to prevent issues with other plugins that emit assets (e.g. `CopyWebpackPlugin` and `ConcatPlugin` after #164 is merged).