### PR TITLE
Always use 8 characters hashes by default

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -110,7 +110,7 @@ class ConfigGenerator {
 
     buildOutputConfig() {
         // Default filename can be overriden using Encore.configureFilenames({ js: '...' })
-        let filename = this.webpackConfig.useVersioning ? '[name].[chunkhash].js' : '[name].js';
+        let filename = this.webpackConfig.useVersioning ? '[name].[chunkhash:8].js' : '[name].js';
         if (this.webpackConfig.configuredFilenames.js) {
             filename = this.webpackConfig.configuredFilenames.js;
         }

--- a/lib/plugins/extract-text.js
+++ b/lib/plugins/extract-text.js
@@ -32,7 +32,7 @@ module.exports = function(plugins, webpackConfig) {
      */
 
     // Default filename can be overriden using Encore.configureFilenames({ css: '...' })
-    let filename = webpackConfig.useVersioning ? '[name].[contenthash].css' : '[name].css';
+    let filename = webpackConfig.useVersioning ? '[name].[contenthash:8].css' : '[name].css';
     if (webpackConfig.configuredFilenames.css) {
         filename = webpackConfig.configuredFilenames.css;
     }

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -201,11 +201,11 @@ describe('The config-generator function', () => {
             config.useVersioning = true;
 
             const actualConfig = configGenerator(config);
-            expect(actualConfig.output.filename).to.equal('[name].[chunkhash].js');
+            expect(actualConfig.output.filename).to.equal('[name].[chunkhash:8].js');
 
             const extractTextPlugin = findPlugin(ExtractTextPlugin, actualConfig.plugins);
 
-            expect(extractTextPlugin.filename).to.equal('[name].[contenthash].css');
+            expect(extractTextPlugin.filename).to.equal('[name].[contenthash:8].css');
         });
     });
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -281,13 +281,13 @@ describe('Functional tests using webpack', function() {
                 testSetup.runWebpack(config, (webpackAssert) => {
                     expect(config.outputPath).to.be.a.directory()
                         .with.files([
-                            'main.f1e0a9350e13fe3a597e.js',
-                            'styles.c84caea6dd12bba7955dee9fedd5fd03.css',
+                            'main.f1e0a935.js',
+                            'styles.c84caea6.css',
                             'manifest.json'
                         ]);
 
                     webpackAssert.assertOutputFileContains(
-                        'styles.c84caea6dd12bba7955dee9fedd5fd03.css',
+                        'styles.c84caea6.css',
                         'font-size: 50px;'
                     );
                     webpackAssert.assertManifestPathDoesNotExist(
@@ -295,7 +295,7 @@ describe('Functional tests using webpack', function() {
                     );
                     webpackAssert.assertManifestPath(
                         'styles.css',
-                        '/styles.c84caea6dd12bba7955dee9fedd5fd03.css'
+                        '/styles.c84caea6.css'
                     );
 
                     done();
@@ -377,10 +377,10 @@ describe('Functional tests using webpack', function() {
             testSetup.runWebpack(config, (webpackAssert) => {
                 expect(config.outputPath).to.be.a.directory()
                     .with.files([
-                        '0.d002be21e9bcf76057e9.js', // chunks are also versioned
-                        'main.292c0347ed1240663cb1.js',
-                        'h1.c84caea6dd12bba7955dee9fedd5fd03.css',
-                        'bg.483832e48e67e6a3b7f0ae064eadca51.css',
+                        '0.d002be21.js', // chunks are also versioned
+                        'main.292c0347.js',
+                        'h1.c84caea6.css',
+                        'bg.483832e4.css',
                         'manifest.json'
                     ]);
 
@@ -390,7 +390,7 @@ describe('Functional tests using webpack', function() {
                     ]);
 
                 webpackAssert.assertOutputFileContains(
-                    'bg.483832e48e67e6a3b7f0ae064eadca51.css',
+                    'bg.483832e4.css',
                     '/build/images/symfony_logo.ea1ca6f7.png'
                 );
 

--- a/test/plugins/extract-text.js
+++ b/test/plugins/extract-text.js
@@ -44,7 +44,7 @@ describe('plugins/extract-text', () => {
         extractTextPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0].plugin).to.be.instanceof(ExtractTextPlugin);
-        expect(plugins[0].plugin.filename).to.equal('[name].[contenthash].css');
+        expect(plugins[0].plugin.filename).to.equal('[name].[contenthash:8].css');
         expect(plugins[0].plugin.options.allChunks).to.equal(false);
     });
 


### PR DESCRIPTION
This PR closes #203 by always generating 8 characters hashes for filenames when using default settings.