### PR TITLE
Remove config stats broken in webpack3.8

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -274,9 +274,7 @@ class ConfigGenerator {
             reasons: false,
             children: false,
             source: false,
-            errors: false,
             errorDetails: false,
-            warnings: false,
             publicPath: false,
         };
     }


### PR DESCRIPTION
Removed `warning` and `error` that were throwing unknown property errors

