### PR TITLE
feat(terser): enable cache and parallelism

### DIFF
--- a/lib/plugins/terser.js
+++ b/lib/plugins/terser.js
@@ -18,7 +18,9 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
  */
 module.exports = function(webpackConfig) {
     const terserPluginOptions = {
-        sourceMap: webpackConfig.useSourceMaps
+        sourceMap: webpackConfig.useSourceMaps,
+        cache: true,
+        parallel: true,
     };
 
     return new TerserPlugin(


### PR DESCRIPTION
Recently Laravel Mix have sped up build time by configuring Terser plugin   (https://github.com/JeffreyWay/laravel-mix/pull/1925).

I though `cache` and `parallelism` options was already set on encore, but nope.

Here a comparaison, before:
![capture d ecran de 2019-01-18 06-49-45](https://user-images.githubusercontent.com/2103975/51367981-77bda780-1aed-11e9-982d-8cf356a82a5f.png)

and after:
![capture d ecran de 2019-01-18 06-51-05](https://user-images.githubusercontent.com/2103975/51367985-79876b00-1aed-11e9-9e33-b754c76c949f.png)

From 16-18 seconds to 14-8 seconds on my machine. 
And even if my project does not have a tons of JavaScript, the building time have been reduced.