### PR TITLE
Allow to configure the JS exclude rules through configureBabel

### DIFF
--- a/index.js
+++ b/index.js
@@ -639,13 +639,23 @@ class Encore {
      *
      * Encore.configureBabel(function(babelConfig) {
      *      // change the babelConfig
+     * }, {
+     *      // set optional Encore-specific options
+     *      // exclude: /(node_modules|bower_components)/
      * });
      *
+     * Supported options:
+     *      * {Condition} exclude (default=/(node_modules|bower_components)/)
+     *              A Webpack Condition passed to the JS/JSX rule that
+     *              determines which files and folders should not be
+     *              processed by Babel (https://webpack.js.org/configuration/module/#condition).
+     *
      * @param {function} callback
+     * @param {object} encoreOptions
      * @returns {Encore}
      */
-    configureBabel(callback) {
-        webpackConfig.configureBabel(callback);
+    configureBabel(callback, encoreOptions = {}) {
+        webpackConfig.configureBabel(callback, encoreOptions);
 
         return this;
     }

--- a/index.js
+++ b/index.js
@@ -649,6 +649,12 @@ class Encore {
      *              A Webpack Condition passed to the JS/JSX rule that
      *              determines which files and folders should not be
      *              processed by Babel (https://webpack.js.org/configuration/module/#condition).
+     *              Cannot be used if the "include_node_modules" option is
+     *              also set.
+     *      * {string[]} include_node_modules
+     *              If set that option will include the given Node modules to
+     *              the files that are processed by Babel. Cannot be used if
+     *              the "exclude" option is also set.
      *
      * @param {function} callback
      * @param {object} encoreOptions

--- a/index.js
+++ b/index.js
@@ -640,8 +640,15 @@ class Encore {
      * Encore.configureBabel(function(babelConfig) {
      *      // change the babelConfig
      * }, {
-     *      // set optional Encore-specific options
-     *      // exclude: /(node_modules|bower_components)/
+     *      // set optional Encore-specific options, for instance:
+     *
+     *      // change the rule that determines which files
+     *      // won't be processed by Babel
+     *      exclude: /bower_components/
+     *
+     *      // ...or keep the default rule but only allow
+     *      // *some* Node modules to be processed by Babel
+     *      include_node_modules: ['foundation-sites']
      * });
      *
      * Supported options:

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -80,7 +80,7 @@ class WebpackConfig {
             fonts: false
         };
         this.babelOptions = {
-            exclude: /(node_modules|bower_components)/,
+            exclude: /(node_modules|bower_components)/
         };
 
         // Features/Loaders options callbacks
@@ -316,11 +316,40 @@ class WebpackConfig {
         this.babelConfigurationCallback = callback;
 
         for (const optionKey of Object.keys(options)) {
-            if (!(optionKey in this.babelOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to configureBabel(). Valid keys are ${Object.keys(this.babelOptions).join(', ')}`);
-            }
+            if (optionKey === 'include_node_modules') {
+                if (Object.keys(options).includes('exclude')) {
+                    throw new Error('"include_node_modules" and "exclude" options can\'t be used together when calling configureBabel().');
+                }
 
-            this.babelOptions[optionKey] = options[optionKey];
+                if (!Array.isArray(options[optionKey])) {
+                    throw new Error('Option "include_node_modules" passed to configureBabel() must be an Array.');
+                }
+
+                this.babelOptions['exclude'] = (filePath) => {
+                    // Don't exclude modules outside of node_modules/bower_components
+                    if (!/(node_modules|bower_components)/.test(filePath)) {
+                        return false;
+                    }
+
+                    // Don't exclude whitelisted Node modules
+                    const whitelistedModules = options[optionKey].map(
+                        module => path.join('node_modules', module) + path.sep
+                    );
+
+                    for (const modulePath of whitelistedModules) {
+                        if (filePath.includes(modulePath)) {
+                            return false;
+                        }
+                    }
+
+                    // Exclude other modules
+                    return true;
+                };
+            } else if (!(optionKey in this.babelOptions)) {
+                throw new Error(`Invalid option "${optionKey}" passed to configureBabel(). Valid keys are ${Object.keys(this.babelOptions).join(', ')}`);
+            } else {
+                this.babelOptions[optionKey] = options[optionKey];
+            }
         }
     }
 

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -79,6 +79,9 @@ class WebpackConfig {
             images: false,
             fonts: false
         };
+        this.babelOptions = {
+            exclude: /(node_modules|bower_components)/,
+        };
 
         // Features/Loaders options callbacks
         this.postCssLoaderOptionsCallback = () => {};
@@ -301,7 +304,7 @@ class WebpackConfig {
         this.useSourceMaps = enabled;
     }
 
-    configureBabel(callback) {
+    configureBabel(callback, options = {}) {
         if (typeof callback !== 'function') {
             throw new Error('Argument 1 to configureBabel() must be a callback function.');
         }
@@ -311,6 +314,14 @@ class WebpackConfig {
         }
 
         this.babelConfigurationCallback = callback;
+
+        for (const optionKey of Object.keys(options)) {
+            if (!(optionKey in this.babelOptions)) {
+                throw new Error(`Invalid option "${optionKey}" passed to configureBabel(). Valid keys are ${Object.keys(this.babelOptions).join(', ')}`);
+            }
+
+            this.babelOptions[optionKey] = options[optionKey];
+        }
     }
 
     configureCssLoader(callback) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -165,7 +165,7 @@ class ConfigGenerator {
             {
                 // match .js and .jsx
                 test: /\.jsx?$/,
-                exclude: /(node_modules|bower_components)/,
+                exclude: this.webpackConfig.babelOptions.exclude,
                 use: babelLoaderUtil.getLoaders(this.webpackConfig)
             },
             {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -407,6 +407,7 @@ describe('WebpackConfig object', () => {
             const testCallback = () => {};
             config.configureBabel(testCallback);
             expect(config.babelConfigurationCallback).to.equal(testCallback);
+            expect(String(config.babelOptions.exclude)).to.equal(String(/(node_modules|bower_components)/));
         });
 
         it('Calling with non-callback throws an error', () => {
@@ -424,6 +425,21 @@ describe('WebpackConfig object', () => {
             expect(() => {
                 config.configureBabel(() => {});
             }).to.throw('configureBabel() cannot be called because your app already has Babel configuration');
+        });
+
+        it('Pass valid config', () => {
+            const config = createConfig();
+            config.configureBabel(() => {}, { exclude: 'foo' });
+
+            expect(config.babelOptions.exclude).to.equal('foo');
+        });
+
+        it('Pass invalid config', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureBabel(() => {}, { fake_option: 'foo' });
+            }).to.throw('Invalid option "fake_option" passed to configureBabel()');
         });
     });
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -826,6 +826,35 @@ describe('The config-generator function', () => {
         });
     });
 
+    describe('Test configureBabel()', () => {
+        it('without configureBabel()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+
+            const actualConfig = configGenerator(config);
+
+            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
+            expect(String(jsRule.exclude)).to.equal(String(/(node_modules|bower_components)/));
+        });
+
+        it('with configureBabel() and a different exclude rule', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            config.configureBabel(() => {}, {
+                exclude: /foo/
+            });
+
+            const actualConfig = configGenerator(config);
+
+            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
+            expect(String(jsRule.exclude)).to.equal(String(/foo/));
+        });
+    });
+
     describe('Test shouldSplitEntryChunks', () => {
         it('Not production', () => {
             const config = createConfig();


### PR DESCRIPTION
This PR closes #342 by allowing to configure the js/jsx loaders' exclude rule by using `configureBabel()`.

For instance:

```js
Encore.configureBabel(
    () => {},
    { exclude: /foo/ }
);
```

Note that it doesn't change the default behavior that excludes `node_modules` and `bower_components`.

**Edit:**

Also adds an `include_node_modules` option to use the default `exclude` rule but only include some Node modules (can't be used if the `exclude` option is also set):

```js
Encore.configureBabel(
    () => {},
    { include_node_modules: ['foo', 'bar', 'baz'] }
);
```