### PR TITLE
Fix 'plugin' typehint on Encore.addPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ class Encore {
      *
      *      Encore.addPlugin(new MyWebpackPlugin(), PluginPriorities.DefinePlugin);
      *
-     * @param {string} plugin
+     * @param {object} plugin
      * @param {number} priority
      * @returns {Encore}
      */


### PR DESCRIPTION
The `plugin` parameter is described as `{string}` but in fact we want to have instances of a Webpack plugin here. So I think we should use `object` here, which reflects the fact that all examples and known usages use an object there...