### PR TITLE
[BC Break] Fixing a bug where the entrypoint path opening slash was stripped

### DIFF
--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -26,15 +26,13 @@ function processOutput(assets) {
     // like normal below
     delete assets.entrypoints;
 
-    // This will iterate over all the entry points and remove the / from the start of the paths. It also converts the
+    // This will iterate over all the entry points and convert the
     // one file entries into an array of one entry since that was how the entry point file was before this change.
     for (const asset in assets) {
         for (const fileType in assets[asset]) {
             if (!Array.isArray(assets[asset][fileType])) {
                 assets[asset][fileType] = [assets[asset][fileType]];
             }
-
-            assets[asset][fileType] = assets[asset][fileType].map(buildPath => buildPath.replace(/^\//g, ''));
         }
     }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -104,15 +104,15 @@ describe('Functional tests using webpack', function() {
                 webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                     entrypoints: {
                         main: {
-                            js: ['build/runtime.js', 'build/main.js']
+                            js: ['/build/runtime.js', '/build/main.js']
                         },
                         font: {
-                            js: ['build/runtime.js'],
-                            css: ['build/font.css']
+                            js: ['/build/runtime.js'],
+                            css: ['/build/font.css']
                         },
                         bg: {
-                            js: ['build/runtime.js'],
-                            css: ['build/bg.css']
+                            js: ['/build/runtime.js'],
+                            css: ['/build/bg.css']
                         }
                     }
                 });
@@ -135,12 +135,12 @@ describe('Functional tests using webpack', function() {
                 webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                     entrypoints: {
                         main: {
-                            js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/main~other.js', 'build/main.js'],
-                            css: ['build/main~other.css']
+                            js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/main~other.js', '/build/main.js'],
+                            css: ['/build/main~other.css']
                         },
                         other: {
-                            js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/main~other.js', 'build/other.js'],
-                            css: ['build/main~other.css']
+                            js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/main~other.js', '/build/other.js'],
+                            css: ['/build/main~other.css']
                         }
                     }
                 });
@@ -695,12 +695,12 @@ describe('Functional tests using webpack', function() {
                 webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                     entrypoints: {
                         main: {
-                            js: ['build/runtime.js', 'build/shared.js', 'build/main.js'],
-                            css: ['build/shared.css']
+                            js: ['/build/runtime.js', '/build/shared.js', '/build/main.js'],
+                            css: ['/build/shared.css']
                         },
                         other: {
-                            js: ['build/runtime.js', 'build/shared.js', 'build/other.js'],
-                            css: ['build/shared.css']
+                            js: ['/build/runtime.js', '/build/shared.js', '/build/other.js'],
+                            css: ['/build/shared.css']
                         }
                     }
                 });
@@ -1621,12 +1621,12 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/main~other.js', 'build/main.js'],
-                                css: ['build/main~other.css']
+                                js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/main~other.js', '/build/main.js'],
+                                css: ['/build/main~other.css']
                             },
                             other: {
-                                js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/main~other.js', 'build/other.js'],
-                                css: ['build/main~other.css']
+                                js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/main~other.js', '/build/other.js'],
+                                css: ['/build/main~other.css']
                             }
                         }
                     });
@@ -1680,6 +1680,48 @@ module.exports = {
                 });
             });
 
+            it('Subdirectory public path affects entrypoints.json but does not affect manifest.json', (done) => {
+                const config = createWebpackConfig('web/build', 'dev');
+                config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
+                config.addEntry('other', ['./css/roboto_font.css', 'vue']);
+                config.setPublicPath('/subdirectory/build');
+                config.setManifestKeyPrefix('custom_prefix');
+                config.configureSplitChunks((splitChunks) => {
+                    splitChunks.chunks = 'all';
+                    splitChunks.minSize = 0;
+                });
+
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
+                        entrypoints: {
+                            main: {
+                                js: [
+                                    '/subdirectory/build/runtime.js',
+                                    '/subdirectory/build/vendors~main~other.js',
+                                    '/subdirectory/build/main~other.js',
+                                    '/subdirectory/build/main.js'
+                                ],
+                                css: ['/subdirectory/build/main~other.css']
+                            },
+                            other: {
+                                js: [
+                                    '/subdirectory/build/runtime.js',
+                                    '/subdirectory/build/vendors~main~other.js',
+                                    '/subdirectory/build/main~other.js',
+                                    '/subdirectory/build/other.js'
+                                ],
+                                css: ['/subdirectory/build/main~other.css']
+                            }
+                        }
+                    });
+
+                    // make split chunks are correct in manifest
+                    webpackAssert.assertManifestKeyExists('custom_prefix/vendors~main~other.js');
+
+                    done();
+                });
+            });
+
             it('Use splitChunks in production mode', (done) => {
                 const config = createWebpackConfig('web/build', 'production');
                 config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
@@ -1695,12 +1737,12 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['build/runtime.js', 'build/vendors~cc515e6e.js', 'build/default~cc515e6e.js', 'build/main.js'],
-                                css: ['build/default~cc515e6e.css']
+                                js: ['/build/runtime.js', '/build/vendors~cc515e6e.js', '/build/default~cc515e6e.js', '/build/main.js'],
+                                css: ['/build/default~cc515e6e.css']
                             },
                             other: {
-                                js: ['build/runtime.js', 'build/vendors~cc515e6e.js', 'build/default~cc515e6e.js', 'build/other.js'],
-                                css: ['build/default~cc515e6e.css']
+                                js: ['/build/runtime.js', '/build/vendors~cc515e6e.js', '/build/default~cc515e6e.js', '/build/other.js'],
+                                css: ['/build/default~cc515e6e.css']
                             }
                         }
                     });
@@ -1726,12 +1768,12 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/main.js']
+                                js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/main.js']
                             },
                             other: {
                                 // the 0.[hash].js is because the "no_require" module was already split to this
                                 // so, it has that filename, instead of following the normal pattern
-                                js: ['build/runtime.js', 'build/vendors~main~other.js', 'build/0.js', 'build/other.js']
+                                js: ['/build/runtime.js', '/build/vendors~main~other.js', '/build/0.js', '/build/other.js']
                             }
                         }
                     });


### PR DESCRIPTION
Fixes #452 

When `entrypoints.json` was originally designed, the values were made so that they matched the *keys* of `manifest.json` - the idea was that you would use both to get the final path. But later (before 0.21.0 releaser), we/I changed `entrypoints.json` so that the value is the final path - to avoid needing to do another lookup in `manifest.json`.

However, there was one piece that I missed when changing this: the opening `/` is currently being stripped off the values in `entrypoints.json`. This breaks subdirectory installs (see #452).

For most Symfony users, you won't notice this change.
**Current behavior**: The value is read from `entrypoints.json` (`build/foo.js`), then it is also found in `manifest.json` (via the `json_manifest_strategy`) and becomes `/build/foo.js`.
**New behavior**: The value is read from `entrypoints.json` (`/build/foo.js`) and that's it. 

In both cases, the final value that enters into "Symfony" is `/build/foo.js`. But, for anyone not using the standard Symfony setup, this is a behavior change, as the values from `entrypoints.json` ARE changing.