### PR TITLE
Fix shared entry file when source maps are enabled

### DIFF
--- a/lib/webpack/shared-entry-concat-plugin.js
+++ b/lib/webpack/shared-entry-concat-plugin.js
@@ -72,7 +72,7 @@ SharedEntryConcatPlugin.prototype.apply = function(compiler) {
 
         fs.writeFileSync(
             sharedEntryOutputFile,
-            fs.readFileSync(sharedEntryOutputFile) + fs.readFileSync(tmpEntryBootstrapFile)
+            [fs.readFileSync(sharedEntryOutputFile), fs.readFileSync(tmpEntryBootstrapFile)].join('\n')
         );
 
         fs.unlinkSync(tmpEntryBootstrapFile);

--- a/test/functional.js
+++ b/test/functional.js
@@ -801,6 +801,30 @@ describe('Functional tests using webpack', function() {
             });
         });
 
+        it('createdSharedEntry() works with source maps enabled', (done) => {
+            const config = createWebpackConfig('www/build', 'dev');
+            config.setPublicPath('/build');
+            config.addEntry('main', ['./js/no_require', './js/code_splitting', './js/arrow_function', './js/print_to_app']);
+            config.addEntry('other', ['./js/no_require', './css/h1_style.css']);
+            config.createSharedEntry('shared', './js/shared_example');
+            config.enableSourceMaps(true);
+
+            testSetup.runWebpack(config, (webpackAssert) => {
+                testSetup.requestTestPage(
+                    path.join(config.getContext(), 'www'),
+                    [
+                        convertToManifestPath('build/runtime.js', config),
+                        convertToManifestPath('build/shared.js', config),
+                    ],
+                    (browser) => {
+                        // assert that the javascript brought into shared is executed
+                        browser.assert.text('#app', 'Welcome to Encore!');
+                        done();
+                    }
+                );
+            });
+        });
+
         it('in production mode, code is uglified', (done) => {
             const config = createWebpackConfig('www/build', 'production');
             config.setPublicPath('/build');


### PR DESCRIPTION
This PR fixes #352.

When source maps are enabled, the original shared entry file ends with a commented line.

This is an issue when the "_tmp_shared" entry is appended to it since its first line then becomes part of that comment.