### PR TITLE
Fix output when using "--json" or "-j" option

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -45,8 +45,10 @@ if (runtimeConfig.useDevServer) {
 
     return require('webpack-dev-server/bin/webpack-dev-server');
 } else {
-    console.log('Running webpack ...');
-    console.log();
+    if (!runtimeConfig.outputJson) {
+        console.log('Running webpack ...');
+        console.log();
+    }
 
     return require('webpack/bin/webpack');
 }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -243,13 +243,15 @@ class ConfigGenerator {
 
         notifierPluginUtil(plugins, this.webpackConfig);
 
-        const friendlyErrorPlugin = friendlyErrorPluginUtil(this.webpackConfig);
-        plugins.push({
-            plugin: friendlyErrorPlugin,
-            priority: PluginPriorities.FriendlyErrorsWebpackPlugin
-        });
+        if (!this.webpackConfig.runtimeConfig.outputJson) {
+            const friendlyErrorPlugin = friendlyErrorPluginUtil(this.webpackConfig);
+            plugins.push({
+                plugin: friendlyErrorPlugin,
+                priority: PluginPriorities.FriendlyErrorsWebpackPlugin
+            });
 
-        assetOutputDisplay(plugins, this.webpackConfig, friendlyErrorPlugin);
+            assetOutputDisplay(plugins, this.webpackConfig, friendlyErrorPlugin);
+        }
 
         this.webpackConfig.plugins.forEach(function(plugin) {
             plugins.push(plugin);
@@ -274,22 +276,28 @@ class ConfigGenerator {
     buildStatsConfig() {
         // try to silence as much as possible: the output is rarely helpful
         // this still doesn't remove all output
-        return {
-            hash: false,
-            version: false,
-            timings: false,
-            assets: false,
-            chunks: false,
-            maxModules: 0,
-            modules: false,
-            reasons: false,
-            children: false,
-            source: false,
-            errors: false,
-            errorDetails: false,
-            warnings: false,
-            publicPath: false,
-        };
+        let stats = {};
+
+        if (!this.webpackConfig.runtimeConfig.outputJson) {
+            stats = {
+                hash: false,
+                version: false,
+                timings: false,
+                assets: false,
+                chunks: false,
+                maxModules: 0,
+                modules: false,
+                reasons: false,
+                children: false,
+                source: false,
+                errors: false,
+                errorDetails: false,
+                warnings: false,
+                publicPath: false,
+            };
+        }
+
+        return stats;
     }
 
     buildDevServerConfig() {

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -24,6 +24,7 @@ module.exports = function(argv, cwd) {
     runtimeConfig.command = argv._[0];
     runtimeConfig.useDevServer = false;
     runtimeConfig.useHotModuleReplacement = false;
+    runtimeConfig.outputJson = false;
 
     switch (runtimeConfig.command) {
         case 'dev':
@@ -66,6 +67,10 @@ module.exports = function(argv, cwd) {
 
     if (argv.h || argv.help) {
         runtimeConfig.helpRequested = true;
+    }
+
+    if (argv.j || argv.json) {
+        runtimeConfig.outputJson = true;
     }
 
     runtimeConfig.babelRcFileExists = (typeof resolveRc(require('fs'), runtimeConfig.context)) !== 'undefined';


### PR DESCRIPTION
This PR fixes #204 by detecting the `--json` and `-j` options and:

* removing some `console.log` calls
* removing the `FriendlyErrorsWebpackPlugin`
* Using default `stats` values

As said in [that comment](https://github.com/symfony/webpack-encore/issues/204#issuecomment-346950361) of the related issue the `--silent` option has to be used with `yarn run encore` or `yarn encore` and must be placed before the name of the script.

For instance:

```bash
# Works
./node_modules/.bin/encore production --json
yarn run --silent encore production  --json
yarn --silent encore production  --json

# Doesn't work (some lines being added by yarn)
yarn run encore production --json
yarn encore production --json

# Doesn't work (since Webpack doesn't know the --silent option)
yarn run encore production --silent --json
yarn encore production --silent --json
```

Edit: Forgot to add a test yesterday, should be good now :)