### PR TITLE
Use default stats output when called with --profile

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -288,7 +288,7 @@ class ConfigGenerator {
         // this still doesn't remove all output
         let stats = {};
 
-        if (!this.webpackConfig.runtimeConfig.outputJson) {
+        if (!this.webpackConfig.runtimeConfig.outputJson && !this.webpackConfig.runtimeConfig.profile) {
             stats = {
                 hash: false,
                 version: false,

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -25,6 +25,7 @@ module.exports = function(argv, cwd) {
     runtimeConfig.useDevServer = false;
     runtimeConfig.useHotModuleReplacement = false;
     runtimeConfig.outputJson = false;
+    runtimeConfig.profile = false;
 
     switch (runtimeConfig.command) {
         case 'dev':
@@ -71,6 +72,10 @@ module.exports = function(argv, cwd) {
 
     if (argv.j || argv.json) {
         runtimeConfig.outputJson = true;
+    }
+
+    if (argv.profile) {
+        runtimeConfig.profile = true;
     }
 
     runtimeConfig.babelRcFileExists = (typeof resolveRc(require('fs'), runtimeConfig.context)) !== 'undefined';

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -123,4 +123,36 @@ module.exports = Encore.getWebpackConfig();
             done();
         });
     });
+
+    it('Smoke test using the --profile option', (done) => {
+        testSetup.emptyTmpDir();
+        const testDir = testSetup.createTestAppDir();
+
+        fs.writeFileSync(
+            path.join(testDir, 'webpack.config.js'),
+            `
+const Encore = require('../../index.js');
+Encore
+    .setOutputPath('build/')
+    .setPublicPath('/build')
+    .addEntry('main', './js/no_require')
+;
+
+module.exports = Encore.getWebpackConfig();
+            `
+        );
+
+        const binPath = path.resolve(__dirname, '../', '../', 'bin', 'encore.js');
+        exec(`node ${binPath} dev --profile --context=${testDir}`, { cwd: testDir }, (err, stdout, stderr) => {
+            if (err) {
+                throw new Error(`Error executing encore: ${err} ${stderr} ${stdout}`);
+            }
+
+            expect(stdout).to.contain('Hash: ');
+            expect(stdout).to.contain('Version: ');
+            expect(stdout).to.contain('Time: ');
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR closes #231 by detecting if Encore was called with the `--profile` option and using the default `stats` Webpack option in that case.