### PR TITLE
Fix temporary map files not being deleted in production mode

### DIFF
--- a/lib/webpack/delete-unused-entries-js-plugin.js
+++ b/lib/webpack/delete-unused-entries-js-plugin.js
@@ -23,7 +23,7 @@ DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
 
                 // loop over the output files and find the 1 that ends in .js
                 chunk.files.forEach((filename) => {
-                    if (/\.js(\?[^.]*)?$/.test(filename)) {
+                    if (/\.js(\.map)?(\?[^.]*)?$/.test(filename)) {
                         fileDeleteCount++;
                         // remove the output file
                         delete compilation.assets[filename];
@@ -32,10 +32,10 @@ DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
                     }
                 });
 
-                // sanity check: make sure 1 file was deleted
-                // if there's some edge case where multiple .js files
+                // sanity check: make sure 1 or 2 files were deleted
+                // if there's some edge case where more .js files
                 // or 0 .js files might be deleted, I'd rather error
-                if (fileDeleteCount !== 1) {
+                if (fileDeleteCount === 0 || fileDeleteCount > 2) {
                     throw new Error(`Problem deleting JS entry for ${chunk.name}: ${fileDeleteCount} files were deleted`);
                 }
             }

--- a/test/functional.js
+++ b/test/functional.js
@@ -332,6 +332,37 @@ describe('Functional tests using webpack', function() {
                     done();
                 });
             });
+
+            it('With source maps in production mode', (done) => {
+                const config = createWebpackConfig('web', 'production');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/');
+                config.addStyleEntry('styles', './css/h1_style.css');
+                config.enableSourceMaps(true);
+
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        .with.files([
+                            'main.js',
+                            'main.js.map',
+                            'styles.css',
+                            'styles.css.map',
+                            'manifest.json'
+                            // no styles.js
+                            // no styles.js.map
+                        ]);
+
+                    webpackAssert.assertManifestPathDoesNotExist(
+                        'styles.js'
+                    );
+
+                    webpackAssert.assertManifestPathDoesNotExist(
+                        'styles.js.map'
+                    );
+
+                    done();
+                });
+            });
         });
 
         it('enableVersioning applies to js, css & manifest', (done) => {


### PR DESCRIPTION
This PR fixes `<entry>.js.map` files not being deleted after calling `addStyleEntry(...)` and `enableSourceMaps(true)` in production mode.