### PR TITLE
Always used named chunks AND prevent split chunks from changing too often.

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -412,22 +412,12 @@ class ConfigGenerator {
             chunks: this.webpackConfig.shouldSplitEntryChunks ? 'all' : 'async'
         };
 
-        // hash the split filenames in production to protect exposing entry names
+        // This causes the split filenames (& internal names) to be,
+        // for example, 0.js. This is needed so that the filename
+        // doesn't change suddenly when another entry needs that same
+        // shared code (e.g. vendor~entry1~entry2.js).
         if (this.webpackConfig.shouldSplitEntryChunks && this.webpackConfig.isProduction()) {
-            // taken from SplitChunksPlugin
-            const hashFilename = name => {
-                return crypto
-                    .createHash('md4')
-                    .update(name)
-                    .digest('hex')
-                    .slice(0, 8);
-            };
-
-            splitChunks.name = function(module, chunks, cacheGroup) {
-                const names = chunks.map(c => c.name);
-
-                return cacheGroup + '~' + hashFilename(names.join('~'));
-            };
+            splitChunks.name = false;
         }
 
         if (this.webpackConfig.sharedCommonsEntryName) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -403,6 +403,10 @@ class ConfigGenerator {
             // which can be useful for debugging, especially with HMR
             optimization.namedModules = true;
         }
+        // https://github.com/webpack/webpack/issues/8354
+        // likely can be removed in Webpack 5
+        // https://github.com/webpack/webpack/pull/8374
+        optimization.chunkIds = 'named';
 
         let splitChunks = {
             chunks: this.webpackConfig.shouldSplitEntryChunks ? 'all' : 'async'

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -416,6 +416,7 @@ class ConfigGenerator {
         // for example, 0.js. This is needed so that the filename
         // doesn't change suddenly when another entry needs that same
         // shared code (e.g. vendor~entry1~entry2.js).
+        // https://github.com/webpack/webpack/issues/8426#issuecomment-442375207
         if (this.webpackConfig.shouldSplitEntryChunks && this.webpackConfig.isProduction()) {
             splitChunks.name = false;
         }

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -877,7 +877,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
             expect(actualConfig.optimization.splitChunks.chunks).to.equal('all');
-            expect(actualConfig.optimization.splitChunks.name).to.be.a('function');
+            expect(actualConfig.optimization.splitChunks.name).to.be.false;
         });
     });
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -1884,6 +1884,10 @@ module.exports = {
                     }
                     config.setPublicPath('/build');
                     config.splitEntryChunks();
+                    config.configureSplitChunks((splitChunks) => {
+                        // will include preact, but prevent any other splitting
+                        splitChunks.minSize = 10000;
+                    });
 
                     return config;
                 };

--- a/test/functional.js
+++ b/test/functional.js
@@ -1794,18 +1794,18 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['/build/runtime.js', '/build/vendors~cc515e6e.js', '/build/default~cc515e6e.js', '/build/main.js'],
-                                css: ['/build/default~cc515e6e.css']
+                                js: ['/build/runtime.js', '/build/0.js', '/build/1.js', '/build/main.js'],
+                                css: ['/build/1.css']
                             },
                             other: {
-                                js: ['/build/runtime.js', '/build/vendors~cc515e6e.js', '/build/default~cc515e6e.js', '/build/other.js'],
-                                css: ['/build/default~cc515e6e.css']
+                                js: ['/build/runtime.js', '/build/0.js', '/build/1.js', '/build/other.js'],
+                                css: ['/build/1.css']
                             }
                         }
                     });
 
                     // make split chunks are correct in manifest
-                    webpackAssert.assertManifestKeyExists('build/vendors~cc515e6e.js');
+                    webpackAssert.assertManifestKeyExists('build/0.js');
 
                     done();
                 });


### PR DESCRIPTION
Fixes #461 

But, this does not expose the entry names internally in the code (as these are used instead of auto-incremet ids). I don't think there's a way around that.

Also, I'm still tracking down a somewhat related but that causes a related issue (meaningless id's changing in generated code) under very specific conditions. In fact, you can see it in this test case just by changing all the 3 of the entries to an array - e.g. 

```js
config.addEntry('main1', ['./js/code_splitting']);
if (includeExtraEntry) {
    config.addEntry('main2', ['./js/eslint']);
}
config.addEntry('main3', ['./js/no_require']);
```

That doesn't need to block this PR, but I need to figure out the issue (it's Webpack behavior) and see if it affects versioning (i.e. if the contents change but the file hashes do NOT change, this is a BIG problem, otherwise, it's more of a minor, performance problem as filenames would just be changing too often).