### PR TITLE
Add new methods `isDev()` and `isDevServer()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1073,6 +1073,24 @@ class Encore {
     }
 
     /**
+     * Is this currently a "dev" build?
+     *
+     * @returns {boolean}
+     */
+    isDev() {
+        return webpackConfig.isDev();
+    }
+
+    /**
+     * Is this currently a "dev-server" build?
+     *
+     * @returns {boolean}
+     */
+    isDevServer() {
+        return webpackConfig.isDevServer();
+    }
+
+    /**
      * Use this at the bottom of your webpack.config.js file:
      *
      * module.exports = Encore.getWebpackConfig();

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -688,6 +688,14 @@ class WebpackConfig {
     isProduction() {
         return this.runtimeConfig.environment === 'production';
     }
+
+    isDev() {
+        return this.runtimeConfig.environment === 'dev';
+    }
+
+    isDevServer() {
+        return this.isDev() && this.runtimeConfig.useDevServer;
+    }
 }
 
 module.exports = WebpackConfig;


### PR DESCRIPTION
Hi,

This PR adds two new methods `isDev()` and `isDevServer()` aside the already existing `isProduction()` method.

On a project at work, we should configure webpack-encore only when we are running the dev-server. 
There is the property `runtimeConfig.useDevServer` but we don't have access to `runtimeConfig` in our `webpack.config.js`.

I know we can do this:
```js
const config = Encore.getWebpackConfig();

if (config.devServer) {
  // ....
}
```

but it means that we can't use webpack-encore methods:
```js
if (Encore.isDevServer()) {
  Encore
    .setPublicPath('http://app.vm:8080/build/')
    .setManifestKeyPrefix('build/')
}
```

Also I tried to add some tests but I didn't find tests for `isProduction()` :(

Thanks!