### PR TITLE
webpack-manifest-plugin.js => Version 1.3.2

### DIFF
--- a/lib/webpack/webpack-manifest-plugin.js
+++ b/lib/webpack/webpack-manifest-plugin.js
@@ -1,6 +1,6 @@
 /*
  * File is originally a direct copy from https://github.com/danethurber/webpack-manifest-plugin
- * at version 1.1.0.
+ * at version 1.3.2.
  *
  * The library is licensed as MIT.
  *
@@ -13,130 +13,178 @@ var fse = require('fs-extra');
 var _ = require('lodash');
 
 function ManifestPlugin(opts) {
-  this.opts = _.assign({
-    basePath: '',
-    publicPath: '',
-    fileName: 'manifest.json',
-    stripSrc: null,
-    transformExtensions: /^(gz|map)$/i,
-    writeToFileEmit: false,
-    cache: null
-  }, opts || {});
+    this.opts = _.assign({
+        basePath: '',
+        publicPath: '',
+        fileName: 'manifest.json',
+        stripSrc: null,
+        transformExtensions: /^(gz|map)$/i,
+        writeToFileEmit: false,
+        cache: null, // TODO: Remove `cache` in next major release in favour of `seed`.
+        seed: null,
+        filter: null,
+        map: null,
+        reduce: null,
+    }, opts || {});
 }
 
 ManifestPlugin.prototype.getFileType = function(str) {
-  str = str.replace(/\?.*/, '');
-  var split = str.split('.');
-  var ext = split.pop();
-  if (this.opts.transformExtensions.test(ext)) {
-    ext = split.pop() + '.' + ext;
-  }
-  return ext;
+    str = str.replace(/\?.*/, '');
+    var split = str.split('.');
+    var ext = split.pop();
+    if (this.opts.transformExtensions.test(ext)) {
+        ext = split.pop() + '.' + ext;
+    }
+    return ext;
 };
 
 ManifestPlugin.prototype.apply = function(compiler) {
-  var outputName = this.opts.fileName;
-  var cache = this.opts.cache || {};
-  var moduleAssets = {};
+    var seed = this.opts.seed || this.opts.cache || {};
+    var moduleAssets = {};
 
-  compiler.plugin("compilation", function (compilation) {
-    compilation.plugin('module-asset', function (module, file) {
-      moduleAssets[file] = path.join(
-          path.dirname(file),
-          path.basename(module.userRequest)
-      );
-      /* *** MODIFICATION START *** */
-        // for Windows, we want the keys to use /, not \
-        // (and path.join will obviously use \ in Windows)
-        if (process.platform === 'win32') {
-            moduleAssets[file] = moduleAssets[file].replace(/\\/g, '/');
-        }
-      /* *** MODIFICATION END *** */
+    compiler.plugin("compilation", function (compilation) {
+        compilation.plugin('module-asset', function (module, file) {
+            moduleAssets[file] = path.join(
+                path.dirname(file),
+                path.basename(module.userRequest)
+            );
+            /* *** MODIFICATION START *** */
+            // for Windows, we want the keys to use /, not \
+            // (and path.join will obviously use \ in Windows)
+            if (process.platform === 'win32') {
+                moduleAssets[file] = moduleAssets[file].replace(/\\/g, '/');
+            }
+            /* *** MODIFICATION END *** */
+        });
     });
-  });
 
-  compiler.plugin('emit', function(compilation, compileCallback) {
-    var stats = compilation.getStats().toJson();
-    var manifest = {};
+    compiler.plugin('emit', function(compilation, compileCallback) {
+        var stats = compilation.getStats().toJson();
 
-    _.merge(manifest, compilation.chunks.reduce(function(memo, chunk) {
-      var chunkName = chunk.name ? chunk.name.replace(this.opts.stripSrc, '') : null;
+        var files = compilation.chunks.reduce(function(files, chunk) {
+            return chunk.files.reduce(function (files, path) {
+                // Don't add hot updates to manifest
+                if (path.indexOf('hot-update') >= 0) {
+                    return files;
+                }
 
-      // Map original chunk name to output files.
-      // For nameless chunks, just map the files directly.
-      return chunk.files.reduce(function(memo, file) {
-        // Don't add hot updates to manifest
-        if (file.indexOf('hot-update') >= 0) {
-          return memo;
+                var name = chunk.name ? chunk.name.replace(this.opts.stripSrc, '') : null;
+
+                if (name) {
+                    name = name + '.' + this.getFileType(path);
+                } else {
+                    // For nameless chunks, just map the files directly.
+                    name = path;
+                }
+
+                return files.concat({
+                    path: path,
+                    chunk: chunk,
+                    name: name,
+                    isInitial: chunk.isInitial ? chunk.isInitial() : chunk.initial,
+                    isChunk: true,
+                    isAsset: false,
+                    isModuleAsset: false
+                });
+            }.bind(this), files);
+        }.bind(this), []);
+
+        // module assets don't show up in assetsByChunkName.
+        // we're getting them this way;
+        files = stats.assets.reduce(function (files, asset) {
+            var name = moduleAssets[asset.name];
+            if (!name) {
+                return files;
+            }
+
+            return files.concat({
+                path: asset.name,
+                name: name,
+                isInitial: false,
+                isChunk: false,
+                isAsset: true,
+                isModuleAsset: true
+            });
+        }, files);
+
+        /* *** MODIFICATION START *** */
+        if (this.opts.basePath && this.opts.publicPath) {
+            // A modification made to the plugin for Encore
+            manifest = _.reduce(manifest, function(memo, value, key) {
+                memo[this.opts.basePath + key] = this.opts.publicPath + value;
+                return memo;
+            }.bind(this), {});
+            /* *** MODIFICATION END *** */
+        } else if (this.opts.basePath) {
+            // Append optional basepath onto all references.
+            // This allows output path to be reflected in the manifest.
+            files = files.map(function(file) {
+                file.name = this.opts.basePath + file.name;
+                file.path = this.opts.basePath + file.path;
+                return file;
+            }.bind(this));
+        } else if (this.opts.publicPath) {
+            // Similar to basePath but only affects the value (similar to how
+            // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
+            // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
+            files = files.map(function(file) {
+                file.path = this.opts.publicPath + file.path;
+                return file;
+            }.bind(this));
         }
-        if (chunkName) {
-          memo[chunkName + '.' + this.getFileType(file)] = file;
+
+        if (this.opts.filter) {
+            files = files.filter(this.opts.filter);
+        }
+
+        if (this.opts.map) {
+            files = files.map(this.opts.map);
+        }
+
+        files = files.sort(function (fileA, fileB) {
+            var a = fileA.name;
+            var b = fileB.name;
+
+            if (a < b) {
+                return -1;
+            } else if (a > b) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
+
+        var manifest;
+        if (this.opts.reduce) {
+            manifest = files.reduce(this.opts.reduce, seed);
         } else {
-          memo[file] = file;
+            manifest = files.reduce(function (manifest, file) {
+                manifest[file.name] = file.path;
+                return manifest;
+            }, seed);
         }
-        return memo;
-      }.bind(this), memo);
-    }.bind(this), {}));
 
-    // module assets don't show up in assetsByChunkName.
-    // we're getting them this way;
-    _.merge(manifest, stats.assets.reduce(function(memo, asset) {
-      var name = moduleAssets[asset.name];
-      if (name) {
-        memo[name] = asset.name;
-      }
-      return memo;
-    }, {}));
+        var json = JSON.stringify(manifest, null, 2);
 
-    /* *** MODIFICATION START *** */
-    if (this.opts.basePath && this.opts.publicPath) {
-      // A modification made to the plugin for Encore
-      manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[this.opts.basePath + key] = this.opts.publicPath + value;
-        return memo;
-      }.bind(this), {});
-    /* *** MODIFICATION END *** */
-    } else if (this.opts.basePath) {
-      // Append optional basepath onto all references.
-      // This allows output path to be reflected in the manifest.
-      manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[this.opts.basePath + key] = this.opts.basePath + value;
-        return memo;
-      }.bind(this), {});
-    } else if (this.opts.publicPath) {
-      // Similar to basePath but only affects the value (similar to how
-      // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
-      // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
-      manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[key] = this.opts.publicPath + value;
-        return memo;
-      }.bind(this), {});
-    }
+        var outputFolder = compilation.options.output.path;
+        var outputFile = path.resolve(compilation.options.output.path, this.opts.fileName);
+        var outputName = path.relative(outputFolder, outputFile);
 
-    Object.keys(manifest).sort().forEach(function(key) {
-      cache[key] = manifest[key];
-    });
+        compilation.assets[outputName] = {
+            source: function() {
+                return json;
+            },
+            size: function() {
+                return json.length;
+            }
+        };
 
-    var json = JSON.stringify(cache, null, 2);
+        if (this.opts.writeToFileEmit) {
+            fse.outputFileSync(outputFile, json);
+        }
 
-    compilation.assets[outputName] = {
-      source: function() {
-        return json;
-      },
-      size: function() {
-        return json.length;
-      }
-    };
-
-    if (this.opts.writeToFileEmit) {
-      var outputFolder = compilation.options.output.path;
-      var outputFile = path.join(outputFolder, this.opts.fileName);
-
-      fse.outputFileSync(outputFile, json);
-    }
-
-    compileCallback();
-  }.bind(this));
+        compileCallback();
+    }.bind(this));
 };
 
 module.exports = ManifestPlugin;


### PR DESCRIPTION
While we are waiting for version 2 of webpack-manifest-plugin.js to be fully integrated in webpack encore, here is an update to version 1.3.2. This version brings new features (hooks) like filter, map and sort https://github.com/danethurber/webpack-manifest-plugin#hooks-options