### PR TITLE
[WIP] Adding support for preload/prefetch & async/defer

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,14 +257,30 @@ class Encore {
      * If the JavaScript file imports/requires CSS/Sass/LESS files,
      * then a CSS file (e.g. main.css) will also be output.
      *
+     * To "hint" that you would like to use defer/ajax or preload/prefetch,
+     * use the options argument. This will output to your entrypoints.json file
+     * which can be used when rendering (WebpackEncoreBundle does this):
+     *
+     *      // final output file will be main.js in the output directory
+     *      Encore.addEntry('main', './path/to/some_file.js', {
+     *          // async or defer
+     *          //async: true
+     *          //defer: true
+     *
+     *          // preload or prefetch
+     *          //preload: true
+     *          //prefetch: true
+     *      });
+     *
      * @param {string} name       The name (without extension) that will be used
      *                            as the output filename (e.g. app will become app.js)
      *                            in the output directory.
      * @param {string|Array} src  The path to the source file (or files)
+     * @param {object} options    An object of options related to the entry
      * @returns {Encore}
      */
-    addEntry(name, src) {
-        webpackConfig.addEntry(name, src);
+    addEntry(name, src, options) {
+        webpackConfig.addEntry(name, src, options);
 
         return this;
     }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -34,6 +34,7 @@ class WebpackConfig {
 
         this.runtimeConfig = runtimeConfig;
         this.entries = new Map();
+        this.entryOptions = new Map();
         this.styleEntries = new Map();
         this.plugins = [];
         this.loaders = [];
@@ -249,17 +250,25 @@ class WebpackConfig {
         return this.runtimeConfig.devServerUrl.replace(/\/$/,'') + this.publicPath;
     }
 
-    addEntry(name, src) {
+    addEntry(name, src, options = {}) {
         if (this.entries.has(name)) {
             throw new Error(`Duplicate name "${name}" passed to addEntry(): entries must be unique.`);
         }
 
         // also check for styleEntries duplicates
         if (this.styleEntries.has(name)) {
-            throw new Error(`The "${name}" passed to addEntry conflicts with a name passed to addStyleEntry(). The entry names between addEntry() and addStyleEntry() must be unique.`);
+            throw new Error(`The "${name}" passed to addEntry() conflicts with a name passed to addStyleEntry(). The entry names between addEntry() and addStyleEntry() must be unique.`);
         }
 
         this.entries.set(name, src);
+
+        if (typeof options !== 'object') {
+            throw new Error('Argument 3 to addEntry() must be an object of options.');
+        }
+
+        // TODO validate the options
+
+        this.entryOptions.set(name, options);
     }
 
     addStyleEntry(name, src) {

--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -14,7 +14,12 @@ const sharedEntryTmpName = require('../utils/sharedEntryTmpName');
 const copyEntryTmpName = require('../utils/copyEntryTmpName');
 const AssetsPlugin = require('assets-webpack-plugin');
 
-function processOutput(assets) {
+/**
+ * @param {object} assets
+ * @param {Map} entriesOptions
+ * @return {string}
+ */
+function processOutput(assets, entriesOptions) {
     for (const entry of [copyEntryTmpName, sharedEntryTmpName]) {
         delete assets[entry];
     }
@@ -25,6 +30,7 @@ function processOutput(assets) {
     // delete the entrypoints key, and then process the new assets
     // like normal below
     delete assets.entrypoints;
+    delete assets.metadata;
 
     // This will iterate over all the entry points and remove the / from the start of the paths. It also converts the
     // one file entries into an array of one entry since that was how the entry point file was before this change.
@@ -38,8 +44,34 @@ function processOutput(assets) {
         }
     }
 
+    const metadata = {
+        entrypoints: {}
+    };
+    for (const [entryName, entryOptions] of entriesOptions) {
+        const options = {};
+
+        if (entryOptions.preload) {
+            options.hint = 'preload';
+        } else if (entryOptions.prefetch) {
+            options.hint = 'prefetch';
+        }
+
+        if (entryOptions.async) {
+            options.attributes = { async: true };
+        } else if (entryOptions.defer) {
+            options.attributes = { defer: true };
+        }
+
+        if (0 === Object.keys(options).length) {
+            continue;
+        }
+
+        metadata.entrypoints[entryName] = options;
+    }
+
     return JSON.stringify({
-        entrypoints: assets
+        entrypoints: assets,
+        metadata: metadata
     }, null, 2);
 }
 
@@ -55,7 +87,9 @@ module.exports = function(plugins, webpackConfig) {
             filename: 'entrypoints.json',
             includeAllFileTypes: true,
             entrypoints: true,
-            processOutput: processOutput
+            processOutput: assets => {
+                return processOutput(assets, webpackConfig.entryOptions);
+            }
         }),
         priority: PluginPriorities.AssetsPlugin
     });


### PR DESCRIPTION
Hi guys!

This is start to supporting preload/prefetch out of the box - #429. I'd like feedback based on real-world requirements.

The usage is entirely centered around each *entry*:

```js
.addEntry('entry1', './js/entry1', {
    preload: true,
    async: true,
});
.addEntry('entry2', './js/entry2', {
    prefetch: true,
    defer: true,
});
```

This will output a new `metadata` key in `entrypoints.json`:

```json
{
    "entrypoints": { "all the normal stuff" },
    "metadata": {
        "entrypoints": {
            "entry1": {
                "hint": "preload",
                "attributes": {
                    "async": true
                }
            },
            "entry2": {
                "hint": "prefetch",
                "attributes": {
                    "defer": true
                }
            },
        }
    }
}
```

Then, WebpackEncoreBundle would be updated to read this new metadata, and output the correct attributes or communicate with the WebLink component to add the prefetch/preload headers.

## Features / Limitations

This initial attempt centers everything around the "entry" file. If you use [splitChunks()](https://symfony.com/doc/current/frontend/encore/split-chunks.html), the `entry1` file may actually render, for example, 3 script tags. And so, all 3 script tags would have the `async` attribute and have a `preload` header set. There is no file-by-file control. The question is: is this the best approach? Or, should this be entirely *filename* based (more like https://github.com/numical/script-ext-html-webpack-plugin)? But does that even make sense with `splitChunks`, where you don't know what the filenames will be.

There is also currently no support for configuring preload/prefetch for async chunks, but we could certainly add that. We *could* also add file-based support as an "override" - e.g. you configure the entries, but can define a pattern or callback to "override" the behavior for one specific file.

Also, if a file - e.g. `runtime.js` - is required by two entries, and both are included on the same page, what should the behavior be in the bundle? If one entry has `prefetch` and one has `preload`, the stronger `preload` should probably win? Or should the "first included entry on the page" win?

Or, we could entirely implement this in the bundle - via a new Twig function or some new options to indicate that you want prefetch/preload behavior.

Any real-world feedback is greatly appreciated!