### PR TITLE
pretty-printing entrypoints.json

### DIFF
--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -40,7 +40,7 @@ function processOutput(assets) {
 
     return JSON.stringify({
         entrypoints: assets
-    });
+    }, null, 2);
 }
 
 /**


### PR DESCRIPTION
Fixes #450 

To be consistent with manifest.json, and because this is read by your server, so file size is not an issue.