### PR TITLE
Fixing bug where a second rebuild would explode due to entrypoints.json processing

### DIFF
--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -19,6 +19,13 @@ function processOutput(assets) {
         delete assets[entry];
     }
 
+    // with --watch or dev-server, subsequent calls will include
+    // the original assets (so, assets.entrypoints) + the new
+    // assets (which will have their original structure). We
+    // delete the entrypoints key, and then process the new assets
+    // like normal below
+    delete assets.entrypoints;
+
     // This will iterate over all the entry points and remove the / from the start of the paths. It also converts the
     // one file entries into an array of one entry since that was how the entry point file was before this change.
     for (const asset in assets) {


### PR DESCRIPTION
Hi guys!

Fixes #426 

Description in the comment