### PR TITLE
enable eslinting of .vue files

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -318,9 +318,9 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useEslintLoader) {
-            const test = this.webpackConfig.useVueLoader 
-            ? /\.(jsx?|vue)$/
-            : /\.jsx?$/
+            const test = this.webpackConfig.useVueLoader
+                ? /\.(jsx?|vue)$/
+                : /\.jsx?$/;
                         
             rules.push({
                 test,

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -318,8 +318,12 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useEslintLoader) {
+            const test = this.webpackConfig.useVueLoader 
+            ? /\.(jsx?|vue)$/
+            : /\.jsx?$/
+                        
             rules.push({
-                test: /\.jsx?$/,
+                test,
                 loader: 'eslint-loader',
                 exclude: /node_modules/,
                 enforce: 'pre',

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -321,7 +321,7 @@ class ConfigGenerator {
             const test = this.webpackConfig.useVueLoader
                 ? /\.(jsx?|vue)$/
                 : /\.jsx?$/;
-                        
+
             rules.push({
                 test,
                 loader: 'eslint-loader',


### PR DESCRIPTION
addresses #473 :  if the eslintloader is activated aside the vue loader it also must load .vue files. This proposal might not be complete: for that case we could also add dependency notes so users are hinted to install `vue-eslint-parser`.