### PR TITLE
Filter --keep-public-path from arguments (fixes #180)

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -23,6 +23,10 @@ context.runtimeConfig = runtimeConfig;
 // remove the command from the output
 process.argv.splice(2, 1);
 
+// remove arguments not supported by webpack/-dev-server
+const EncoreOnlyArguments = new Set(['--keep-public-path']);
+process.argv = process.argv.filter(arg => !EncoreOnlyArguments.has(arg));
+
 if (!runtimeConfig.isValidCommand) {
     if (runtimeConfig.command) {
         console.log(chalk.bgRed.white(`Invalid command "${runtimeConfig.command}"`));

--- a/bin/encore.js
+++ b/bin/encore.js
@@ -24,8 +24,8 @@ context.runtimeConfig = runtimeConfig;
 process.argv.splice(2, 1);
 
 // remove arguments not supported by webpack/-dev-server
-const EncoreOnlyArguments = new Set(['--keep-public-path']);
-process.argv = process.argv.filter(arg => !EncoreOnlyArguments.has(arg));
+const encoreOnlyArguments = new Set(['--keep-public-path']);
+process.argv = process.argv.filter(arg => !encoreOnlyArguments.has(arg));
 
 if (!runtimeConfig.isValidCommand) {
     if (runtimeConfig.command) {

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -155,4 +155,32 @@ module.exports = Encore.getWebpackConfig();
             done();
         });
     });
+
+    it('Smoke test using the --keep-public-path option', (done) => {
+        testSetup.emptyTmpDir();
+        const testDir = testSetup.createTestAppDir();
+
+        fs.writeFileSync(
+            path.join(testDir, 'webpack.config.js'),
+            `
+const Encore = require('../../index.js');
+Encore
+    .setOutputPath('build/')
+    .setPublicPath('/build')
+    .addEntry('main', './js/no_require')
+;
+
+module.exports = Encore.getWebpackConfig();
+            `
+        );
+
+        const binPath = path.resolve(__dirname, '../', '../', 'bin', 'encore.js');
+        exec(`node ${binPath} dev --keep-public-path --context=${testDir}`, { cwd: testDir }, (err, stdout, stderr) => {
+            if (err) {
+                throw new Error(`Error executing encore: ${err} ${stderr} ${stdout}`);
+            }
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
The webpack-dev-server dose not know the --keep-public-path argument
and fails with an 'Unknown Argument' error if it is aplied.

So before webpack-encore hands over controle to webpack-cli/-dev-server it has to
remove arguments that only exist for webpack-encore.