### PR TITLE
Fix entries disappearing from the manifest when using --watch

### DIFF
--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -22,6 +22,7 @@ const manifestKeyPrefixHelper = require('../utils/manifest-key-prefix-helper');
  */
 module.exports = function(plugins, webpackConfig) {
     const manifestPluginOptions = {
+        seed: {},
         basePath: manifestKeyPrefixHelper(webpackConfig),
         // always write a manifest.json file, even with webpack-dev-server
         writeToFileEmit: true,


### PR DESCRIPTION
This PR should fix #413.

When using `--watch` the first build works fine (unless you're using a recent version of `mini-css-extract-plugin`... but that's another story :)), but the next ones don't include all the assets.

Based on a few tests I made it could be related to https://github.com/danethurber/webpack-manifest-plugin/issues/144 but that issue won't be fixed until the next major version of WebpackManifestPlugin (3.x).

Since the workaround (setting the `seed` option to `{}`) seems to be working fine I suggest that we add it to the default options that are passed to the plugin.