### PR TITLE
Add alias prod for production command

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -60,7 +60,7 @@ if (runtimeConfig.useDevServer) {
 }
 
 function showUsageInstructions() {
-    const validCommands = ['dev', 'production', 'dev-server'];
+    const validCommands = ['dev', 'prod', 'production', 'dev-server'];
 
     console.log(`usage ${chalk.green('encore')} [${ validCommands.map(command => chalk.green(command)).join('|') }]`);
     console.log();

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -33,8 +33,8 @@ module.exports = function(argv, cwd) {
             runtimeConfig.environment = 'dev';
             runtimeConfig.verbose = true;
             break;
-        case 'production': 
-		case 'prod':
+        case 'production':
+        case 'prod':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'production';
             runtimeConfig.verbose = false;

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -33,7 +33,7 @@ module.exports = function(argv, cwd) {
             runtimeConfig.environment = 'dev';
             runtimeConfig.verbose = true;
             break;
-        case 'production':
+        case 'production': case 'prod':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'production';
             runtimeConfig.verbose = false;

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -33,7 +33,8 @@ module.exports = function(argv, cwd) {
             runtimeConfig.environment = 'dev';
             runtimeConfig.verbose = true;
             break;
-        case 'production': case 'prod':
+        case 'production': 
+		case 'prod':
             runtimeConfig.isValidCommand = true;
             runtimeConfig.environment = 'production';
             runtimeConfig.verbose = false;


### PR DESCRIPTION
Very simple PR, everytime I write `yarn run encore prod` instead of `yarn run encore production`, I guess it's because we use _dev_ for _development_.

I kept the `production` command of course.