### PR TITLE
Use a copy of the given aliases and externals in the generated config

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -92,7 +92,7 @@ class ConfigGenerator {
 
         config.resolve = {
             extensions: ['.js', '.jsx', '.vue', '.ts', '.tsx'],
-            alias: this.webpackConfig.aliases
+            alias: Object.assign({}, this.webpackConfig.aliases)
         };
 
         if (this.webpackConfig.useVueLoader) {
@@ -104,7 +104,7 @@ class ConfigGenerator {
             config.resolve.alias['react-dom'] = 'preact-compat';
         }
 
-        config.externals = this.webpackConfig.externals;
+        config.externals = Object.assign({}, this.webpackConfig.externals);
 
         return config;
     }


### PR DESCRIPTION
As noted by @stof in #217, the current implementation of `Encore.addAliases()` and `Encore.addExternals()` doesn't create a copy of the given objects before putting them in the generated Webpack config.

Since it can lead to some issues when calling `getWebpackConfig()` multiple times without resetting Encore (the same objects being shared between configs), this PR creates a copy of them before adding them to the final config.