### PR TITLE
Add an instance of DefinePlugin even in development mode

### DIFF
--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -17,14 +17,9 @@ const webpack = require('webpack');
  * @return {void}
  */
 module.exports = function(plugins, webpackConfig) {
-
-    if (!webpackConfig.isProduction()) {
-        return;
-    }
-
     const definePluginOptions = {
         'process.env': {
-            NODE_ENV: '"production"'
+            NODE_ENV: webpackConfig.isProduction() ? '"production"' : '"development"'
         }
     };
 

--- a/test/plugins/define.js
+++ b/test/plugins/define.js
@@ -30,7 +30,9 @@ describe('plugins/define', () => {
         const plugins = [];
 
         definePluginUtil(plugins, config);
-        expect(plugins.length).to.equal(0);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0]).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('development'));
     });
 
     it('production environment with default settings', () => {
@@ -40,6 +42,7 @@ describe('plugins/define', () => {
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0]).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
     });
 
     it('production environment with options callback', () => {


### PR DESCRIPTION
This PR fixes #171 by adding an instance of the `DefinePlugin` to the generated Webpack config no matter what the current environment is.