### PR TITLE
Allow to replace options in configuration callbacks

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -200,7 +200,7 @@ class ConfigGenerator {
         if (this.webpackConfig.useVueLoader) {
             rules.push({
                 test: /\.vue$/,
-                use: vueLoaderUtil.getLoaders(this.webpackConfig, this.webpackConfig.vueLoaderOptionsCallback)
+                use: vueLoaderUtil.getLoaders(this.webpackConfig)
             });
         }
 

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -68,11 +68,15 @@ module.exports = {
             }
 
             // allow for babel config to be controlled
-            webpackConfig.babelConfigurationCallback.apply(
+            const callbackResult = webpackConfig.babelConfigurationCallback.apply(
                 // use babelConfig as the this variable
                 babelConfig,
                 [babelConfig]
             );
+
+            if (callbackResult instanceof Object) {
+                babelConfig = callbackResult;
+            }
         }
 
         return [

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const loaderFeatures = require('../features');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -67,16 +68,7 @@ module.exports = {
                 }
             }
 
-            // allow for babel config to be controlled
-            const callbackResult = webpackConfig.babelConfigurationCallback.apply(
-                // use babelConfig as the this variable
-                babelConfig,
-                [babelConfig]
-            );
-
-            if (callbackResult instanceof Object) {
-                babelConfig = callbackResult;
-            }
+            babelConfig = applyOptionsCallback(webpackConfig.babelConfigurationCallback, babelConfig);
         }
 
         return [

--- a/lib/loaders/coffee-script.js
+++ b/lib/loaders/coffee-script.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const loaderFeatures = require('../features');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -19,27 +20,17 @@ module.exports = {
     getLoaders(webpackConfig) {
         loaderFeatures.ensurePackagesExist('coffeescript');
 
-        let options = {
+        const options = {
             sourceMap: webpackConfig.useSourceMaps,
             transpile: {
                 presets: ['env']
             }
         };
 
-        // allow options to be configured
-        const callbackResult = webpackConfig.coffeeScriptConfigurationCallback.apply(
-            options,
-            [options]
-        );
-
-        if (callbackResult instanceof Object) {
-            options = callbackResult;
-        }
-
         return [
             {
                 loader: 'coffee-loader',
-                options: options,
+                options: applyOptionsCallback(webpackConfig.coffeeScriptConfigurationCallback, options)
             },
         ];
     }

--- a/lib/loaders/coffee-script.js
+++ b/lib/loaders/coffee-script.js
@@ -19,7 +19,7 @@ module.exports = {
     getLoaders(webpackConfig) {
         loaderFeatures.ensurePackagesExist('coffeescript');
 
-        const options = {
+        let options = {
             sourceMap: webpackConfig.useSourceMaps,
             transpile: {
                 presets: ['env']
@@ -27,10 +27,14 @@ module.exports = {
         };
 
         // allow options to be configured
-        webpackConfig.coffeeScriptConfigurationCallback.apply(
+        const callbackResult = webpackConfig.coffeeScriptConfigurationCallback.apply(
             options,
             [options]
         );
+
+        if (callbackResult instanceof Object) {
+            options = callbackResult;
+        }
 
         return [
             {

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const loaderFeatures = require('../features');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -38,24 +39,13 @@ module.exports = {
         if (usePostCssLoader) {
             loaderFeatures.ensurePackagesExist('postcss');
 
-            let postCssLoaderOptions = {
+            const postCssLoaderOptions = {
                 sourceMap: webpackConfig.useSourceMaps
             };
 
-            // allow options to be configured
-            const callbackResult = webpackConfig.postCssLoaderOptionsCallback.apply(
-                // use config as the this variable
-                postCssLoaderOptions,
-                [postCssLoaderOptions]
-            );
-
-            if (callbackResult instanceof Object) {
-                postCssLoaderOptions = callbackResult;
-            }
-
             cssLoaders.push({
                 loader: 'postcss-loader',
-                options: postCssLoaderOptions
+                options: applyOptionsCallback(webpackConfig.postCssLoaderOptionsCallback, postCssLoaderOptions)
             });
         }
 

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -38,16 +38,20 @@ module.exports = {
         if (usePostCssLoader) {
             loaderFeatures.ensurePackagesExist('postcss');
 
-            const postCssLoaderOptions = {
+            let postCssLoaderOptions = {
                 sourceMap: webpackConfig.useSourceMaps
             };
 
             // allow options to be configured
-            webpackConfig.postCssLoaderOptionsCallback.apply(
+            const callbackResult = webpackConfig.postCssLoaderOptionsCallback.apply(
                 // use config as the this variable
                 postCssLoaderOptions,
                 [postCssLoaderOptions]
             );
+
+            if (callbackResult instanceof Object) {
+                postCssLoaderOptions = callbackResult;
+            }
 
             cssLoaders.push({
                 loader: 'postcss-loader',

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -21,16 +21,20 @@ module.exports = {
     getLoaders(webpackConfig, ignorePostCssLoader = false) {
         loaderFeatures.ensurePackagesExist('less');
 
-        const config = {
+        let config = {
             sourceMap: webpackConfig.useSourceMaps
         };
 
         // allow options to be configured
-        webpackConfig.lessLoaderOptionsCallback.apply(
+        const callbackResult = webpackConfig.lessLoaderOptionsCallback.apply(
             // use config as the this variable
             config,
             [config]
         );
+
+        if (callbackResult instanceof Object) {
+            config = callbackResult;
+        }
 
         return [
             ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -11,6 +11,7 @@
 
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -21,26 +22,15 @@ module.exports = {
     getLoaders(webpackConfig, ignorePostCssLoader = false) {
         loaderFeatures.ensurePackagesExist('less');
 
-        let config = {
+        const config = {
             sourceMap: webpackConfig.useSourceMaps
         };
-
-        // allow options to be configured
-        const callbackResult = webpackConfig.lessLoaderOptionsCallback.apply(
-            // use config as the this variable
-            config,
-            [config]
-        );
-
-        if (callbackResult instanceof Object) {
-            config = callbackResult;
-        }
 
         return [
             ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),
             {
                 loader: 'less-loader',
-                options: config
+                options: applyOptionsCallback(webpackConfig.lessLoaderOptionsCallback, config)
             },
         ];
     }

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -11,6 +11,7 @@
 
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -35,25 +36,14 @@ module.exports = {
             });
         }
 
-        let config = Object.assign({}, sassOptions, {
+        const config = Object.assign({}, sassOptions, {
             // needed by the resolve-url-loader
             sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps
         });
 
-        // allow options to be configured
-        const callbackResult = webpackConfig.sassLoaderOptionsCallback.apply(
-            // use config as the this variable
-            config,
-            [config]
-        );
-
-        if (callbackResult instanceof Object) {
-            config = callbackResult;
-        }
-
         sassLoaders.push({
             loader: 'sass-loader',
-            options: config,
+            options: applyOptionsCallback(webpackConfig.sassLoaderOptionsCallback, config)
         });
 
         return sassLoaders;

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -41,11 +41,15 @@ module.exports = {
         });
 
         // allow options to be configured
-        webpackConfig.sassLoaderOptionsCallback.apply(
+        const callbackResult = webpackConfig.sassLoaderOptionsCallback.apply(
             // use config as the this variable
             config,
             [config]
         );
+
+        if (callbackResult instanceof Object) {
+            config = callbackResult;
+        }
 
         sassLoaders.push({
             loader: 'sass-loader',

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -11,6 +11,7 @@
 
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -21,26 +22,15 @@ module.exports = {
     getLoaders(webpackConfig, ignorePostCssLoader = false) {
         loaderFeatures.ensurePackagesExist('stylus');
 
-        let config = {
+        const config = {
             sourceMap: webpackConfig.useSourceMaps
         };
-
-        // allow options to be configured
-        const callbackResult = webpackConfig.stylusLoaderOptionsCallback.apply(
-            // use config as the this variable
-            config,
-            [config]
-        );
-
-        if (callbackResult instanceof Object) {
-            config = callbackResult;
-        }
 
         return [
             ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),
             {
                 loader: 'stylus-loader',
-                options: config
+                options: applyOptionsCallback(webpackConfig.stylusLoaderOptionsCallback, config)
             },
         ];
     }

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -21,16 +21,20 @@ module.exports = {
     getLoaders(webpackConfig, ignorePostCssLoader = false) {
         loaderFeatures.ensurePackagesExist('stylus');
 
-        const config = {
+        let config = {
             sourceMap: webpackConfig.useSourceMaps
         };
 
         // allow options to be configured
-        webpackConfig.stylusLoaderOptionsCallback.apply(
+        const callbackResult = webpackConfig.stylusLoaderOptionsCallback.apply(
             // use config as the this variable
             config,
             [config]
         );
+
+        if (callbackResult instanceof Object) {
+            config = callbackResult;
+        }
 
         return [
             ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -26,11 +26,15 @@ module.exports = {
         };
 
         // allow for ts-loader config to be controlled
-        webpackConfig.tsConfigurationCallback.apply(
+        const callbackResult = webpackConfig.tsConfigurationCallback.apply(
             // use config as the this variable
             config,
             [config]
         );
+
+        if (callbackResult instanceof Object) {
+            config = callbackResult;
+        }
 
         // fork-ts-checker-webpack-plugin integration
         if (webpackConfig.useForkedTypeScriptTypeChecking) {

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -11,6 +11,7 @@
 
 const loaderFeatures = require('../features');
 const babelLoader = require('./babel');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
@@ -26,15 +27,7 @@ module.exports = {
         };
 
         // allow for ts-loader config to be controlled
-        const callbackResult = webpackConfig.tsConfigurationCallback.apply(
-            // use config as the this variable
-            config,
-            [config]
-        );
-
-        if (callbackResult instanceof Object) {
-            config = callbackResult;
-        }
+        config = applyOptionsCallback(webpackConfig.tsConfigurationCallback, config);
 
         // fork-ts-checker-webpack-plugin integration
         if (webpackConfig.useForkedTypeScriptTypeChecking) {

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -15,14 +15,14 @@ const sassLoaderUtil = require('./sass');
 const lessLoaderUtil = require('./less');
 const babelLoaderUtil = require('./babel');
 const extractText = require('./extract-text');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @param {function} vueLoaderOptionsCallback
  * @return {Array} of loaders to use for Vue files
  */
 module.exports = {
-    getLoaders(webpackConfig, vueLoaderOptionsCallback) {
+    getLoaders(webpackConfig) {
         loaderFeatures.ensurePackagesExist('vue');
 
         /*
@@ -117,21 +117,14 @@ module.exports = {
             };
         }
 
-        let options = {
+        const options = {
             loaders: loaders
         };
-
-        // allow the options to be mutated via a callback
-        const callbackResult = vueLoaderOptionsCallback(options);
-
-        if (callbackResult instanceof Object) {
-            options = callbackResult;
-        }
 
         return [
             {
                 loader: 'vue-loader',
-                options: options
+                options: applyOptionsCallback(webpackConfig.vueLoaderOptionsCallback, options)
             }
         ];
     }

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -120,8 +120,13 @@ module.exports = {
         let options = {
             loaders: loaders
         };
+
         // allow the options to be mutated via a callback
-        vueLoaderOptionsCallback(options);
+        const callbackResult = vueLoaderOptionsCallback(options);
+
+        if (callbackResult instanceof Object) {
+            options = callbackResult;
+        }
 
         return [
             {

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -11,6 +11,7 @@
 
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * Updates plugins array passed adding CleanWebpackPlugin instance
@@ -25,24 +26,15 @@ module.exports = function(plugins, webpackConfig) {
         return;
     }
 
-    let cleanWebpackPluginOptions = {
+    const cleanWebpackPluginOptions = {
         root: webpackConfig.outputPath,
         verbose: false,
     };
 
-    const callbackResult = webpackConfig.cleanWebpackPluginOptionsCallback.apply(
-        cleanWebpackPluginOptions,
-        [cleanWebpackPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        cleanWebpackPluginOptions = callbackResult;
-    }
-
     plugins.push({
         plugin: new CleanWebpackPlugin(
             webpackConfig.cleanWebpackPluginPaths,
-            cleanWebpackPluginOptions
+            applyOptionsCallback(webpackConfig.cleanWebpackPluginOptionsCallback, cleanWebpackPluginOptions)
         ),
         priority: PluginPriorities.CleanWebpackPlugin
     });

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -25,15 +25,19 @@ module.exports = function(plugins, webpackConfig) {
         return;
     }
 
-    const cleanWebpackPluginOptions = {
+    let cleanWebpackPluginOptions = {
         root: webpackConfig.outputPath,
         verbose: false,
     };
 
-    webpackConfig.cleanWebpackPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.cleanWebpackPluginOptionsCallback.apply(
         cleanWebpackPluginOptions,
         [cleanWebpackPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        cleanWebpackPluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new CleanWebpackPlugin(

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -11,6 +11,7 @@
 
 const webpack = require('webpack');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -18,23 +19,16 @@ const PluginPriorities = require('./plugin-priorities');
  * @return {void}
  */
 module.exports = function(plugins, webpackConfig) {
-    let definePluginOptions = {
+    const definePluginOptions = {
         'process.env': {
             NODE_ENV: webpackConfig.isProduction() ? '"production"' : '"development"'
         }
     };
 
-    const callbackResult = webpackConfig.definePluginOptionsCallback.apply(
-        definePluginOptions,
-        [definePluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        definePluginOptions = callbackResult;
-    }
-
     plugins.push({
-        plugin: new webpack.DefinePlugin(definePluginOptions),
+        plugin: new webpack.DefinePlugin(
+            applyOptionsCallback(webpackConfig.definePluginOptionsCallback, definePluginOptions)
+        ),
         priority: PluginPriorities.DefinePlugin
     });
 };

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -18,16 +18,20 @@ const PluginPriorities = require('./plugin-priorities');
  * @return {void}
  */
 module.exports = function(plugins, webpackConfig) {
-    const definePluginOptions = {
+    let definePluginOptions = {
         'process.env': {
             NODE_ENV: webpackConfig.isProduction() ? '"production"' : '"development"'
         }
     };
 
-    webpackConfig.definePluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.definePluginOptionsCallback.apply(
         definePluginOptions,
         [definePluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        definePluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new webpack.DefinePlugin(definePluginOptions),

--- a/lib/plugins/extract-text.js
+++ b/lib/plugins/extract-text.js
@@ -37,7 +37,7 @@ module.exports = function(plugins, webpackConfig) {
         filename = webpackConfig.configuredFilenames.css;
     }
 
-    const extractTextPluginOptions = {
+    let extractTextPluginOptions = {
         filename: filename,
         // if true, async CSS (e.g. loaded via require.ensure())
         // is extracted to the entry point CSS. If false, it's
@@ -45,10 +45,14 @@ module.exports = function(plugins, webpackConfig) {
         allChunks: false
     };
 
-    webpackConfig.extractTextPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.extractTextPluginOptionsCallback.apply(
         extractTextPluginOptions,
         [extractTextPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        extractTextPluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new ExtractTextPlugin(extractTextPluginOptions),

--- a/lib/plugins/extract-text.js
+++ b/lib/plugins/extract-text.js
@@ -11,6 +11,7 @@
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -37,7 +38,7 @@ module.exports = function(plugins, webpackConfig) {
         filename = webpackConfig.configuredFilenames.css;
     }
 
-    let extractTextPluginOptions = {
+    const extractTextPluginOptions = {
         filename: filename,
         // if true, async CSS (e.g. loaded via require.ensure())
         // is extracted to the entry point CSS. If false, it's
@@ -45,17 +46,10 @@ module.exports = function(plugins, webpackConfig) {
         allChunks: false
     };
 
-    const callbackResult = webpackConfig.extractTextPluginOptionsCallback.apply(
-        extractTextPluginOptions,
-        [extractTextPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        extractTextPluginOptions = callbackResult;
-    }
-
     plugins.push({
-        plugin: new ExtractTextPlugin(extractTextPluginOptions),
+        plugin: new ExtractTextPlugin(
+            applyOptionsCallback(webpackConfig.extractTextPluginOptionsCallback, extractTextPluginOptions)
+        ),
         priority: PluginPriorities.ExtractTextWebpackPlugin
     });
 };

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -11,27 +11,19 @@
 
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin'); // eslint-disable-line
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @return {void}
  */
 module.exports = function(webpackConfig) {
-    let config = {};
-
-    // allow for ts-loader config to be controlled
-    const callbackResult = webpackConfig.forkedTypeScriptTypesCheckOptionsCallback.apply(
-        // use config as the this variable
-        config,
-        [config]
-    );
-
-    if (callbackResult instanceof Object) {
-        config = callbackResult;
-    }
+    const config = {};
 
     webpackConfig.addPlugin(
-        new ForkTsCheckerWebpackPlugin(config),
+        new ForkTsCheckerWebpackPlugin(
+            applyOptionsCallback(webpackConfig.forkedTypeScriptTypesCheckOptionsCallback, config)
+        ),
         PluginPriorities.ForkTsCheckerWebpackPlugin
     );
 };

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -20,11 +20,15 @@ module.exports = function(webpackConfig) {
     let config = {};
 
     // allow for ts-loader config to be controlled
-    webpackConfig.forkedTypeScriptTypesCheckOptionsCallback.apply(
+    const callbackResult = webpackConfig.forkedTypeScriptTypesCheckOptionsCallback.apply(
         // use config as the this variable
         config,
         [config]
     );
+
+    if (callbackResult instanceof Object) {
+        config = callbackResult;
+    }
 
     webpackConfig.addPlugin(
         new ForkTsCheckerWebpackPlugin(config),

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -16,13 +16,14 @@ const missingPostCssConfigTransformer = require('../friendly-errors/transformers
 const missingPostCssConfigFormatter = require('../friendly-errors/formatters/missing-postcss-config');
 const vueUnactivatedLoaderTransformer = require('../friendly-errors/transformers/vue-unactivated-loader-error');
 const vueUnactivatedLoaderFormatter = require('../friendly-errors/formatters/vue-unactivated-loader-error');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @return {FriendlyErrorsWebpackPlugin}
  */
 module.exports = function(webpackConfig) {
-    let friendlyErrorsPluginOptions = {
+    const friendlyErrorsPluginOptions = {
         clearConsole: false,
         additionalTransformers: [
             missingLoaderTransformer,
@@ -39,14 +40,7 @@ module.exports = function(webpackConfig) {
         }
     };
 
-    const callbackResult = webpackConfig.friendlyErrorsPluginOptionsCallback.apply(
-        friendlyErrorsPluginOptions,
-        [friendlyErrorsPluginOptions]
+    return new FriendlyErrorsWebpackPlugin(
+        applyOptionsCallback(webpackConfig.friendlyErrorsPluginOptionsCallback, friendlyErrorsPluginOptions)
     );
-
-    if (callbackResult instanceof Object) {
-        friendlyErrorsPluginOptions = callbackResult;
-    }
-
-    return new FriendlyErrorsWebpackPlugin(friendlyErrorsPluginOptions);
 };

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -22,7 +22,7 @@ const vueUnactivatedLoaderFormatter = require('../friendly-errors/formatters/vue
  * @return {FriendlyErrorsWebpackPlugin}
  */
 module.exports = function(webpackConfig) {
-    const friendlyErrorsPluginOptions = {
+    let friendlyErrorsPluginOptions = {
         clearConsole: false,
         additionalTransformers: [
             missingLoaderTransformer,
@@ -39,10 +39,14 @@ module.exports = function(webpackConfig) {
         }
     };
 
-    webpackConfig.friendlyErrorsPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.friendlyErrorsPluginOptionsCallback.apply(
         friendlyErrorsPluginOptions,
         [friendlyErrorsPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        friendlyErrorsPluginOptions = callbackResult;
+    }
 
     return new FriendlyErrorsWebpackPlugin(friendlyErrorsPluginOptions);
 };

--- a/lib/plugins/loader-options.js
+++ b/lib/plugins/loader-options.js
@@ -27,7 +27,7 @@ module.exports = function(plugins, webpackConfig) {
      * not totally sure what's going on here
      * https://github.com/jtangelder/sass-loader/issues/285
      */
-    const loaderOptionsPluginOptions = {
+    let loaderOptionsPluginOptions = {
         debug: !webpackConfig.isProduction(),
         options: {
             context: webpackConfig.getContext(),
@@ -35,10 +35,14 @@ module.exports = function(plugins, webpackConfig) {
         }
     };
 
-    webpackConfig.loaderOptionsPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.loaderOptionsPluginOptionsCallback.apply(
         loaderOptionsPluginOptions,
         [loaderOptionsPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        loaderOptionsPluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new webpack.LoaderOptionsPlugin(loaderOptionsPluginOptions),

--- a/lib/plugins/loader-options.js
+++ b/lib/plugins/loader-options.js
@@ -11,6 +11,7 @@
 
 const webpack = require('webpack');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -27,7 +28,7 @@ module.exports = function(plugins, webpackConfig) {
      * not totally sure what's going on here
      * https://github.com/jtangelder/sass-loader/issues/285
      */
-    let loaderOptionsPluginOptions = {
+    const loaderOptionsPluginOptions = {
         debug: !webpackConfig.isProduction(),
         options: {
             context: webpackConfig.getContext(),
@@ -35,17 +36,10 @@ module.exports = function(plugins, webpackConfig) {
         }
     };
 
-    const callbackResult = webpackConfig.loaderOptionsPluginOptionsCallback.apply(
-        loaderOptionsPluginOptions,
-        [loaderOptionsPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        loaderOptionsPluginOptions = callbackResult;
-    }
-
     plugins.push({
-        plugin: new webpack.LoaderOptionsPlugin(loaderOptionsPluginOptions),
+        plugin: new webpack.LoaderOptionsPlugin(
+            applyOptionsCallback(webpackConfig.loaderOptionsPluginOptionsCallback, loaderOptionsPluginOptions)
+        ),
         priority: PluginPriorities.LoaderOptionsPlugin
     });
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -11,6 +11,7 @@
 
 const ManifestPlugin = require('../webpack/webpack-manifest-plugin');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -33,17 +34,10 @@ module.exports = function(plugins, webpackConfig) {
         writeToFileEmit: true,
     };
 
-    const callbackResult = webpackConfig.manifestPluginOptionsCallback.apply(
-        manifestPluginOptions,
-        [manifestPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        manifestPluginOptions = callbackResult;
-    }
-
     plugins.push({
-        plugin: new ManifestPlugin(manifestPluginOptions),
+        plugin: new ManifestPlugin(
+            applyOptionsCallback(webpackConfig.manifestPluginOptionsCallback, manifestPluginOptions)
+        ),
         priority: PluginPriorities.WebpackManifestPlugin
     });
 };

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -26,7 +26,7 @@ module.exports = function(plugins, webpackConfig) {
         manifestPrefix = webpackConfig.publicPath.replace(/^\//, '');
     }
 
-    let manifestPluginOptions = {
+    const manifestPluginOptions = {
         basePath: manifestPrefix,
         // guarantee the value uses the public path (or CDN public path)
         publicPath: webpackConfig.getRealPublicPath(),

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -25,7 +25,7 @@ module.exports = function(plugins, webpackConfig) {
         manifestPrefix = webpackConfig.publicPath.replace(/^\//, '');
     }
 
-    const manifestPluginOptions = {
+    let manifestPluginOptions = {
         basePath: manifestPrefix,
         // guarantee the value uses the public path (or CDN public path)
         publicPath: webpackConfig.getRealPublicPath(),
@@ -33,10 +33,14 @@ module.exports = function(plugins, webpackConfig) {
         writeToFileEmit: true,
     };
 
-    webpackConfig.manifestPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.manifestPluginOptionsCallback.apply(
         manifestPluginOptions,
         [manifestPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        manifestPluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new ManifestPlugin(manifestPluginOptions),

--- a/lib/plugins/notifier.js
+++ b/lib/plugins/notifier.js
@@ -11,6 +11,7 @@
 
 const pluginFeatures = require('../features');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -24,22 +25,15 @@ module.exports = function(plugins, webpackConfig) {
 
     pluginFeatures.ensurePackagesExist('notifier');
 
-    let notifierPluginOptions = {
+    const notifierPluginOptions = {
         title: 'Webpack Encore'
     };
 
-    const callbackResult = webpackConfig.notifierPluginOptionsCallback.apply(
-        notifierPluginOptions,
-        [notifierPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        notifierPluginOptions = callbackResult;
-    }
-
     const WebpackNotifier = require('webpack-notifier'); // eslint-disable-line
     plugins.push({
-        plugin: new WebpackNotifier(notifierPluginOptions),
+        plugin: new WebpackNotifier(
+            applyOptionsCallback(webpackConfig.notifierPluginOptionsCallback, notifierPluginOptions)
+        ),
         priority: PluginPriorities.WebpackNotifier
     });
 };

--- a/lib/plugins/notifier.js
+++ b/lib/plugins/notifier.js
@@ -24,14 +24,18 @@ module.exports = function(plugins, webpackConfig) {
 
     pluginFeatures.ensurePackagesExist('notifier');
 
-    const notifierPluginOptions = {
+    let notifierPluginOptions = {
         title: 'Webpack Encore'
     };
 
-    webpackConfig.notifierPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.notifierPluginOptionsCallback.apply(
         notifierPluginOptions,
         [notifierPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        notifierPluginOptions = callbackResult;
+    }
 
     const WebpackNotifier = require('webpack-notifier'); // eslint-disable-line
     plugins.push({

--- a/lib/plugins/uglify.js
+++ b/lib/plugins/uglify.js
@@ -23,14 +23,18 @@ module.exports = function(plugins, webpackConfig) {
         return;
     }
 
-    const uglifyJsPluginOptions = {
+    let uglifyJsPluginOptions = {
         sourceMap: webpackConfig.useSourceMaps
     };
 
-    webpackConfig.uglifyJsPluginOptionsCallback.apply(
+    const callbackResult = webpackConfig.uglifyJsPluginOptionsCallback.apply(
         uglifyJsPluginOptions,
         [uglifyJsPluginOptions]
     );
+
+    if (callbackResult instanceof Object) {
+        uglifyJsPluginOptions = callbackResult;
+    }
 
     plugins.push({
         plugin: new webpack.optimize.UglifyJsPlugin(uglifyJsPluginOptions),

--- a/lib/plugins/uglify.js
+++ b/lib/plugins/uglify.js
@@ -11,6 +11,7 @@
 
 const webpack = require('webpack');
 const PluginPriorities = require('./plugin-priorities');
+const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {Array} plugins
@@ -23,21 +24,14 @@ module.exports = function(plugins, webpackConfig) {
         return;
     }
 
-    let uglifyJsPluginOptions = {
+    const uglifyJsPluginOptions = {
         sourceMap: webpackConfig.useSourceMaps
     };
 
-    const callbackResult = webpackConfig.uglifyJsPluginOptionsCallback.apply(
-        uglifyJsPluginOptions,
-        [uglifyJsPluginOptions]
-    );
-
-    if (callbackResult instanceof Object) {
-        uglifyJsPluginOptions = callbackResult;
-    }
-
     plugins.push({
-        plugin: new webpack.optimize.UglifyJsPlugin(uglifyJsPluginOptions),
+        plugin: new webpack.optimize.UglifyJsPlugin(
+            applyOptionsCallback(webpackConfig.uglifyJsPluginOptionsCallback, uglifyJsPluginOptions)
+        ),
         priority: PluginPriorities.UglifyJsPlugin
     });
 };

--- a/lib/utils/apply-options-callback.js
+++ b/lib/utils/apply-options-callback.js
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+module.exports = function(optionsCallback, options) {
+    const result = optionsCallback.call(options, options);
+
+    if (typeof result === 'object') {
+        return result;
+    }
+
+    return options;
+};

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -101,4 +101,19 @@ describe('loaders/babel', () => {
             'foo'
         ]);
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+        config.enablePreactPreset({ preactCompat: true });
+
+        config.configureBabel(function(babelConfig) {
+            babelConfig.plugins.push('foo');
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        const actualLoaders = babelLoader.getLoaders(config);
+        expect(actualLoaders[0].options).to.deep.equal({ 'foo': true });
+    });
 });

--- a/test/loaders/coffee-script.js
+++ b/test/loaders/coffee-script.js
@@ -36,4 +36,18 @@ describe('loaders/coffee-script', () => {
             header: true,
         });
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+        config.enableCoffeeScriptLoader(function(options) {
+            options.header = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        const loaders = coffeeScriptLoader.getLoaders(config);
+        expect(loaders[0].options).to.deep.equal({ foo: true });
+    });
 });

--- a/test/loaders/css.js
+++ b/test/loaders/css.js
@@ -71,5 +71,23 @@ describe('loaders/css', () => {
             expect(actualLoaders[1].options.sourceMap).to.be.true;
             expect(actualLoaders[1].options.config.path).to.equal('config/postcss.config.js');
         });
+
+        it('with options callback that returns an object', () => {
+            const config = createConfig();
+            config.enableSourceMaps(true);
+            config.enablePostCssLoader((options) => {
+                options.config = {
+                    path: 'config/postcss.config.js'
+                };
+
+                // This should override the original config
+                return { foo: true };
+            });
+
+            const actualLoaders = cssLoader.getLoaders(config);
+            // css-loader & postcss-loader
+            expect(actualLoaders).to.have.lengthOf(2);
+            expect(actualLoaders[1].options).to.deep.equal({ foo: true });
+        });
     });
 });

--- a/test/loaders/less.js
+++ b/test/loaders/less.js
@@ -61,4 +61,24 @@ describe('loaders/less', () => {
         });
         cssLoader.getLoaders.restore();
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        config.enableLessLoader(function(lessOptions) {
+            lessOptions.custom_option = 'foo';
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        const actualLoaders = lessLoader.getLoaders(config);
+        expect(actualLoaders[0].options).to.deep.equals({ foo: true });
+        cssLoader.getLoaders.restore();
+    });
 });

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -127,4 +127,25 @@ describe('loaders/sass', () => {
         });
         cssLoader.getLoaders.restore();
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        config.enableSassLoader(function(sassOptions) {
+            sassOptions.custom_option = 'baz';
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+
+        const actualLoaders = sassLoader.getLoaders(config, {});
+        expect(actualLoaders[1].options).to.deep.equals({ foo: true });
+
+        cssLoader.getLoaders.restore();
+    });
 });

--- a/test/loaders/stylus.js
+++ b/test/loaders/stylus.js
@@ -61,4 +61,24 @@ describe('loaders/stylus', () => {
         });
         cssLoader.getLoaders.restore();
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        config.enableStylusLoader(function(stylusOptions) {
+            stylusOptions.custom_option = 'foo';
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        const actualLoaders = stylusLoader.getLoaders(config);
+        expect(actualLoaders[0].options).to.deep.equals({ foo: true });
+        cssLoader.getLoaders.restore();
+    });
 });

--- a/test/loaders/typescript.js
+++ b/test/loaders/typescript.js
@@ -48,4 +48,16 @@ describe('loaders/typescript', () => {
         expect(actualLoaders[1].options.silent).to.be.true;
     });
 
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+        config.enableTypeScriptLoader(function(config) {
+            config.foo = false;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        const actualLoaders = tsLoader.getLoaders(config);
+        expect(actualLoaders[1].options).to.deep.equal({ foo: true });
+    });
 });

--- a/test/loaders/vue.js
+++ b/test/loaders/vue.js
@@ -43,13 +43,11 @@ describe('loaders/vue', () => {
 
     it('getLoaders() with extra options', () => {
         const config = createConfig();
+        config.enableVueLoader((options) => {
+            options.postLoaders = { foo: 'foo-loader' };
+        });
 
-        const actualLoaders = vueLoader.getLoaders(
-            config,
-            (options) => {
-                options.postLoaders = { foo: 'foo-loader' };
-            }
-        );
+        const actualLoaders = vueLoader.getLoaders(config);
 
         expect(actualLoaders).to.have.lengthOf(1);
         expect(actualLoaders[0].options.postLoaders.foo).to.equal('foo-loader');
@@ -57,16 +55,14 @@ describe('loaders/vue', () => {
 
     it('getLoaders() with a callback that returns an object', () => {
         const config = createConfig();
+        config.enableVueLoader((options) => {
+            options.postLoaders = { foo: 'foo-loader' };
 
-        const actualLoaders = vueLoader.getLoaders(
-            config,
-            (options) => {
-                options.postLoaders = { foo: 'foo-loader' };
+            // This should override the original config
+            return { foo: true };
+        });
 
-                // This should override the original config
-                return { foo: true };
-            }
-        );
+        const actualLoaders = vueLoader.getLoaders(config);
 
         expect(actualLoaders).to.have.lengthOf(1);
         expect(actualLoaders[0].options).to.deep.equal({ foo: true });

--- a/test/loaders/vue.js
+++ b/test/loaders/vue.js
@@ -54,4 +54,21 @@ describe('loaders/vue', () => {
         expect(actualLoaders).to.have.lengthOf(1);
         expect(actualLoaders[0].options.postLoaders.foo).to.equal('foo-loader');
     });
+
+    it('getLoaders() with a callback that returns an object', () => {
+        const config = createConfig();
+
+        const actualLoaders = vueLoader.getLoaders(
+            config,
+            (options) => {
+                options.postLoaders = { foo: 'foo-loader' };
+
+                // This should override the original config
+                return { foo: true };
+            }
+        );
+
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options).to.deep.equal({ foo: true });
+    });
 });

--- a/test/plugins/clean.js
+++ b/test/plugins/clean.js
@@ -59,4 +59,22 @@ describe('plugins/clean', () => {
         expect(plugins[0].plugin.paths).to.deep.equal(['**/*.js', '**/*.css']);
         expect(plugins[0].plugin.options.dry).to.equal(true);
     });
+
+    it('enabled with an options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.cleanupOutputBeforeBuild(['**/*.js', '**/*.css'], (options) => {
+            options.dry = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        cleanPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(CleanWebpackPlugin);
+        expect(plugins[0].plugin.options.dry).to.equal(false);
+        expect(plugins[0].plugin.options.foo).to.equal(true);
+    });
 });

--- a/test/plugins/define.js
+++ b/test/plugins/define.js
@@ -65,4 +65,22 @@ describe('plugins/define', () => {
         // Doesn't remove default definitions
         expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
     });
+
+    it('production environment with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.configureDefinePlugin((options) => {
+            options['bar'] = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        definePluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
+        expect(plugins[0].plugin.definitions.bar).to.be.undefined;
+        expect(plugins[0].plugin.definitions.foo).to.equal(true);
+    });
 });

--- a/test/plugins/extract-text.js
+++ b/test/plugins/extract-text.js
@@ -70,4 +70,22 @@ describe('plugins/extract-text', () => {
         // Doesn't remove default options
         expect(plugins[0].plugin.options.allChunks).to.equal(false);
     });
+
+    it('with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.configureExtractTextPlugin((options) => {
+            options.disable = true;
+
+            // This should override the original config
+            return { filename: 'foo' };
+        });
+
+        extractTextPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(ExtractTextPlugin);
+        expect(plugins[0].plugin.options.disable).to.be.undefined;
+        expect(plugins[0].plugin.filename).to.equal('foo');
+    });
 });

--- a/test/plugins/forked-ts-types.js
+++ b/test/plugins/forked-ts-types.js
@@ -34,8 +34,43 @@ describe('plugins/forkedtypecheck', () => {
         tsTypeChecker(config);
         expect(config.plugins).to.have.lengthOf(1);
         expect(config.plugins[0].plugin).to.be.an.instanceof(ForkTsCheckerWebpackPlugin);
+        expect(config.plugins[0].plugin.options.silent).to.be.undefined;
         // after enabling plugin, check typescript loader has right config
         const actualLoaders = tsLoader.getLoaders(config);
         expect(actualLoaders[1].options.transpileOnly).to.be.true;
+    });
+
+    it('getPlugins() with options callback', () => {
+        const config = createConfig();
+        config.enableTypeScriptLoader();
+        config.enableForkedTypeScriptTypesChecking(function(options) {
+            options.silent = true;
+        });
+
+        expect(config.plugins).to.have.lengthOf(0);
+        const tsTypeChecker = require('../../lib/plugins/forked-ts-types');
+        tsTypeChecker(config);
+        expect(config.plugins).to.have.lengthOf(1);
+        expect(config.plugins[0].plugin).to.be.an.instanceof(ForkTsCheckerWebpackPlugin);
+        expect(config.plugins[0].plugin.options.silent).to.equal(true);
+    });
+
+    it('getPlugins() with options callback that returns an object', () => {
+        const config = createConfig();
+        config.enableTypeScriptLoader();
+        config.enableForkedTypeScriptTypesChecking(function(options) {
+            options.silent = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        expect(config.plugins).to.have.lengthOf(0);
+        const tsTypeChecker = require('../../lib/plugins/forked-ts-types');
+        tsTypeChecker(config);
+        expect(config.plugins).to.have.lengthOf(1);
+        expect(config.plugins[0].plugin).to.be.an.instanceof(ForkTsCheckerWebpackPlugin);
+        expect(config.plugins[0].plugin.options.silent).to.be.undefined;
+        expect(config.plugins[0].plugin.options.foo).to.equal(true);
     });
 });

--- a/test/plugins/friendly-errors.js
+++ b/test/plugins/friendly-errors.js
@@ -48,4 +48,21 @@ describe('plugins/friendly-errors', () => {
         expect(plugin.formatters.length).to.equal(3);
         expect(plugin.transformers.length).to.equal(6);
     });
+
+    it('with options callback that returns an object', () => {
+        const config = createConfig();
+
+        config.configureFriendlyErrorsPlugin((options) => {
+            options.clearConsole = false;
+
+            // This should override the original config
+            return { additionalFormatters: [] };
+        });
+
+        const plugin = friendlyErrorsPluginUtil(config);
+        expect(plugin).to.be.instanceof(FriendlyErrorsWebpackPlugin);
+        expect(plugin.shouldClearConsole).to.equal(true);
+        expect(plugin.formatters.length).to.equal(3);
+        expect(plugin.transformers.length).to.equal(3);
+    });
 });

--- a/test/plugins/loader-options.js
+++ b/test/plugins/loader-options.js
@@ -63,4 +63,22 @@ describe('plugins/loader-options', () => {
         // Doesn't remove default options
         expect(plugins[0].plugin.options.options.context).to.equal(config.getContext());
     });
+
+    it('production environment with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.configureLoaderOptionsPlugin((options) => {
+            options.debug = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        loaderOptionsPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.LoaderOptionsPlugin);
+        expect(plugins[0].plugin.options.debug).to.be.undefined;
+        expect(plugins[0].plugin.options.foo).to.equal(true);
+    });
 });

--- a/test/plugins/manifest.js
+++ b/test/plugins/manifest.js
@@ -55,4 +55,22 @@ describe('plugins/manifest', () => {
         // Doesn't remove default options
         expect(plugins[0].plugin.opts.publicPath).to.equal('/foo/');
     });
+
+    it('with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.configureManifestPlugin((options) => {
+            options.fileName = 'bar';
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        manifestPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(ManifestPlugin);
+        expect(plugins[0].plugin.opts.fileName).to.equal('manifest.json');
+        expect(plugins[0].plugin.opts.foo).to.equal(true);
+    });
 });

--- a/test/plugins/notifier.js
+++ b/test/plugins/notifier.js
@@ -67,4 +67,22 @@ describe('plugins/notifier', () => {
         expect(plugins[0].plugin).to.be.instanceof(WebpackNotifier);
         expect(plugins[0].plugin.options.title).to.equal('foo');
     });
+
+    it('enabled with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.enableBuildNotifications(true, (options) => {
+            options.title = 'foo';
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        notifierPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(WebpackNotifier);
+        expect(plugins[0].plugin.options.title).to.be.undefined;
+        expect(plugins[0].plugin.options.foo).to.equal(true);
+    });
 });

--- a/test/plugins/uglify.js
+++ b/test/plugins/uglify.js
@@ -61,4 +61,22 @@ describe('plugins/uglify', () => {
         // Doesn't remove default options
         expect(plugins[0].plugin.options.sourceMap).to.equal(false);
     });
+
+    it('with options callback that returns an object', () => {
+        const config = createConfig();
+        const plugins = [];
+
+        config.configureUglifyJsPlugin((options) => {
+            options.beautify = true;
+
+            // This should override the original config
+            return { foo: true };
+        });
+
+        uglifyPluginUtil(plugins, config);
+        expect(plugins.length).to.equal(1);
+        expect(plugins[0].plugin).to.be.instanceof(webpack.optimize.UglifyJsPlugin);
+        expect(plugins[0].plugin.options.beautify).to.be.undefined;
+        expect(plugins[0].plugin.options.foo).to.equal(true);
+    });
 });


### PR DESCRIPTION
This PR closes #298 by using the return value of callback functions (for loaders/plugins) as options if it is an object.

For instance: 

```js
Encore.configureUglifyJsPlugin((options) => {
    return {
        ...options,
        beautify: true
    };
});
```