### PR TITLE
Update the description of the webpack runtime chunk

### DIFF
--- a/lib/plugins/commons-chunks.js
+++ b/lib/plugins/commons-chunks.js
@@ -29,8 +29,8 @@ module.exports = function(plugins, webpackConfig) {
             name: [
                 webpackConfig.sharedCommonsEntryName,
                 /*
-                * Always dump a 2nd file - manifest.json that
-                * will contain the webpack manifest information.
+                * Always dump a 2nd file - manifest.js that
+                * will contain the webpack runtime.
                 * This changes frequently, and without this line,
                 * it would be packaged inside the "shared commons entry"
                 * file - e.g. vendor.js, which would prevent long-term caching.


### PR DESCRIPTION
What gets extracted in this chunk is not the manifest (which creates confusion with the webpack manifest which is a JSON file used by the backend code, i.e. the Symfony asset component); it is the webpack runtime.

This runtime indeed includes some information also present in the manifest (it contains the mapping for all dynamic chunks), but that's not all of it.