### PR TITLE
feat: configure watching options

### DIFF
--- a/index.js
+++ b/index.js
@@ -589,12 +589,12 @@ class Encore {
     }
 
     /**
-     * Configure the devServer.watchOptions configuration, only when the dev server is running.
+     * Configure the watchOptions and devServer.watchOptions configuration.
      *
-     * https://webpack.js.org/configuration/dev-server/#devserver-watchoptions-
      * https://webpack.js.org/configuration/watch/
+     * https://webpack.js.org/configuration/dev-server/#devserver-watchoptions-
      *
-     * Encore.configureDevServerWatchOptions(function(watchOptions) {
+     * Encore.configureWatchOptions(function(watchOptions) {
      *      // change the configuration
      *
      *      watchOptions.poll = 250; // useful when running inside a Virtual Machine
@@ -603,8 +603,8 @@ class Encore {
      * @param {function} callback
      * @returns {Encore}
      */
-    configureDevServerWatchOptions(callback) {
-        webpackConfig.configureDevServerWatchOptions(callback);
+    configureWatchOptions(callback) {
+        webpackConfig.configureWatchOptions(callback);
 
         return this;
     }

--- a/index.js
+++ b/index.js
@@ -589,6 +589,27 @@ class Encore {
     }
 
     /**
+     * Configure the devServer.watchOptions configuration, only when the dev server is running.
+     *
+     * https://webpack.js.org/configuration/dev-server/#devserver-watchoptions-
+     * https://webpack.js.org/configuration/watch/
+     *
+     * Encore.configureDevServerWatchOptions(function(watchOptions) {
+     *      // change the configuration
+     *
+     *      watchOptions.poll = 250;
+     * });
+     *
+     * @param {function} callback
+     * @returns {Encore}
+     */
+    configureDevServerWatchOptions(callback) {
+        webpackConfig.configureDevServerWatchOptions(callback);
+
+        return this;
+    }
+
+    /**
      * Automatically make some variables available everywhere!
      *
      * Usage:

--- a/index.js
+++ b/index.js
@@ -597,7 +597,7 @@ class Encore {
      * Encore.configureDevServerWatchOptions(function(watchOptions) {
      *      // change the configuration
      *
-     *      watchOptions.poll = 250;
+     *      watchOptions.poll = 250; // useful when running inside a Virtual Machine
      * });
      *
      * @param {function} callback

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -94,7 +94,7 @@ class WebpackConfig {
         this.shouldUseSingleRuntimeChunk = null;
         this.shouldSplitEntryChunks = false;
         this.splitChunksConfigurationCallback = () => {};
-        this.devServerWatchOptionsConfigurationCallback = () => {};
+        this.watchOptionsConfigurationCallback = () => {};
         this.vueLoaderOptionsCallback = () => {};
         this.eslintLoaderOptionsCallback = () => {};
         this.tsConfigurationCallback = () => {};
@@ -396,12 +396,12 @@ class WebpackConfig {
         this.splitChunksConfigurationCallback = callback;
     }
 
-    configureDevServerWatchOptions(callback) {
+    configureWatchOptions(callback) {
         if (typeof callback !== 'function') {
-            throw new Error('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+            throw new Error('Argument 1 to configureWatchOptions() must be a callback function.');
         }
 
-        this.devServerWatchOptionsConfigurationCallback = callback;
+        this.watchOptionsConfigurationCallback = callback;
     }
 
     createSharedEntry(name, file) {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -94,6 +94,7 @@ class WebpackConfig {
         this.shouldUseSingleRuntimeChunk = null;
         this.shouldSplitEntryChunks = false;
         this.splitChunksConfigurationCallback = () => {};
+        this.devServerWatchOptionsConfigurationCallback = () => {};
         this.vueLoaderOptionsCallback = () => {};
         this.eslintLoaderOptionsCallback = () => {};
         this.tsConfigurationCallback = () => {};
@@ -393,6 +394,14 @@ class WebpackConfig {
         }
 
         this.splitChunksConfigurationCallback = callback;
+    }
+
+    configureDevServerWatchOptions(callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+        }
+
+        this.devServerWatchOptionsConfigurationCallback = callback;
     }
 
     createSharedEntry(name, file) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -527,6 +527,11 @@ class ConfigGenerator {
 
     buildDevServerConfig() {
         const contentBase = pathUtil.getContentBase(this.webpackConfig);
+        const watchOptions = {
+            ignored: /node_modules/
+        };
+
+        this.webpackConfig.devServerWatchOptionsConfigurationCallback(watchOptions);
 
         return {
             contentBase: contentBase,
@@ -539,9 +544,7 @@ class ConfigGenerator {
             quiet: true,
             compress: true,
             historyApiFallback: true,
-            watchOptions: {
-                ignored: /node_modules/
-            },
+            watchOptions: watchOptions,
             https: this.webpackConfig.useDevServerInHttps()
         };
     }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -531,9 +531,10 @@ class ConfigGenerator {
             ignored: /node_modules/
         };
 
-        this.webpackConfig.watchOptionsConfigurationCallback(watchOptions);
-
-        return watchOptions;
+        return applyOptionsCallback(
+            this.webpackConfig.watchOptionsConfigurationCallback,
+            watchOptions
+        );
     }
 
     buildDevServerConfig() {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -69,7 +69,8 @@ class ConfigGenerator {
                 rules: this.buildRulesConfig(),
             },
             plugins: this.buildPluginsConfig(),
-            optimization: this.buildOptimizationConfig()
+            optimization: this.buildOptimizationConfig(),
+            watchOptions: this.buildWatchOptionsConfig()
         };
 
         if (this.webpackConfig.useSourceMaps) {
@@ -525,13 +526,18 @@ class ConfigGenerator {
         return stats;
     }
 
-    buildDevServerConfig() {
-        const contentBase = pathUtil.getContentBase(this.webpackConfig);
+    buildWatchOptionsConfig() {
         const watchOptions = {
             ignored: /node_modules/
         };
 
-        this.webpackConfig.devServerWatchOptionsConfigurationCallback(watchOptions);
+        this.webpackConfig.watchOptionsConfigurationCallback(watchOptions);
+
+        return watchOptions;
+    }
+
+    buildDevServerConfig() {
+        const contentBase = pathUtil.getContentBase(this.webpackConfig);
 
         return {
             contentBase: contentBase,
@@ -544,7 +550,7 @@ class ConfigGenerator {
             quiet: true,
             compress: true,
             historyApiFallback: true,
-            watchOptions: watchOptions,
+            watchOptions: this.buildWatchOptionsConfig(),
             https: this.webpackConfig.useDevServerInHttps()
         };
     }

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1066,28 +1066,28 @@ describe('WebpackConfig object', () => {
         });
     });
 
-    describe('configureDevServerWatchOptions()', () => {
+    describe('configureWatchOptions()', () => {
         it('Pass config', () => {
             const config = createConfig();
             const callback = (watchOptions) => {
                 watchOptions.poll = 250;
             };
 
-            config.configureDevServerWatchOptions(callback);
+            config.configureWatchOptions(callback);
 
-            expect(config.devServerWatchOptionsConfigurationCallback).to.equal(callback);
+            expect(config.watchOptionsConfigurationCallback).to.equal(callback);
         });
 
         it('Call method without a valid callback', () => {
             const config = createConfig();
 
             expect(() => {
-                config.configureDevServerWatchOptions();
-            }).to.throw('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+                config.configureWatchOptions();
+            }).to.throw('Argument 1 to configureWatchOptions() must be a callback function.');
 
             expect(() => {
-                config.configureDevServerWatchOptions({});
-            }).to.throw('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+                config.configureWatchOptions({});
+            }).to.throw('Argument 1 to configureWatchOptions() must be a callback function.');
         });
     });
 });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1065,4 +1065,29 @@ describe('WebpackConfig object', () => {
             }).to.throw('"foo" is not a valid key');
         });
     });
+
+    describe('configureDevServerWatchOptions()', () => {
+        it('Pass config', () => {
+            const config = createConfig();
+            const callback = (watchOptions) => {
+                watchOptions.poll = 250;
+            };
+
+            config.configureDevServerWatchOptions(callback);
+
+            expect(config.devServerWatchOptionsConfigurationCallback).to.equal(callback);
+        });
+
+        it('Call method without a valid callback', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureDevServerWatchOptions();
+            }).to.throw('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+
+            expect(() => {
+                config.configureDevServerWatchOptions({});
+            }).to.throw('Argument 1 to configureDevServerWatchOptions() must be a callback function.');
+        });
+    });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -583,11 +583,15 @@ describe('The config-generator function', () => {
             config.setPublicPath('/');
             config.addEntry('main', './main');
 
-            config.configureDevServerWatchOptions(watchOptions => {
+            config.configureWatchOptions(watchOptions => {
                 watchOptions.poll = 250;
             });
 
             const actualConfig = configGenerator(config);
+            expect(actualConfig.watchOptions).to.deep.equals({
+                'ignored': /node_modules/,
+                'poll': 250,
+            });
             expect(actualConfig.devServer.watchOptions).to.deep.equals({
                 'ignored': /node_modules/,
                 'poll': 250,
@@ -952,6 +956,23 @@ describe('The config-generator function', () => {
             const actualConfig = configGenerator(config);
             expect(actualConfig.optimization.runtimeChunk).to.be.undefined;
             expect(JSON.stringify(logger.getMessages().deprecation)).to.contain('the recommended setting is Encore.enableSingleRuntimeChunk()');
+        });
+    });
+
+    describe('Test buildWatchOptionsConfig()', () => {
+        it('Set webpack watch options', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/public/build';
+            config.setPublicPath('/build/');
+            config.configureWatchOptions(watchOptions => {
+                watchOptions.poll = 250;
+            });
+
+            const actualConfig = configGenerator(config);
+            expect(actualConfig.watchOptions).to.deep.equals({
+                ignored: /node_modules/,
+                poll: 250,
+            });
         });
     });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -573,6 +573,26 @@ describe('The config-generator function', () => {
             const actualConfig = configGenerator(config);
             expect(actualConfig.devServer.hot).to.be.true;
         });
+
+        it('devServer with custom watch options', () => {
+            const config = createConfig();
+            config.runtimeConfig.useDevServer = true;
+            config.runtimeConfig.devServerUrl = 'http://localhost:8080/';
+            config.runtimeConfig.useHotModuleReplacement = true;
+            config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
+            config.setPublicPath('/');
+            config.addEntry('main', './main');
+
+            config.configureDevServerWatchOptions(watchOptions => {
+                watchOptions.poll = 250;
+            });
+
+            const actualConfig = configGenerator(config);
+            expect(actualConfig.devServer.watchOptions).to.deep.equals({
+                'ignored': /node_modules/,
+                'poll': 250,
+            });
+        });
     });
 
     describe('test for addPlugin config', () => {


### PR DESCRIPTION
This PR adds support for _properly_ configuring watching options.
References: #35, #126

Before, we had to do this:
```js
const config = Encore.getWebpackConfig();

if (config.devServer) {
  config.devServer.watchOptions.poll = 250;
}
```

Now, we can do this:
```js
Encore.configureWatchOptions(watchOptions => {
    watchOptions.poll = 250;
});
```

Also, I think it would be better to rename it to `configureWatchOptions()`, but I don't know how encore apply watching options to webpack when running dev or prod environment with `encore [prod|dev] --watch`. :thinking: 

Thanks!

---

**EDIT**: Ah, I found it! 
![selection_052](https://user-images.githubusercontent.com/2103975/50780738-00de0e80-12a4-11e9-8f90-1de8f8604964.png)

I will see how can I modify `watchOptions` in dev/prod modes.