### PR TITLE
Fix support for Webpack externals. This fixes #471

### DIFF
--- a/index.js
+++ b/index.js
@@ -397,7 +397,9 @@ class Encore {
      *      const nodeExternals = require('webpack-node-externals');
      *
      *      Encore.addExternals(
-     *          nodeExternals()
+     *          // add any valid externals you have
+     *          nodeExternals(),
+     *          /^(jquery|\$)$/i
      *      );
      *
      * @param {*} externals

--- a/index.js
+++ b/index.js
@@ -387,15 +387,18 @@ class Encore {
      *
      * For example:
      *
+     *      Encore.addExternals({
+     *          jquery: 'jQuery',
+     *          react: 'react'
+     *      });
+     *
+     * Or:
+     *
      *      const nodeExternals = require('webpack-node-externals');
      *
-     *      Encore.addExternals([
-     *          {
-     *             jquery: 'jQuery',
-     *             react: 'react'
-     *          },
+     *      Encore.addExternals(
      *          nodeExternals()
-     *      ]);
+     *      );
      *
      * @param {*} externals
      *

--- a/index.js
+++ b/index.js
@@ -397,7 +397,7 @@ class Encore {
      *          nodeExternals()
      *      ]);
      *
-     * @param {object} externals
+     * @param {*} externals
      *
      * @returns {Encore}
      */

--- a/index.js
+++ b/index.js
@@ -387,10 +387,15 @@ class Encore {
      *
      * For example:
      *
-     *      Encore.addExternals({
-     *          jquery: 'jQuery',
-     *          react: 'react'
-     *      })
+     *      const nodeExternals = require('webpack-node-externals');
+     *
+     *      Encore.addExternals([
+     *          {
+     *             jquery: 'jQuery',
+     *             react: 'react'
+     *          },
+     *          nodeExternals()
+     *      ]);
      *
      * @param {object} externals
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -47,7 +47,7 @@ class WebpackConfig {
         this.providedVariables = {};
         this.configuredFilenames = {};
         this.aliases = {};
-        this.externals = {};
+        this.externals = [];
 
         // Features/Loaders flags
         this.useVersioning = false;
@@ -298,12 +298,12 @@ class WebpackConfig {
         Object.assign(this.aliases, aliases);
     }
 
-    addExternals(externals = {}) {
-        if (typeof externals !== 'object') {
-            throw new Error('Argument 1 to addExternals() must be an object.');
+    addExternals(externals = []) {
+        if (!Array.isArray(externals)) {
+            externals = [externals];
         }
 
-        Object.assign(this.externals, externals);
+        this.externals = this.externals.concat(externals);
     }
 
     enableVersioning(enabled = true) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -107,7 +107,7 @@ class ConfigGenerator {
             config.resolve.alias['react-dom'] = 'preact-compat';
         }
 
-        config.externals = Object.assign({}, this.webpackConfig.externals);
+        config.externals = this.webpackConfig.externals;
 
         return config;
     }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -107,7 +107,7 @@ class ConfigGenerator {
             config.resolve.alias['react-dom'] = 'preact-compat';
         }
 
-        config.externals = this.webpackConfig.externals;
+        config.externals = [...this.webpackConfig.externals];
 
         return config;
     }

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -944,10 +944,12 @@ describe('WebpackConfig object', () => {
 
             config.addExternals({ 'jquery': 'jQuery', 'react': 'react' });
             config.addExternals({ 'lodash': 'lodash' });
+			config.addExternals(/^(jquery|\$)$/i);
 
             expect(config.externals).to.deep.equals([
                 { 'jquery': 'jQuery', 'react': 'react'},
-                { 'lodash': 'lodash' }
+                { 'lodash': 'lodash' },
+				/^(jquery|\$)$/i
             ]);
         });
     });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -940,24 +940,15 @@ describe('WebpackConfig object', () => {
         it('Adds new externals', () => {
             const config = createConfig();
 
-            expect(config.externals).to.deep.equals({});
+            expect(config.externals).to.deep.equals([]);
 
             config.addExternals({ 'jquery': 'jQuery', 'react': 'react' });
             config.addExternals({ 'lodash': 'lodash' });
 
-            expect(config.externals).to.deep.equals({
-                'jquery': 'jQuery',
-                'react': 'react',
-                'lodash': 'lodash'
-            });
-        });
-
-        it('Calling it with an invalid argument', () => {
-            const config = createConfig();
-
-            expect(() => {
-                config.addExternals('foo');
-            }).to.throw('must be an object');
+            expect(config.externals).to.deep.equals([
+                { 'jquery': 'jQuery', 'react': 'react'},
+                { 'lodash': 'lodash' }
+            ]);
         });
     });
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -944,12 +944,12 @@ describe('WebpackConfig object', () => {
 
             config.addExternals({ 'jquery': 'jQuery', 'react': 'react' });
             config.addExternals({ 'lodash': 'lodash' });
-			config.addExternals(/^(jquery|\$)$/i);
+            config.addExternals(/^(jquery|\$)$/i);
 
             expect(config.externals).to.deep.equals([
-                { 'jquery': 'jQuery', 'react': 'react'},
+                { 'jquery': 'jQuery', 'react': 'react' },
                 { 'lodash': 'lodash' },
-				/^(jquery|\$)$/i
+                /^(jquery|\$)$/i
             ]);
         });
     });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -471,7 +471,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            expect(actualConfig.externals).to.deep.equals({});
+            expect(actualConfig.externals).to.deep.equals([]);
         });
 
         it('with addExternals()', () => {
@@ -485,10 +485,10 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            expect(actualConfig.externals).to.deep.equals({
+            expect(actualConfig.externals).to.deep.equals([{
                 'jquery': 'jQuery',
                 'react': 'react'
-            });
+            }]);
         });
     });
 


### PR DESCRIPTION
This is an alternative to https://github.com/symfony/webpack-encore/pull/472 which does not modify the public Encore API and requires the user to pass an array if they want to add multiple externals at a time.