### PR TITLE
feat(aurelia): Add an Aurelia plugin option and expose module resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -647,11 +647,11 @@ const publicApi = {
      *
      * https://github.com/aurelia/webpack-plugin/wiki
      *
-     * @param {function} aureliaLoaderOptionsCallback
+     * @param {function} aureliaPluginOptionsCallback
      * @returns {exports}
      */
-    enableAureliaPlugin(aureliaLoaderOptionsCallback = () => {}) {
-        webpackConfig.enableAureliaPlugin(aureliaLoaderOptionsCallback);
+    enableAureliaPlugin(aureliaPluginOptionsCallback = () => {}) {
+        webpackConfig.enableAureliaPlugin(aureliaPluginOptionsCallback);
 
         return this;
     },

--- a/index.js
+++ b/index.js
@@ -630,6 +630,18 @@ const publicApi = {
     },
 
     /**
+     * If enabled, the Aurelia plugin is enabled
+     *
+     * @param {function} aureliaLoaderOptionsCallback
+     * @returns {exports}
+     */
+    enableAurelia(aureliaLoaderOptionsCallback = () => {}) {
+        webpackConfig.enableAurelia(aureliaLoaderOptionsCallback);
+
+        return this;
+    },
+
+    /**
      * If enabled, display build notifications using
      * webpack-notifier.
      *
@@ -701,6 +713,12 @@ const publicApi = {
      */
     configureFilenames(filenames) {
         webpackConfig.configureFilenames(filenames);
+
+        return this;
+    },
+
+    configureResolveModules(directories) {
+        webpackConfig.configureResolveModules(directories);
 
         return this;
     },

--- a/index.js
+++ b/index.js
@@ -632,11 +632,26 @@ const publicApi = {
     /**
      * If enabled, the Aurelia plugin is enabled
      *
+     * https://github.com/aurelia/webpack-plugin
+     *
+     * Encore.enableAureliaPlugin();
+     *
+     * or with configuration options:
+     *
+     * Encore.enableAureliaPlugin(function(options) {
+     *      // Set the startup module to hint webpack to module tracing
+     *      options.aureliaApp = "main";
+     * });
+     *
+     * Read about more configuration options that are available:
+     *
+     * https://github.com/aurelia/webpack-plugin/wiki
+     *
      * @param {function} aureliaLoaderOptionsCallback
      * @returns {exports}
      */
-    enableAurelia(aureliaLoaderOptionsCallback = () => {}) {
-        webpackConfig.enableAurelia(aureliaLoaderOptionsCallback);
+    enableAureliaPlugin(aureliaLoaderOptionsCallback = () => {}) {
+        webpackConfig.enableAureliaPlugin(aureliaLoaderOptionsCallback);
 
         return this;
     },

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -405,7 +405,7 @@ class WebpackConfig {
         this.vueLoaderOptionsCallback = vueLoaderOptionsCallback;
     }
 
-    enableAurelia(aureliaPluginConfig = {}) {
+    enableAureliaPlugin(aureliaPluginConfig = {}) {
         this.useAurelia = true;
         this.aureliaPluginConfig = aureliaPluginConfig;
     }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -95,6 +95,7 @@ class WebpackConfig {
         this.manifestPluginOptionsCallback = () => {};
         this.uglifyJsPluginOptionsCallback = () => {};
         this.notifierPluginOptionsCallback = () => {};
+        this.aureliaPluginOptionsCallback = () => {};
     }
 
     getContext() {
@@ -405,9 +406,14 @@ class WebpackConfig {
         this.vueLoaderOptionsCallback = vueLoaderOptionsCallback;
     }
 
-    enableAureliaPlugin(aureliaPluginConfig = {}) {
+    enableAureliaPlugin(aureliaPluginOptionsCallback = () => {}) {
         this.useAurelia = true;
-        this.aureliaPluginConfig = aureliaPluginConfig;
+
+        if (typeof aureliaPluginOptionsCallback !== 'function') {
+            throw new Error('Argument 1 to enableVueLoader() must be a callback function.');
+        }
+
+        this.aureliaPluginOptionsCallback = aureliaPluginOptionsCallback;
     }
 
     enableBuildNotifications(enabled = true, notifierPluginOptionsCallback = () => {}) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -45,6 +45,7 @@ class WebpackConfig {
         this.sharedCommonsEntryName = null;
         this.providedVariables = {};
         this.configuredFilenames = {};
+        this.resolveModules = null;
 
         // Features/Loaders flags
         this.useVersioning = false;
@@ -59,6 +60,7 @@ class WebpackConfig {
         this.useReact = false;
         this.usePreact = false;
         this.useVueLoader = false;
+        this.useAurelia = false;
         this.useTypeScriptLoader = false;
         this.useForkedTypeScriptTypeChecking = false;
         this.useWebpackNotifier = false;
@@ -403,6 +405,11 @@ class WebpackConfig {
         this.vueLoaderOptionsCallback = vueLoaderOptionsCallback;
     }
 
+    enableAurelia(aureliaPluginConfig = {}) {
+        this.useAurelia = true;
+        this.aureliaPluginConfig = aureliaPluginConfig;
+    }
+
     enableBuildNotifications(enabled = true, notifierPluginOptionsCallback = () => {}) {
         if (typeof notifierPluginOptionsCallback !== 'function') {
             throw new Error('Argument 2 to enableBuildNotifications() must be a callback function.');
@@ -434,6 +441,10 @@ class WebpackConfig {
         }
 
         this.configuredFilenames = configuredFilenames;
+    }
+
+    configureResolveModules(directories) {
+        this.resolveModules = directories;
     }
 
     cleanupOutputBeforeBuild(paths = ['**/*'], cleanWebpackPluginOptionsCallback = () => {}) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -449,7 +449,11 @@ class WebpackConfig {
         this.configuredFilenames = configuredFilenames;
     }
 
-    configureResolveModules(directories) {
+    configureResolveModules(directories = ['node_modules']) {
+        if (!Array.isArray(directories)) {
+            throw new Error('Argument 1 to configureResolveModules() must be an Array of directories - e.g. [\'./path/to/modules\']');
+        }
+
         this.resolveModules = directories;
     }
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -91,7 +91,7 @@ class ConfigGenerator {
             config.resolve.alias['react-dom'] = 'preact-compat';
         }
 
-        if (this.webpackConfig.resolveModules && Array.isArray(this.webpackConfig.resolveModules)) {
+        if (this.webpackConfig.resolveModules) {
             config.resolve.modules = this.webpackConfig.resolveModules;
         }
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -19,6 +19,7 @@ const stylusLoaderUtil = require('./loaders/stylus');
 const babelLoaderUtil = require('./loaders/babel');
 const tsLoaderUtil = require('./loaders/typescript');
 const vueLoaderUtil = require('./loaders/vue');
+
 // plugins utils
 const extractTextPluginUtil = require('./plugins/extract-text');
 const deleteUnusedEntriesPluginUtil = require('./plugins/delete-unused-entries');
@@ -33,6 +34,7 @@ const uglifyPluginUtil = require('./plugins/uglify');
 const friendlyErrorPluginUtil = require('./plugins/friendly-errors');
 const assetOutputDisplay = require('./plugins/asset-output-display');
 const notifierPluginUtil = require('./plugins/notifier');
+const aureliaPluginUtil = require('./plugins/aurelia');
 const PluginPriorities = require('./plugins/plugin-priorities');
 
 class ConfigGenerator {
@@ -87,6 +89,10 @@ class ConfigGenerator {
         if (this.webpackConfig.usePreact && this.webpackConfig.preactOptions.preactCompat) {
             config.resolve.alias['react'] = 'preact-compat';
             config.resolve.alias['react-dom'] = 'preact-compat';
+        }
+
+        if (this.webpackConfig.resolveModules && Array.isArray(this.webpackConfig.resolveModules)) {
+            config.resolve.modules = this.webpackConfig.resolveModules;
         }
 
         return config;
@@ -209,6 +215,12 @@ class ConfigGenerator {
             });
         }
 
+        if (this.webpackConfig.useAurelia) {
+            rules.push(
+                { test: /\.html$/i, use: 'html-loader' }
+            );
+        }
+
         this.webpackConfig.loaders.forEach((loader) => {
             rules.push(loader);
         });
@@ -242,6 +254,8 @@ class ConfigGenerator {
         uglifyPluginUtil(plugins, this.webpackConfig);
 
         notifierPluginUtil(plugins, this.webpackConfig);
+
+        aureliaPluginUtil(plugins, this.webpackConfig);
 
         if (!this.webpackConfig.runtimeConfig.outputJson) {
             const friendlyErrorPlugin = friendlyErrorPluginUtil(this.webpackConfig);

--- a/lib/features.js
+++ b/lib/features.js
@@ -64,7 +64,7 @@ const features = {
         description: 'load VUE files'
     },
     aurelia: {
-        method: 'enableAurelia()',
+        method: 'enableAureliaPlugin()',
         packages: ['aurelia-webpack-plugin'],
         description: 'Build Aurelia projects'
     },

--- a/lib/features.js
+++ b/lib/features.js
@@ -63,6 +63,11 @@ const features = {
         packages: ['vue', 'vue-loader', 'vue-template-compiler'],
         description: 'load VUE files'
     },
+    aurelia: {
+        method: 'enableAurelia()',
+        packages: ['aurelia-webpack-plugin'],
+        description: 'Build Aurelia projects'
+    },
     notifier: {
         method: 'enableBuildNotifications()',
         packages: ['webpack-notifier'],

--- a/lib/plugins/aurelia.js
+++ b/lib/plugins/aurelia.js
@@ -21,7 +21,7 @@ const { AureliaPlugin } = require('aurelia-webpack-plugin');
 module.exports = function(plugins, webpackConfig) {
     if (!webpackConfig.useAurelia) return;
 
-    loaderFeatures.ensurePackagesExist('aurelia-webpack-plugin');
+    loaderFeatures.ensurePackagesExist('aurelia');
 
     const aureliaPluginOptions = {};
 

--- a/lib/plugins/aurelia.js
+++ b/lib/plugins/aurelia.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const PluginPriorities = require('./plugin-priorities');
+const { AureliaPlugin } = require('aurelia-webpack-plugin');
+
+/**
+ * @param {Array} plugins
+ * @param {WebpackConfig} webpackConfig
+ * @return {void}
+ */
+module.exports = function(plugins, webpackConfig) {
+    if (!webpackConfig.useAurelia) return;
+
+    plugins.push({
+        plugin: new AureliaPlugin(webpackConfig.aureliaPluginConfig),
+        priority: PluginPriorities.AureliaPlugin
+    });
+};

--- a/lib/plugins/aurelia.js
+++ b/lib/plugins/aurelia.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const PluginPriorities = require('./plugin-priorities');
-const { AureliaPlugin } = require('aurelia-webpack-plugin');
+const loaderFeatures = require('../features');
 
 /**
  * @param {Array} plugins
@@ -19,6 +19,10 @@ const { AureliaPlugin } = require('aurelia-webpack-plugin');
  */
 module.exports = function(plugins, webpackConfig) {
     if (!webpackConfig.useAurelia) return;
+
+    loaderFeatures.ensurePackagesExist('aurelia-webpack-plugin');
+
+    const AureliaPlugin = require.resolve('aurelia-webpack-plugin');
 
     plugins.push({
         plugin: new AureliaPlugin(webpackConfig.aureliaPluginConfig),

--- a/lib/plugins/aurelia.js
+++ b/lib/plugins/aurelia.js
@@ -11,6 +11,7 @@
 
 const PluginPriorities = require('./plugin-priorities');
 const loaderFeatures = require('../features');
+const { AureliaPlugin } = require('aurelia-webpack-plugin');
 
 /**
  * @param {Array} plugins
@@ -22,10 +23,15 @@ module.exports = function(plugins, webpackConfig) {
 
     loaderFeatures.ensurePackagesExist('aurelia-webpack-plugin');
 
-    const AureliaPlugin = require.resolve('aurelia-webpack-plugin');
+    const aureliaPluginOptions = {};
+
+    webpackConfig.aureliaPluginOptionsCallback.apply(
+        aureliaPluginOptions,
+        [aureliaPluginOptions]
+    );
 
     plugins.push({
-        plugin: new AureliaPlugin(webpackConfig.aureliaPluginConfig),
+        plugin: new AureliaPlugin(aureliaPluginOptions),
         priority: PluginPriorities.AureliaPlugin
     });
 };

--- a/lib/plugins/plugin-priorities.js
+++ b/lib/plugins/plugin-priorities.js
@@ -26,4 +26,5 @@ module.exports = {
     NamedModulesPlugin: 0,
     WebpackChunkHash: 0,
     WebpackNotifier: 0,
+    AureliaPlugin: 0
 };

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   },
   "homepage": "https://github.com/symfony/webpack-encore",
   "dependencies": {
-    "aurelia-loader-webpack": "^2.1.0",
-    "aurelia-webpack-plugin": "^2.0.0-rc.5",
     "babel-core": "^6.24.0",
     "babel-loader": "^7.1.0",
     "babel-preset-env": "^1.2.2",
@@ -51,6 +49,7 @@
     "yargs": "^8.0.1"
   },
   "devDependencies": {
+    "aurelia-webpack-plugin": "^2.0.0-rc.5",
     "autoprefixer": "^6.7.7",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "homepage": "https://github.com/symfony/webpack-encore",
   "dependencies": {
+    "aurelia-loader-webpack": "^2.1.0",
+    "aurelia-webpack-plugin": "^2.0.0-rc.5",
     "babel-core": "^6.24.0",
     "babel-loader": "^7.1.0",
     "babel-preset-env": "^1.2.2",

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -619,4 +619,43 @@ describe('The config-generator function', () => {
             });
         });
     });
+
+    describe('Test resolveModules option', () => {
+        it('should not appear in config if not set', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.resolve).not.to.include.keys('modules');
+        });
+
+        it('should have node_modules set as default if called without arguments', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+            config.configureResolveModules();
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.resolve.modules.length).to.equal(1);
+            expect(actualConfig.resolve.modules[0]).to.equal('node_modules');
+        });
+
+        it('should set the module paths used as arguments', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+
+            const modulePath = '/foo/bar';
+
+            config.configureResolveModules([modulePath]);
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.resolve.modules.length).to.equal(1);
+            expect(actualConfig.resolve.modules[0]).to.equal(modulePath);
+        });
+    });
 });

--- a/test/plugins/aurelia.js
+++ b/test/plugins/aurelia.js
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const { AureliaPlugin } = require('aurelia-webpack-plugin');
+const WebpackConfig = require('../../lib/WebpackConfig');
+const RuntimeConfig = require('../../lib/config/RuntimeConfig');
+const aureliaPluginUtil = require('../../lib/plugins/aurelia');
+
+function createConfig() {
+    const runtimeConfig = new RuntimeConfig();
+    runtimeConfig.context = __dirname;
+    runtimeConfig.babelRcFileExists = false;
+
+    return new WebpackConfig(runtimeConfig);
+}
+describe('plugins/aurelia', () => {
+    it('is disabled by default', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        aureliaPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(0);
+    });
+
+    it('uses an options callback', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.enableAureliaPlugin((options) => {
+            options.aureliaApp = 'foo';
+        });
+
+        aureliaPluginUtil(plugins, config);
+
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceOf(AureliaPlugin);
+
+        // Ensure that the options were set
+        expect(plugins[0].plugin.options.aureliaApp).to.equal('foo');
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,8 +351,8 @@ aurelia-metadata@^1.0.0, aurelia-metadata@^1.0.2:
     aurelia-pal "^1.0.0"
 
 aurelia-pal@^1.0.0, aurelia-pal@^1.1.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/aurelia-pal/-/aurelia-pal-1.4.0.tgz#1148f256c854c0e020a0a8f465cbf4a6eeaf9188"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/aurelia-pal/-/aurelia-pal-1.5.0.tgz#26607538d60a973f73824d75b0bfa91384ce9dd3"
 
 aurelia-path@^1.0.0:
   version "1.1.1"
@@ -5871,8 +5871,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
 uglify-js@3.3.x:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.8.tgz#51e9a5db73afb53ac98603d08224edcd0be45fd8"
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.9.tgz#33869666c8ab7f7658ce3d22f0f1ced40097d33a"
   dependencies:
     commander "~2.13.0"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,6 +264,10 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -293,6 +297,94 @@ asynckit@^0.4.0:
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
+aurelia-binding@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/aurelia-binding/-/aurelia-binding-1.6.0.tgz#a3db1f43f823a0d392e9d2d7db4442a2d336255d"
+  dependencies:
+    aurelia-logging "^1.0.0"
+    aurelia-metadata "^1.0.0"
+    aurelia-pal "^1.0.0"
+    aurelia-task-queue "^1.0.0"
+
+aurelia-dependency-injection@^1.0.0, aurelia-dependency-injection@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/aurelia-dependency-injection/-/aurelia-dependency-injection-1.3.2.tgz#5f9ca5dede6a1ccc72a0838c980df3dfe7918756"
+  dependencies:
+    aurelia-metadata "^1.0.0"
+    aurelia-pal "^1.0.0"
+
+aurelia-hot-module-reload@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/aurelia-hot-module-reload/-/aurelia-hot-module-reload-0.1.0.tgz#fc39d5157a1c57fb66ebe3ec47b05923b7360008"
+  dependencies:
+    aurelia-dependency-injection "^1.2.0"
+    aurelia-loader "^1.0.0"
+    aurelia-metadata "^1.0.2"
+    aurelia-pal "^1.0.0"
+    aurelia-templating "^1.1.2"
+
+aurelia-loader-webpack@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/aurelia-loader-webpack/-/aurelia-loader-webpack-2.1.0.tgz#6d1c8d768eac07ed219771a64c7bb7d5902743cd"
+  dependencies:
+    aurelia-hot-module-reload "^0.1.0"
+    aurelia-loader "^1.0.0"
+    aurelia-metadata "^1.0.2"
+    aurelia-pal "^1.1.1"
+
+aurelia-loader@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/aurelia-loader/-/aurelia-loader-1.0.0.tgz#b78c2a2813aa8e441247237dd66fd62e5d4e19ea"
+  dependencies:
+    aurelia-metadata "^1.0.0"
+    aurelia-path "^1.0.0"
+
+aurelia-logging@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/aurelia-logging/-/aurelia-logging-1.4.0.tgz#04fb7aa74015593f7a15b225beeba07b7d14dcd5"
+
+aurelia-metadata@^1.0.0, aurelia-metadata@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/aurelia-metadata/-/aurelia-metadata-1.0.3.tgz#1e8d59da188e2871a8ad749ba42ca85084a3f30e"
+  dependencies:
+    aurelia-pal "^1.0.0"
+
+aurelia-pal@^1.0.0, aurelia-pal@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/aurelia-pal/-/aurelia-pal-1.4.0.tgz#1148f256c854c0e020a0a8f465cbf4a6eeaf9188"
+
+aurelia-path@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/aurelia-path/-/aurelia-path-1.1.1.tgz#caa9d20bc8515a5f9f286d9a3b18d81b2c85b0dd"
+
+aurelia-task-queue@^1.0.0, aurelia-task-queue@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/aurelia-task-queue/-/aurelia-task-queue-1.2.1.tgz#2e25c7cd663b7e3074f1d99744eb2d14ec5ce594"
+  dependencies:
+    aurelia-pal "^1.0.0"
+
+aurelia-templating@^1.1.2:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aurelia-templating/-/aurelia-templating-1.7.0.tgz#013c08fd1b09a57f5051522e1bb3f657f0803b68"
+  dependencies:
+    aurelia-binding "^1.0.0"
+    aurelia-dependency-injection "^1.0.0"
+    aurelia-loader "^1.0.0"
+    aurelia-logging "^1.0.0"
+    aurelia-metadata "^1.0.0"
+    aurelia-pal "^1.0.0"
+    aurelia-path "^1.0.0"
+    aurelia-task-queue "^1.1.0"
+
+aurelia-webpack-plugin@^2.0.0-rc.5:
+  version "2.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/aurelia-webpack-plugin/-/aurelia-webpack-plugin-2.0.0-rc.5.tgz#62bd19a17a230361d83d5b5ebe5ba13608dc5435"
+  dependencies:
+    aurelia-loader-webpack "^2.1.0"
+    bundle-loader "^0.5.5"
+    html-loader "^0.4.5"
+    minimatch "^3.0.4"
 
 autoprefixer@^6.3.1, autoprefixer@^6.7.7:
   version "6.7.7"
@@ -1065,6 +1157,12 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bundle-loader@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.5.tgz#11fd7b08edf86a1d708efcb1eca62ca51f6c368a"
+  dependencies:
+    loader-utils "^1.0.2"
+
 bytes@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
@@ -1082,6 +1180,13 @@ caller-path@^0.1.0:
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
+camel-case@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1205,6 +1310,12 @@ clap@^1.0.9:
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
   dependencies:
     chalk "^1.1.3"
+
+clean-css@4.1.x:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
+  dependencies:
+    source-map "0.5.x"
 
 clean-webpack-plugin@^0.1.16:
   version "0.1.16"
@@ -1332,11 +1443,19 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.12.x:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commander@2.9.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1981,6 +2100,13 @@ es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbo
     d "1"
     es5-ext "~0.10.14"
 
+es6-templates@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
+  dependencies:
+    recast "~0.11.12"
+    through "~2.3.6"
+
 es6-weak-map@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
@@ -2090,6 +2216,10 @@ esprima@^4.0.0:
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
+
+esprima@~3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esquery@^1.0.0:
   version "1.0.0"
@@ -2663,13 +2793,13 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+he@1.1.x, he@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
 he@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
-
-he@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -2710,6 +2840,29 @@ html-comment-regex@^1.1.0:
 html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+
+html-loader@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.4.5.tgz#5fbcd87cd63a5c49a7fce2fe56f425e05729c68c"
+  dependencies:
+    es6-templates "^0.2.2"
+    fastparse "^1.1.1"
+    html-minifier "^3.0.1"
+    loader-utils "^1.0.2"
+    object-assign "^4.1.0"
+
+html-minifier@^3.0.1:
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.8.tgz#5ccdb1f73a0d654e6090147511f6e6b2ee312700"
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.1.x"
+    commander "2.12.x"
+    he "1.1.x"
+    ncname "1.0.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.3.x"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -3509,6 +3662,10 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
 lru-cache@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
@@ -3735,9 +3892,21 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+ncname@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
+  dependencies:
+    xml-char-classes "^1.0.0"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  dependencies:
+    lower-case "^1.1.1"
 
 node-emoji@^1.4.1:
   version "1.8.1"
@@ -4081,6 +4250,12 @@ p-map@^1.1.1:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+
+param-case@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  dependencies:
+    no-case "^2.2.0"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -4565,6 +4740,10 @@ private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
+private@~0.1.5:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -4764,6 +4943,15 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
+recast@~0.11.12:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -4849,6 +5037,10 @@ regjsparser@^0.1.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+relateurl@0.2.x:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
 remove-trailing-separator@^1.0.1:
   version "1.0.2"
@@ -5263,6 +5455,10 @@ source-map@0.1.x, source-map@^0.1.38:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.5.x, source-map@~0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -5278,6 +5474,10 @@ source-map@~0.2.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -5560,7 +5760,7 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5670,6 +5870,13 @@ ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
+uglify-js@3.3.x:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.8.tgz#51e9a5db73afb53ac98603d08224edcd0be45fd8"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -5722,6 +5929,10 @@ uniqs@^2.0.0:
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
@@ -6055,6 +6266,10 @@ ws@^1.0.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+xml-char-classes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
 "xml-name-validator@>= 2.0.1 < 3.0.0":
   version "2.0.1"


### PR DESCRIPTION
I thought Symfony needed some Aurelia love :)

I'm fairly new to Webpack so any feedback is welcomed

As Aurelia leverages dynamic modules, exposing the module resolve configuration let's the Aurelia Plugin work properly.

Aurelia also uses `.html` for templating as the standard option, so added in a rule for `.html` if the Aurelia plugin is enabled.

Will work on an example shortly :)