### PR TITLE
These changes allow empty public path in webpack.config.js

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -134,9 +134,11 @@ class WebpackConfig {
             logger.warning('The value passed to setPublicPath() should *usually* start with "/" or be a full URL (http://...). If you\'re not sure, then you should probably change your public path and make this message disappear.');
         }
 
-        // guarantee a single trailing slash
-        publicPath = publicPath.replace(/\/$/,'');
-        publicPath = publicPath + '/';
+        if (publicPath !== '') {
+            // guarantee a single trailing slash
+            publicPath = publicPath.replace(/\/$/, '');
+            publicPath = publicPath + '/';
+        }
 
         this.publicPath = publicPath;
     }

--- a/test/functional.js
+++ b/test/functional.js
@@ -246,8 +246,8 @@ describe('Functional tests using webpack', function() {
                     ],
                     (browser) => {
                         webpackAssert.assertResourcesLoadedCorrectly(browser, [
-                            'http://127.0.0.1:8080/public/build/0.js',
-                            'http://127.0.0.1:8080/public/build/main.js'
+                            'http://127.0.0.1:8080/build/0.js',
+                            'http://127.0.0.1:8080/build/main.js'
                         ]);
 
                         done();

--- a/test/functional.js
+++ b/test/functional.js
@@ -240,8 +240,7 @@ describe('Functional tests using webpack', function() {
                 );
 
                 testSetup.requestTestPage(
-                    // the webroot will not include the public/build part
-                    path.join(config.getContext(), ''),
+                    path.join(config.getContext(), 'public'),
                     [
                         convertToManifestPath('build/main.js', config)
                     ],

--- a/test/functional.js
+++ b/test/functional.js
@@ -227,6 +227,36 @@ describe('Functional tests using webpack', function() {
             });
         });
 
+        it('Deploying to an unknown (at compile-time) subdirectory is no problem', (done) => {
+            const config = createWebpackConfig('public/build', 'dev');
+            config.addEntry('main', './js/code_splitting');
+            config.setPublicPath('');
+            config.setManifestKeyPrefix('build/');
+
+            testSetup.runWebpack(config, (webpackAssert) => {
+                webpackAssert.assertManifestPath(
+                    'build/main.js',
+                    'build/main.js'
+                );
+
+                testSetup.requestTestPage(
+                    // the webroot will not include the public/build part
+                    path.join(config.getContext(), ''),
+                    [
+                        convertToManifestPath('build/main.js', config)
+                    ],
+                    (browser) => {
+                        webpackAssert.assertResourcesLoadedCorrectly(browser, [
+                            'http://127.0.0.1:8080/public/build/0.js',
+                            'http://127.0.0.1:8080/public/build/main.js'
+                        ]);
+
+                        done();
+                    }
+                );
+            });
+        });
+
         it('Empty manifestKeyPrefix is allowed', (done) => {
             const config = createWebpackConfig('build', 'dev');
             config.addEntry('main', './js/code_splitting');


### PR DESCRIPTION
This allows empty publicPath in webpack.config.js
Provided a functional test.
See https://github.com/symfony/webpack-encore/issues/26#issuecomment-362560685

I'm new to webpack/encore/nodejs/git, so I hope I didn't make any mistake :)