### PR TITLE
Fix new ts-loader rule being added when getWebpackConfig is called

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -193,7 +193,7 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useTypeScriptLoader) {
-            this.webpackConfig.addLoader({
+            rules.push({
                 test: /\.tsx?$/,
                 exclude: /node_modules/,
                 use: tsLoaderUtil.getLoaders(this.webpackConfig)


### PR DESCRIPTION
Due to the following lines a new ts-loader rule is currently being added everytime the Webpack config is generated (for instance by calling `Encore.getWebpackConfig()`):

https://github.com/symfony/webpack-encore/blob/c6057af7521594d9d76cfd072b1f2421591e4a3f/lib/config-generator.js#L196-L200

__Example:__

```js
// webpack.config.js
const Encore = require('@symfony/webpack-encore');

Encore
    .setOutputPath('build')
    .setPublicPath('/')
    .addEntry('src/index.ts')
    .enableTypeScriptLoader()
;

console.log(Encore.getWebpackConfig().module.rules.length); // => 5
console.log(Encore.getWebpackConfig().module.rules.length); // => 6
console.log(Encore.getWebpackConfig().module.rules.length); // => 7
```