### PR TITLE
Display a warning when calling "copyFiles" with an invalid path

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -148,11 +148,25 @@ class ConfigGenerator {
             entry[sharedEntryTmpName] = tmpFilename;
         }
 
-        if (this.webpackConfig.copyFilesConfigs.length > 0) {
+        const copyFilesConfigs = this.webpackConfig.copyFilesConfigs.filter(entry => {
+            const copyFrom = path.resolve(
+                this.webpackConfig.getContext(),
+                entry.from
+            );
+
+            if (!fs.existsSync(copyFrom) || !fs.lstatSync(copyFrom).isDirectory()) {
+                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" does not seem to be one. No file will be copied for this entry.`);
+                return false;
+            }
+
+            return true;
+        });
+
+        if (copyFilesConfigs.length > 0) {
             const tmpFileObject = tmp.fileSync();
             fs.writeFileSync(
                 tmpFileObject.name,
-                this.webpackConfig.copyFilesConfigs.reduce((buffer, entry, index) => {
+                copyFilesConfigs.reduce((buffer, entry, index) => {
                     const copyFrom = path.resolve(
                         this.webpackConfig.getContext(),
                         entry.from

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -154,8 +154,13 @@ class ConfigGenerator {
                 entry.from
             );
 
-            if (!fs.existsSync(copyFrom) || !fs.lstatSync(copyFrom).isDirectory()) {
-                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" does not seem to be one. No file will be copied for this entry.`);
+            if (!fs.existsSync(copyFrom)) {
+                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" does not seem to exist. Nothing will be copied for this copyFiles() config object.`);
+                return false;
+            }
+
+            if (!fs.lstatSync(copyFrom).isDirectory()) {
+                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" seems to be a file. Nothing will be copied for this copyFiles() config object.`);
                 return false;
             }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -1603,6 +1603,43 @@ module.exports = {
                     done();
                 });
             });
+
+            it('Do not try to copy files from an invalid path', (done) => {
+                const config = createWebpackConfig('www/build', 'production');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/build');
+                config.copyFiles([{
+                    from: './images',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false
+                }, {
+                    from: './foo',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false
+                }, {
+                    from: './fonts',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false
+                }, {
+                    from: './bar/baz',
+                    includeSubdirectories: true
+                }]);
+
+                testSetup.runWebpack(config, (webpackAssert, stats, stdout) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        .with.files([
+                            'entrypoints.json',
+                            'runtime.js',
+                            'main.js',
+                            'manifest.json'
+                        ]);
+
+                    expect(stdout).to.contain('should be set to an existing directory but "./foo" does not seem to be one');
+                    expect(stdout).to.contain('should be set to an existing directory but "./bar/baz" does not seem to be one');
+
+                    done();
+                });
+            });
         });
 
         describe('entrypoints.json', () => {

--- a/test/functional.js
+++ b/test/functional.js
@@ -1621,7 +1621,7 @@ module.exports = {
                     to: 'assets/[path][name].[ext]',
                     includeSubdirectories: false
                 }, {
-                    from: './bar/baz',
+                    from: './images/symfony_logo.png',
                     includeSubdirectories: true
                 }]);
 
@@ -1634,8 +1634,8 @@ module.exports = {
                             'manifest.json'
                         ]);
 
-                    expect(stdout).to.contain('should be set to an existing directory but "./foo" does not seem to be one');
-                    expect(stdout).to.contain('should be set to an existing directory but "./bar/baz" does not seem to be one');
+                    expect(stdout).to.contain('should be set to an existing directory but "./foo" does not seem to exist');
+                    expect(stdout).to.contain('should be set to an existing directory but "./images/symfony_logo.png" seems to be a file');
 
                     done();
                 });


### PR DESCRIPTION
This PR adds a warning when `copyFiles()` is called with a `from` value that isn't an existing directory.

This is kind of related to #445 but even if the friendly-errors-webpack-plugin worked properly in this case the origin of the error would probably not be obvious (it'd most likely contain a reference to the temporary entry).