### PR TITLE
Improve `copyFiles` method examples #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,13 +441,13 @@ class Encore {
      *      Encore.copyFiles({
      *          from: './assets/images',
      *          pattern: /\.(png|jpg|jpeg)$/,
-     *          to: 'assets/images/[path][name].[ext]'
+     *          to: 'images/[path][name].[ext]'
      *      })
      *
      *      // Version files
      *      Encore.copyFiles({
      *          from: './assets/images',
-     *          to: 'assets/images/[path][name].[hash:8].[ext]'
+     *          to: 'images/[path][name].[hash:8].[ext]'
      *      })
      *
      *      // Add multiple configs in a single call


### PR DESCRIPTION
Like in #442 Fix also `to` option in examples - paths are relative to build dir, not root dir.