### PR TITLE
Remove debug logging in some tests

### DIFF
--- a/test/utils/string-escaper.js
+++ b/test/utils/string-escaper.js
@@ -23,14 +23,12 @@ describe('string-escaper', () => {
         const filename = "/foo/bar's/stuff";
 
         const escapedFilename = stringEscaper(filename);
-        console.log(escapedFilename);
         expectEvaledStringToEqual(escapedFilename, filename);
     });
 
     it('escapes Windows filenames', () => {
         // eslint-disable-next-line quotes
         const filename = `C:\\path\\to\\file`;
-        console.log(filename);
 
         const escapedFilename = stringEscaper(filename);
         expectEvaledStringToEqual(escapedFilename, filename);


### PR DESCRIPTION
These logging calls are written in the output while running tests, which look weird in the test output.
I assume they were added to debug stuff while writing tests, but they should not be necessary anymore.