### PR TITLE
Add a priority parameter to the Encore.addPlugin() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,11 +269,35 @@ const publicApi = {
      * For example, if you want to add the "webpack.IgnorePlugin()", then:
      *      .addPlugin(new webpack.IgnorePlugin(requestRegExp, contextRegExp))
      *
+     * By default custom plugins are added after the ones managed by Encore
+     * but you can also set a priority to define where your plugin will be
+     * added in the generated Webpack config.
+     *
+     * For example, if a plugin has a priority of 0 and you want to add
+     * another plugin after it, then:
+     *
+     *      .addPlugin(new MyWebpackPlugin(), -10)
+     *
+     * The priority of each plugin added by Encore can be found in the
+     * "lib/plugins/plugin-priorities.js" file. It is recommended to use
+     * these constants if you want to add a plugin using the same priority
+     * as one managed by Encore in order to avoid backward compatibility
+     * breaks.
+     *
+     * For example, if you want one of your plugins to have the same priority
+     * than the DefinePlugin:
+     *
+     *      const Encore = require('@symfony/webpack-encore');
+     *      const PluginPriorities = require('@symfony/webpack-encore/lib/plugins/plugin-priorities.js');
+     *
+     *      Encore.addPlugin(new MyWebpackPlugin(), PluginPriorities.DefinePlugin);
+     *
      * @param {string} plugin
+     * @param {number} priority
      * @return {exports}
      */
-    addPlugin(plugin) {
-        webpackConfig.addPlugin(plugin);
+    addPlugin(plugin, priority = 0) {
+        webpackConfig.addPlugin(plugin, priority);
 
         return this;
     },

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -252,8 +252,15 @@ class WebpackConfig {
         this.styleEntries.set(name, src);
     }
 
-    addPlugin(plugin) {
-        this.plugins.push(plugin);
+    addPlugin(plugin, priority = 0) {
+        if (typeof priority !== 'number') {
+            throw new Error('Argument 2 to addPlugin() must be a number.');
+        }
+
+        this.plugins.push({
+            plugin: plugin,
+            priority: priority
+        });
     }
 
     addLoader(loader) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -31,6 +31,7 @@ const definePluginUtil = require('./plugins/define');
 const uglifyPluginUtil = require('./plugins/uglify');
 const friendlyErrorPluginUtil = require('./plugins/friendly-errors');
 const assetOutputDisplay = require('./plugins/asset-output-display');
+const PluginPriorities = require('./plugins/plugin-priorities');
 
 class ConfigGenerator {
     /**
@@ -207,7 +208,7 @@ class ConfigGenerator {
     }
 
     buildPluginsConfig() {
-        let plugins = [];
+        const plugins = [];
 
         extractTextPluginUtil(plugins, this.webpackConfig);
 
@@ -232,7 +233,10 @@ class ConfigGenerator {
         uglifyPluginUtil(plugins, this.webpackConfig);
 
         const friendlyErrorPlugin = friendlyErrorPluginUtil(this.webpackConfig);
-        plugins.push(friendlyErrorPlugin);
+        plugins.push({
+            plugin: friendlyErrorPlugin,
+            priority: PluginPriorities.FriendlyErrorsWebpackPlugin
+        });
 
         assetOutputDisplay(plugins, this.webpackConfig, friendlyErrorPlugin);
 
@@ -240,7 +244,20 @@ class ConfigGenerator {
             plugins.push(plugin);
         });
 
-        return plugins;
+        // Return sorted plugins
+        return plugins
+            .map((plugin, position) => Object.assign({}, plugin, { position: position }))
+            .sort((a, b) => {
+                // Keep the original order if two plugins have the same priority
+                if (a.priority === b.priority) {
+                    return a.position - b.position;
+                }
+
+                // A plugin with a priority of -10 will be placed after one
+                // that has a priority of 0.
+                return b.priority - a.priority;
+            })
+            .map((plugin) => plugin.plugin);
     }
 
     buildStatsConfig() {

--- a/lib/plugins/asset-output-display.js
+++ b/lib/plugins/asset-output-display.js
@@ -11,6 +11,7 @@
 
 const pathUtil = require('../config/path-util');
 const AssetOutputDisplayPlugin = require('../friendly-errors/asset-output-display-plugin');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * Updates plugins array passed adding AssetOutputDisplayPlugin instance
@@ -26,5 +27,8 @@ module.exports = function(plugins, webpackConfig, friendlyErrorsPlugin) {
     }
 
     const outputPath = pathUtil.getRelativeOutputPath(webpackConfig);
-    plugins.push(new AssetOutputDisplayPlugin(outputPath, friendlyErrorsPlugin));
+    plugins.push({
+        plugin: new AssetOutputDisplayPlugin(outputPath, friendlyErrorsPlugin),
+        priority: PluginPriorities.AssetOutputDisplayPlugin
+    });
 };

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * Updates plugins array passed adding CleanWebpackPlugin instance
@@ -34,8 +35,11 @@ module.exports = function(plugins, webpackConfig) {
         [cleanWebpackPluginOptions]
     );
 
-    plugins.push(new CleanWebpackPlugin(
-        webpackConfig.cleanWebpackPluginPaths,
-        cleanWebpackPluginOptions
-    ));
+    plugins.push({
+        plugin: new CleanWebpackPlugin(
+            webpackConfig.cleanWebpackPluginPaths,
+            cleanWebpackPluginOptions
+        ),
+        priority: PluginPriorities.CleanWebpackPlugin
+    });
 };

--- a/lib/plugins/commons-chunks.js
+++ b/lib/plugins/commons-chunks.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const webpack = require('webpack');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -23,18 +24,21 @@ module.exports = function(plugins, webpackConfig) {
     }
 
     // if we're extracting a vendor chunk, set it up!
-    plugins.push(new webpack.optimize.CommonsChunkPlugin({
-        name: [
-            webpackConfig.sharedCommonsEntryName,
-            /*
-             * Always dump a 2nd file - manifest.json that
-             * will contain the webpack manifest information.
-             * This changes frequently, and without this line,
-             * it would be packaged inside the "shared commons entry"
-             * file - e.g. vendor.js, which would prevent long-term caching.
-             */
-            'manifest'
-        ],
-        minChunks: Infinity,
-    }));
+    plugins.push({
+        plugin: new webpack.optimize.CommonsChunkPlugin({
+            name: [
+                webpackConfig.sharedCommonsEntryName,
+                /*
+                * Always dump a 2nd file - manifest.json that
+                * will contain the webpack manifest information.
+                * This changes frequently, and without this line,
+                * it would be packaged inside the "shared commons entry"
+                * file - e.g. vendor.js, which would prevent long-term caching.
+                */
+                'manifest'
+            ],
+            minChunks: Infinity,
+        }),
+        priority: PluginPriorities.CommonsChunkPlugin
+    });
 };

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const webpack = require('webpack');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -28,5 +29,8 @@ module.exports = function(plugins, webpackConfig) {
         [definePluginOptions]
     );
 
-    plugins.push(new webpack.DefinePlugin(definePluginOptions));
+    plugins.push({
+        plugin: new webpack.DefinePlugin(definePluginOptions),
+        priority: PluginPriorities.DefinePlugin
+    });
 };

--- a/lib/plugins/delete-unused-entries.js
+++ b/lib/plugins/delete-unused-entries.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const DeleteUnusedEntriesJSPlugin = require('../webpack/delete-unused-entries-js-plugin');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -18,8 +19,11 @@ const DeleteUnusedEntriesJSPlugin = require('../webpack/delete-unused-entries-js
  */
 module.exports = function(plugins, webpackConfig) {
 
-    plugins.push(new DeleteUnusedEntriesJSPlugin(
-        // transform into an Array
-        [... webpackConfig.styleEntries.keys()]
-    ));
+    plugins.push({
+        plugin: new DeleteUnusedEntriesJSPlugin(
+            // transform into an Array
+            [... webpackConfig.styleEntries.keys()]
+        ),
+        priority: PluginPriorities.DeleteUnusedEntriesJSPlugin
+    });
 };

--- a/lib/plugins/extract-text.js
+++ b/lib/plugins/extract-text.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -49,5 +50,8 @@ module.exports = function(plugins, webpackConfig) {
         [extractTextPluginOptions]
     );
 
-    plugins.push(new ExtractTextPlugin(extractTextPluginOptions));
+    plugins.push({
+        plugin: new ExtractTextPlugin(extractTextPluginOptions),
+        priority: PluginPriorities.ExtractTextWebpackPlugin
+    });
 };

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin'); // eslint-disable-line
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -25,5 +26,8 @@ module.exports = function(webpackConfig) {
         [config]
     );
 
-    webpackConfig.addPlugin(new ForkTsCheckerWebpackPlugin(config));
+    webpackConfig.addPlugin(
+        new ForkTsCheckerWebpackPlugin(config),
+        PluginPriorities.ForkTsCheckerWebpackPlugin
+    );
 };

--- a/lib/plugins/loader-options.js
+++ b/lib/plugins/loader-options.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const webpack = require('webpack');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -39,5 +40,8 @@ module.exports = function(plugins, webpackConfig) {
         [loaderOptionsPluginOptions]
     );
 
-    plugins.push(new webpack.LoaderOptionsPlugin(loaderOptionsPluginOptions));
+    plugins.push({
+        plugin: new webpack.LoaderOptionsPlugin(loaderOptionsPluginOptions),
+        priority: PluginPriorities.LoaderOptionsPlugin
+    });
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const ManifestPlugin = require('../webpack/webpack-manifest-plugin');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -37,5 +38,8 @@ module.exports = function(plugins, webpackConfig) {
         [manifestPluginOptions]
     );
 
-    plugins.push(new ManifestPlugin(manifestPluginOptions));
+    plugins.push({
+        plugin: new ManifestPlugin(manifestPluginOptions),
+        priority: PluginPriorities.WebpackManifestPlugin
+    });
 };

--- a/lib/plugins/plugin-priorities.js
+++ b/lib/plugins/plugin-priorities.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+module.exports = {
+    ExtractTextWebpackPlugin: 0,
+    DeleteUnusedEntriesJSPlugin: 0,
+    WebpackManifestPlugin: 0,
+    LoaderOptionsPlugin: 0,
+    ProvidePlugin: 0,
+    CleanWebpackPlugin: 0,
+    CommonsChunkPlugin: 0,
+    DefinePlugin: 0,
+    UglifyJsPlugin: 0,
+    FriendlyErrorsWebpackPlugin: 0,
+    AssetOutputDisplayPlugin: 0,
+    ForkTsCheckerWebpackPlugin: 0,
+    HashedModuleIdsPlugin: 0,
+    NamedModulesPlugin: 0,
+    WebpackChunkHash: 0,
+};

--- a/lib/plugins/uglify.js
+++ b/lib/plugins/uglify.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const webpack = require('webpack');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -31,5 +32,8 @@ module.exports = function(plugins, webpackConfig) {
         [uglifyJsPluginOptions]
     );
 
-    plugins.push(new webpack.optimize.UglifyJsPlugin(uglifyJsPluginOptions));
+    plugins.push({
+        plugin: new webpack.optimize.UglifyJsPlugin(uglifyJsPluginOptions),
+        priority: PluginPriorities.UglifyJsPlugin
+    });
 };

--- a/lib/plugins/variable-provider.js
+++ b/lib/plugins/variable-provider.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const webpack = require('webpack');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -18,6 +19,9 @@ const webpack = require('webpack');
  */
 module.exports = function(plugins, webpackConfig) {
     if (Object.keys(webpackConfig.providedVariables).length > 0) {
-        plugins.push(new webpack.ProvidePlugin(webpackConfig.providedVariables));
+        plugins.push({
+            plugin: new webpack.ProvidePlugin(webpackConfig.providedVariables),
+            priority: PluginPriorities.ProvidePlugin
+        });
     }
 };

--- a/lib/plugins/versioning.js
+++ b/lib/plugins/versioning.js
@@ -11,6 +11,7 @@
 
 const webpack = require('webpack');
 const WebpackChunkHash = require('webpack-chunk-hash');
+const PluginPriorities = require('./plugin-priorities');
 
 /**
  * @param {Array} plugins
@@ -44,15 +45,24 @@ module.exports = function(plugins, webpackConfig) {
         // shorter, and obfuscated module ids (versus NamedModulesPlugin)
         // makes the final assets *slightly* larger, but prevents contents
         // from sometimes changing when nothing really changed
-        plugins.push(new webpack.HashedModuleIdsPlugin());
+        plugins.push({
+            plugin: new webpack.HashedModuleIdsPlugin(),
+            priority: PluginPriorities.HashedModuleIdsPlugin
+        });
     } else {
         // human-readable module names, helps debug in HMR
         // enable always when not in production for consistency
-        plugins.push(new webpack.NamedModulesPlugin());
+        plugins.push({
+            plugin: new webpack.NamedModulesPlugin(),
+            priority: PluginPriorities.NamedModulesPlugin
+        });
     }
 
     if (webpackConfig.useVersioning) {
         // enables the [chunkhash] ability
-        plugins.push(new WebpackChunkHash());
+        plugins.push({
+            plugin: new WebpackChunkHash(),
+            priority: PluginPriorities.WebpackChunkHash
+        });
     }
 };

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -614,6 +614,32 @@ describe('WebpackConfig object', () => {
             config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
 
             expect(config.plugins.length).to.equal(1);
+            expect(config.plugins[0].plugin).to.be.instanceof(webpack.IgnorePlugin);
+            expect(config.plugins[0].priority).to.equal(0);
+        });
+
+        it('Calling it with a priority', () => {
+            const config = createConfig();
+            const nbOfPlugins = config.plugins.length;
+
+            expect(nbOfPlugins).to.equal(0);
+
+            config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), 10);
+
+            expect(config.plugins.length).to.equal(1);
+            expect(config.plugins[0].plugin).to.be.instanceof(webpack.IgnorePlugin);
+            expect(config.plugins[0].priority).to.equal(10);
+        });
+
+        it('Calling it with an invalid priority', () => {
+            const config = createConfig();
+            const nbOfPlugins = config.plugins.length;
+
+            expect(nbOfPlugins).to.equal(0);
+
+            expect(() => {
+                config.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), 'foo');
+            }).to.throw('must be a number');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -404,6 +404,10 @@ describe('The config-generator function', () => {
     });
 
     describe('test for addPlugin config', () => {
+        function CustomPlugin1() {}
+        function CustomPlugin2() {}
+        function CustomPlugin3() {}
+
         it('extra plugin is set correctly', () => {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
@@ -414,6 +418,38 @@ describe('The config-generator function', () => {
 
             const ignorePlugin = findPlugin(webpack.IgnorePlugin, actualConfig.plugins);
             expect(ignorePlugin).to.not.be.undefined;
+        });
+
+        it('by default custom plugins are added at the end and are kept in order', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+            config.addPlugin(new CustomPlugin1());
+            config.addPlugin(new CustomPlugin2());
+            config.addPlugin(new CustomPlugin3());
+
+            const actualConfig = configGenerator(config);
+            const plugins = actualConfig.plugins;
+
+            expect(plugins[plugins.length - 3]).to.be.instanceof(CustomPlugin1);
+            expect(plugins[plugins.length - 2]).to.be.instanceof(CustomPlugin2);
+            expect(plugins[plugins.length - 1]).to.be.instanceof(CustomPlugin3);
+        });
+
+        it('plugins can be sorted relatively to each other', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+            config.addPlugin(new CustomPlugin1(), 2000);
+            config.addPlugin(new CustomPlugin2(), -1000);
+            config.addPlugin(new CustomPlugin3(), 1000);
+
+            const actualConfig = configGenerator(config);
+            const plugins = actualConfig.plugins;
+
+            expect(plugins[0]).to.be.instanceof(CustomPlugin1);
+            expect(plugins[1]).to.be.instanceof(CustomPlugin3);
+            expect(plugins[plugins.length - 1]).to.be.instanceof(CustomPlugin2);
         });
     });
 

--- a/test/plugins/clean.js
+++ b/test/plugins/clean.js
@@ -40,9 +40,9 @@ describe('plugins/clean', () => {
 
         cleanPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(CleanWebpackPlugin);
-        expect(plugins[0].paths).to.deep.equal(['**/*']);
-        expect(plugins[0].options.dry).to.equal(false);
+        expect(plugins[0].plugin).to.be.instanceof(CleanWebpackPlugin);
+        expect(plugins[0].plugin.paths).to.deep.equal(['**/*']);
+        expect(plugins[0].plugin.options.dry).to.equal(false);
     });
 
     it('enabled with custom paths and options callback', () => {
@@ -55,8 +55,8 @@ describe('plugins/clean', () => {
 
         cleanPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(CleanWebpackPlugin);
-        expect(plugins[0].paths).to.deep.equal(['**/*.js', '**/*.css']);
-        expect(plugins[0].options.dry).to.equal(true);
+        expect(plugins[0].plugin).to.be.instanceof(CleanWebpackPlugin);
+        expect(plugins[0].plugin.paths).to.deep.equal(['**/*.js', '**/*.css']);
+        expect(plugins[0].plugin.options.dry).to.equal(true);
     });
 });

--- a/test/plugins/define.js
+++ b/test/plugins/define.js
@@ -31,8 +31,8 @@ describe('plugins/define', () => {
 
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.DefinePlugin);
-        expect(plugins[0].definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('development'));
+        expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('development'));
     });
 
     it('production environment with default settings', () => {
@@ -41,8 +41,8 @@ describe('plugins/define', () => {
 
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.DefinePlugin);
-        expect(plugins[0].definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
+        expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
     });
 
     it('production environment with options callback', () => {
@@ -56,13 +56,13 @@ describe('plugins/define', () => {
 
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
 
         // Allows to add new definitions
-        expect(plugins[0].definitions.foo).to.equal(true);
-        expect(plugins[0].definitions['process.env'].bar).to.equal(true);
+        expect(plugins[0].plugin.definitions.foo).to.equal(true);
+        expect(plugins[0].plugin.definitions['process.env'].bar).to.equal(true);
 
         // Doesn't remove default definitions
-        expect(plugins[0].definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
+        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
     });
 });

--- a/test/plugins/extract-text.js
+++ b/test/plugins/extract-text.js
@@ -30,9 +30,9 @@ describe('plugins/extract-text', () => {
 
         extractTextPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(ExtractTextPlugin);
-        expect(plugins[0].filename).to.equal('[name].css');
-        expect(plugins[0].options.allChunks).to.equal(false);
+        expect(plugins[0].plugin).to.be.instanceof(ExtractTextPlugin);
+        expect(plugins[0].plugin.filename).to.equal('[name].css');
+        expect(plugins[0].plugin.options.allChunks).to.equal(false);
     });
 
     it('with default settings and versioning enabled', () => {
@@ -43,9 +43,9 @@ describe('plugins/extract-text', () => {
 
         extractTextPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(ExtractTextPlugin);
-        expect(plugins[0].filename).to.equal('[name].[contenthash].css');
-        expect(plugins[0].options.allChunks).to.equal(false);
+        expect(plugins[0].plugin).to.be.instanceof(ExtractTextPlugin);
+        expect(plugins[0].plugin.filename).to.equal('[name].[contenthash].css');
+        expect(plugins[0].plugin.options.allChunks).to.equal(false);
     });
 
     it('with options callback', () => {
@@ -59,15 +59,15 @@ describe('plugins/extract-text', () => {
 
         extractTextPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(ExtractTextPlugin);
+        expect(plugins[0].plugin).to.be.instanceof(ExtractTextPlugin);
 
         // Allows to add new options
-        expect(plugins[0].options.disable).to.equal(true);
+        expect(plugins[0].plugin.options.disable).to.equal(true);
 
         // Allows to override default options
-        expect(plugins[0].filename).to.equal('bar');
+        expect(plugins[0].plugin.filename).to.equal('bar');
 
         // Doesn't remove default options
-        expect(plugins[0].options.allChunks).to.equal(false);
+        expect(plugins[0].plugin.options.allChunks).to.equal(false);
     });
 });

--- a/test/plugins/forked-ts-types.js
+++ b/test/plugins/forked-ts-types.js
@@ -33,7 +33,7 @@ describe('plugins/forkedtypecheck', () => {
         const tsTypeChecker = require('../../lib/plugins/forked-ts-types');
         tsTypeChecker(config);
         expect(config.plugins).to.have.lengthOf(1);
-        expect(config.plugins[0]).to.be.an.instanceof(ForkTsCheckerWebpackPlugin);
+        expect(config.plugins[0].plugin).to.be.an.instanceof(ForkTsCheckerWebpackPlugin);
         // after enabling plugin, check typescript loader has right config
         const actualLoaders = tsLoader.getLoaders(config);
         expect(actualLoaders[1].options.transpileOnly).to.be.true;

--- a/test/plugins/loader-options.js
+++ b/test/plugins/loader-options.js
@@ -31,8 +31,8 @@ describe('plugins/loader-options', () => {
 
         loaderOptionsPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.LoaderOptionsPlugin);
-        expect(plugins[0].options.debug).to.equal(true);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.LoaderOptionsPlugin);
+        expect(plugins[0].plugin.options.debug).to.equal(true);
     });
 
     it('production environment with default settings', () => {
@@ -41,8 +41,8 @@ describe('plugins/loader-options', () => {
 
         loaderOptionsPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.LoaderOptionsPlugin);
-        expect(plugins[0].options.debug).to.equal(false);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.LoaderOptionsPlugin);
+        expect(plugins[0].plugin.options.debug).to.equal(false);
     });
 
     it('production environment with options callback', () => {
@@ -55,12 +55,12 @@ describe('plugins/loader-options', () => {
 
         loaderOptionsPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.LoaderOptionsPlugin);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.LoaderOptionsPlugin);
 
         // Allows to override default options
-        expect(plugins[0].options.debug).to.equal(true);
+        expect(plugins[0].plugin.options.debug).to.equal(true);
 
         // Doesn't remove default options
-        expect(plugins[0].options.options.context).to.equal(config.getContext());
+        expect(plugins[0].plugin.options.options.context).to.equal(config.getContext());
     });
 });

--- a/test/plugins/manifest.js
+++ b/test/plugins/manifest.js
@@ -32,9 +32,9 @@ describe('plugins/manifest', () => {
 
         manifestPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(ManifestPlugin);
-        expect(plugins[0].opts.fileName).to.equal('manifest.json');
-        expect(plugins[0].opts.publicPath).to.equal('/foo/');
+        expect(plugins[0].plugin).to.be.instanceof(ManifestPlugin);
+        expect(plugins[0].plugin.opts.fileName).to.equal('manifest.json');
+        expect(plugins[0].plugin.opts.publicPath).to.equal('/foo/');
     });
 
     it('with options callback', () => {
@@ -47,12 +47,12 @@ describe('plugins/manifest', () => {
 
         manifestPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(ManifestPlugin);
+        expect(plugins[0].plugin).to.be.instanceof(ManifestPlugin);
 
         // Allows to override default options
-        expect(plugins[0].opts.fileName).to.equal('bar');
+        expect(plugins[0].plugin.opts.fileName).to.equal('bar');
 
         // Doesn't remove default options
-        expect(plugins[0].opts.publicPath).to.equal('/foo/');
+        expect(plugins[0].plugin.opts.publicPath).to.equal('/foo/');
     });
 });

--- a/test/plugins/uglify.js
+++ b/test/plugins/uglify.js
@@ -39,8 +39,8 @@ describe('plugins/uglify', () => {
 
         uglifyPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.optimize.UglifyJsPlugin);
-        expect(plugins[0].options.sourceMap).to.equal(false);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.optimize.UglifyJsPlugin);
+        expect(plugins[0].plugin.options.sourceMap).to.equal(false);
     });
 
     it('with options callback', () => {
@@ -53,12 +53,12 @@ describe('plugins/uglify', () => {
 
         uglifyPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
-        expect(plugins[0]).to.be.instanceof(webpack.optimize.UglifyJsPlugin);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.optimize.UglifyJsPlugin);
 
         // Allows to override default options
-        expect(plugins[0].options.beautify).to.equal(true);
+        expect(plugins[0].plugin.options.beautify).to.equal(true);
 
         // Doesn't remove default options
-        expect(plugins[0].options.sourceMap).to.equal(false);
+        expect(plugins[0].plugin.options.sourceMap).to.equal(false);
     });
 });


### PR DESCRIPTION
Following the discussion in #165 this PR adds a `priority` parameter to the `Encore.addPlugin()` method in order to allow people to choose where their custom plugins will be added in the generated Webpack config (fixes #163).

__Examples:__

```js
const Encore = require('@symfony/webpack-encore');

// Without setting the priority a plugin will be
// appended to the other plugins.
Encore.addPlugin(new CustomPlugin());
```

```js
const Encore = require('@symfony/webpack-encore');

// If two plugins need to be sorted relatively to
// eachother (CustomPluginB will be placed before
// CustomPluginA):
Encore
    .addPlugin(new CustomPluginA(), 100);
    .addPlugin(new CustomPluginB(), 50)
;
```

```js
const Encore = require('@symfony/webpack-encore');
const PluginPriorities = require('@symfony/webpack-encore/lib/plugins/plugin-priorities.js');

// For now all plugins added by Encore have a
// priority of 0 (the same as the default priority for
// custom plugins), but constants are available in
// order to avoid BC breaks:
Encore.addPlugin(new CustomPlugin(), PluginPriorities.UglifyJsPlugin);
```