### PR TITLE
Replace error throwing with logger warning when publicPath is not absolute

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -127,7 +127,7 @@ class WebpackConfig {
             // technically, not starting with "/" is legal, but not
             // what you want in most cases. Let's warn the user that
             // they might be making a mistake.
-            logger.warning('The value passed to setPublicPath() should usually start with "/" or be a full URL (http://...)');
+            logger.warning('The value passed to setPublicPath() should *usually* start with "/" or be a full URL (http://...). If you\'re not sure, then you should probably change your public path and make this message disappear.');
         }
 
         // guarantee a single trailing slash

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -125,9 +125,9 @@ class WebpackConfig {
     setPublicPath(publicPath) {
         if (publicPath.includes('://') === false && publicPath.indexOf('/') !== 0) {
             // technically, not starting with "/" is legal, but not
-            // what you want in most cases. Let's not let the user make
-            // a mistake (and we can always change this later).
-            throw new Error('The value passed to setPublicPath() must start with "/" or be a full URL (http://...)');
+            // what you want in most cases. Let's warn the user that
+            // they might be making a mistake.
+            logger.warning('The value passed to setPublicPath() should usually start with "/" or be a full URL (http://...)');
         }
 
         // guarantee a single trailing slash

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -100,10 +100,9 @@ describe('WebpackConfig object', () => {
 
         it('foo/ throws an exception', () => {
             const config = createConfig();
+            config.setPublicPath('foo');
 
-            expect(() => {
-                config.setPublicPath('foo/');
-            }).to.throw('The value passed to setPublicPath() must start with "/"');
+            expect(logger.getMessages().warning).to.have.lengthOf(1);
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -98,7 +98,7 @@ describe('WebpackConfig object', () => {
             expect(config.publicPath).to.equal('https://example.com/');
         });
 
-        it('foo/ throws an exception', () => {
+        it('You can omit the opening slash, but get a warning', () => {
             const config = createConfig();
             config.setPublicPath('foo');
 


### PR DESCRIPTION
There are valid use cases for setting the publicPath to something not starting with a forward slash as discussed in #88 and #26 

Throwing an error and stopping compilation is overkill for this and beyond the remit of webpack encore, so I propose this PR where a warning is given to the user instead and the `setPublicPath` method falls in line with behaviour of `setManifestKeyPrefix`