### PR TITLE
feat: Add method to configure loaders rules 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1112,8 +1112,8 @@ class Encore {
      *     Encore
      *         .enableEslintLoader()
      *         .enableVueLoader()
-     *         .configureLoaderRule('eslint', (loader) => {
-     *              loader.test = /\.(jsx?|vue)/;
+     *         .configureLoaderRule('eslint', (loaderRule) => {
+     *              loaderRule.test = /\.(jsx?|vue)/;
      *         });
      *
      * @param {string} name

--- a/index.js
+++ b/index.js
@@ -1101,6 +1101,32 @@ class Encore {
     }
 
     /**
+     * Configure Webpack loaders rules (`module.rules`).
+     * This is a low-level function, be careful when using it.
+     *
+     * https://webpack.js.org/concepts/loaders/#configuration
+     *
+     * For example, if you are using Vue and ESLint loader,
+     * this is how you can configure ESLint to lint Vue files:
+     *
+     *     Encore
+     *         .enableEslintLoader()
+     *         .enableVueLoader()
+     *         .configureLoaderRule('eslint', (loader) => {
+     *              loader.test = /\.(jsx?|vue)/;
+     *         });
+     *
+     * @param {string} name
+     * @param {function} callback
+     * @return {Encore}
+     */
+    configureLoaderRule(name, callback) {
+        webpackConfig.configureLoaderRule(name, callback);
+
+        return this;
+    }
+
+    /**
      * If enabled, the output directory is emptied between each build (to remove old files).
      *
      * A list of available options can be found at https://github.com/johnagan/clean-webpack-plugin

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -721,7 +721,7 @@ class WebpackConfig {
 
     configureLoaderRule(name, callback) {
         if (!(name in this.loaderConfigurationCallbacks)) {
-            throw new Error(`Loader "${name}" is not configurable. Either open an issue or a pull request.`);
+            throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}".`);
         }
 
         if (typeof callback !== 'function') {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -101,7 +101,20 @@ class WebpackConfig {
         this.tsConfigurationCallback = () => {};
         this.handlebarsConfigurationCallback = () => {};
         this.loaderConfigurationCallbacks = {
-            'eslint': () => {},
+            javascript: () => {},
+            js: () => {},
+            css: () => {},
+            images: () => {},
+            fonts: () => {},
+            sass: () => {},
+            scss: () => {},
+            less: () => {},
+            stylus: () => {},
+            vue: () => {},
+            eslint: () => {},
+            typescript: () => {},
+            ts: () => {},
+            handlebars: () => {},
         };
 
         // Plugins options

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -730,7 +730,7 @@ class WebpackConfig {
     }
 
     configureLoaderRule(name, callback) {
-        logger.warning('Be careful when using Encore.configureLoaderRule(), this is a low-level method that can potentially breaks Encore and Webpack when not used carefully.');
+        logger.warning('Be careful when using Encore.configureLoaderRule(), this is a low-level method that can potentially break Encore and Webpack when not used carefully.');
 
         // Key: alias, Value: existing loader in `this.loaderConfigurationCallbacks`
         const aliases = {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -733,6 +733,8 @@ class WebpackConfig {
     }
 
     configureLoaderRule(name, callback) {
+        logger.warning('Be careful when using Encore.configureLoaderRule(), this is a low-level method that can potentially breaks Encore and Webpack when not used carefully.');
+
         if (!(name in this.loaderConfigurationCallbacks)) {
             throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}".`);
         }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -102,18 +102,15 @@ class WebpackConfig {
         this.handlebarsConfigurationCallback = () => {};
         this.loaderConfigurationCallbacks = {
             javascript: () => {},
-            js: () => {},
             css: () => {},
             images: () => {},
             fonts: () => {},
             sass: () => {},
-            scss: () => {},
             less: () => {},
             stylus: () => {},
             vue: () => {},
             eslint: () => {},
             typescript: () => {},
-            ts: () => {},
             handlebars: () => {},
         };
 
@@ -735,8 +732,19 @@ class WebpackConfig {
     configureLoaderRule(name, callback) {
         logger.warning('Be careful when using Encore.configureLoaderRule(), this is a low-level method that can potentially breaks Encore and Webpack when not used carefully.');
 
+        // Key: alias, Value: existing loader in `this.loaderConfigurationCallbacks`
+        const aliases = {
+            js: 'javascript',
+            ts: 'typescript',
+            scss: 'sass',
+        };
+
+        if (name in aliases) {
+            name = aliases[name];
+        }
+
         if (!(name in this.loaderConfigurationCallbacks)) {
-            throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}".`);
+            throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}" and the aliases "${Object.keys(aliases).join('", "')}".`);
         }
 
         if (typeof callback !== 'function') {

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -100,6 +100,9 @@ class WebpackConfig {
         this.eslintLoaderOptionsCallback = () => {};
         this.tsConfigurationCallback = () => {};
         this.handlebarsConfigurationCallback = () => {};
+        this.loaderConfigurationCallbacks = {
+            'eslint': () => {},
+        };
 
         // Plugins options
         this.cleanWebpackPluginPaths = ['**/*'];
@@ -714,6 +717,18 @@ class WebpackConfig {
             jQuery: 'jquery',
             'window.jQuery': 'jquery',
         });
+    }
+
+    configureLoaderRule(name, callback) {
+        if (!(name in this.loaderConfigurationCallbacks)) {
+            throw new Error(`Loader "${name}" is not configurable. Either open an issue or a pull request.`);
+        }
+
+        if (typeof callback !== 'function') {
+            throw new Error('Argument 2 to configureLoaderRule() must be a callback function.');
+        }
+
+        this.loaderConfigurationCallbacks[name] = callback;
     }
 
     useDevServer() {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -357,13 +357,13 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useEslintLoader) {
-            rules.push({
+            rules.push(applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks['eslint'], {
                 test: /\.jsx?$/,
                 loader: 'eslint-loader',
                 exclude: /node_modules/,
                 enforce: 'pre',
                 options: eslintLoaderUtil.getOptions(this.webpackConfig)
-            });
+            }));
         }
 
         if (this.webpackConfig.useTypeScriptLoader) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -221,6 +221,14 @@ class ConfigGenerator {
     }
 
     buildRulesConfig() {
+        const applyRuleConfigurationCallback = (name, defaultRules) => {
+            if (!(name in this.webpackConfig.loaderConfigurationCallbacks)) {
+                throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.webpackConfig.loaderConfigurationCallbacks).join('", "')}".`);
+            }
+
+            return applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks[name], defaultRules);
+        };
+
         let rules = [
             {
                 // match .js and .jsx
@@ -357,7 +365,7 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useEslintLoader) {
-            rules.push(applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks['eslint'], {
+            rules.push(applyRuleConfigurationCallback('eslint', {
                 test: /\.jsx?$/,
                 loader: 'eslint-loader',
                 exclude: /node_modules/,

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -229,14 +229,24 @@ class ConfigGenerator {
             return applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks[name], defaultRules);
         };
 
+        const applyRuleConfigurationCallbacks = (names, defaultRules) => {
+            let rules = defaultRules;
+
+            names.forEach(name => {
+                rules = applyRuleConfigurationCallback(name, rules);
+            });
+
+            return rules;
+        };
+
         let rules = [
-            {
+            applyRuleConfigurationCallbacks(['javascript', 'js'], {
                 // match .js and .jsx
                 test: /\.jsx?$/,
                 exclude: this.webpackConfig.babelOptions.exclude,
                 use: babelLoaderUtil.getLoaders(this.webpackConfig)
-            },
-            {
+            }),
+            applyRuleConfigurationCallback('css', {
                 test: /\.css$/,
                 oneOf: [
                     {
@@ -253,7 +263,7 @@ class ConfigGenerator {
                         )
                     }
                 ]
-            }
+            })
         ];
 
         if (this.webpackConfig.useImagesLoader) {
@@ -277,11 +287,11 @@ class ConfigGenerator {
                 Object.assign(loaderOptions, this.webpackConfig.urlLoaderOptions.images);
             }
 
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('images', {
                 test: /\.(png|jpg|jpeg|gif|ico|svg|webp)$/,
                 loader: loaderName,
                 options: loaderOptions
-            });
+            }));
         }
 
         if (this.webpackConfig.useFontsLoader) {
@@ -305,15 +315,15 @@ class ConfigGenerator {
                 Object.assign(loaderOptions, this.webpackConfig.urlLoaderOptions.fonts);
             }
 
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('fonts', {
                 test: /\.(woff|woff2|ttf|eot|otf)$/,
                 loader: loaderName,
                 options: loaderOptions
-            });
+            }));
         }
 
         if (this.webpackConfig.useSassLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallbacks(['sass', 'scss'], {
                 test: /\.s[ac]ss$/,
                 oneOf: [
                     {
@@ -324,11 +334,11 @@ class ConfigGenerator {
                         use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig))
                     }
                 ]
-            });
+            }));
         }
 
         if (this.webpackConfig.useLessLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('less', {
                 test: /\.less/,
                 oneOf: [
                     {
@@ -339,11 +349,11 @@ class ConfigGenerator {
                         use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig))
                     }
                 ]
-            });
+            }));
         }
 
         if (this.webpackConfig.useStylusLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('stylus', {
                 test: /\.styl/,
                 oneOf: [
                     {
@@ -354,14 +364,14 @@ class ConfigGenerator {
                         use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig))
                     }
                 ]
-            });
+            }));
         }
 
         if (this.webpackConfig.useVueLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('vue', {
                 test: /\.vue$/,
                 use: vueLoaderUtil.getLoaders(this.webpackConfig)
-            });
+            }));
         }
 
         if (this.webpackConfig.useEslintLoader) {
@@ -375,18 +385,18 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useTypeScriptLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallbacks(['typescript', 'ts'], {
                 test: /\.tsx?$/,
                 exclude: /node_modules/,
                 use: tsLoaderUtil.getLoaders(this.webpackConfig)
-            });
+            }));
         }
 
         if (this.webpackConfig.useHandlebarsLoader) {
-            rules.push({
+            rules.push(applyRuleConfigurationCallback('handlebars', {
                 test: /\.(handlebars|hbs)$/,
                 use: handlebarsLoaderUtil.getLoaders(this.webpackConfig)
-            });
+            }));
         }
 
         this.webpackConfig.loaders.forEach((loader) => {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -222,25 +222,11 @@ class ConfigGenerator {
 
     buildRulesConfig() {
         const applyRuleConfigurationCallback = (name, defaultRules) => {
-            if (!(name in this.webpackConfig.loaderConfigurationCallbacks)) {
-                throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.webpackConfig.loaderConfigurationCallbacks).join('", "')}".`);
-            }
-
             return applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks[name], defaultRules);
         };
 
-        const applyRuleConfigurationCallbacks = (names, defaultRules) => {
-            let rules = defaultRules;
-
-            names.forEach(name => {
-                rules = applyRuleConfigurationCallback(name, rules);
-            });
-
-            return rules;
-        };
-
         let rules = [
-            applyRuleConfigurationCallbacks(['javascript', 'js'], {
+            applyRuleConfigurationCallback('javascript', {
                 // match .js and .jsx
                 test: /\.jsx?$/,
                 exclude: this.webpackConfig.babelOptions.exclude,
@@ -323,7 +309,7 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useSassLoader) {
-            rules.push(applyRuleConfigurationCallbacks(['sass', 'scss'], {
+            rules.push(applyRuleConfigurationCallback('sass', {
                 test: /\.s[ac]ss$/,
                 oneOf: [
                     {
@@ -385,7 +371,7 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.useTypeScriptLoader) {
-            rules.push(applyRuleConfigurationCallbacks(['typescript', 'ts'], {
+            rules.push(applyRuleConfigurationCallback('typescript', {
                 test: /\.tsx?$/,
                 exclude: /node_modules/,
                 use: tsLoaderUtil.getLoaders(this.webpackConfig)

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1160,8 +1160,8 @@ describe('WebpackConfig object', () => {
             const config = createConfig();
 
             expect(() => {
-                config.configureLoaderRule('vue');
-            }).to.throw('Loader "vue" is not configurable. Valid loaders are "eslint".');
+                config.configureLoaderRule('reason');
+            }).to.throw('Loader "reason" is not configurable. Valid loaders are "javascript", "js", "css", "images", "fonts", "sass", "scss", "less", "stylus", "vue", "eslint", "typescript", "ts", "handlebars".');
         });
 
         it('Call method with not a valid callback', () => {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1144,4 +1144,36 @@ describe('WebpackConfig object', () => {
             }).to.throw('Argument 1 to configureWatchOptions() must be a callback function.');
         });
     });
+
+    describe('configureLoaderRule()', () => {
+        it('works properly', () => {
+            const config = createConfig();
+            const callback = (loader) => {};
+
+            expect(config.loaderConfigurationCallbacks['eslint']).to.not.equal(callback);
+
+            config.configureLoaderRule('eslint', callback);
+            expect(config.loaderConfigurationCallbacks['eslint']).to.equal(callback);
+        });
+
+        it('Call method with a not supported loader', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureLoaderRule('vue');
+            }).to.throw('Loader "vue" is not configurable. Either open an issue or a pull request.');
+        });
+
+        it('Call method with not a valid callback', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureLoaderRule('eslint');
+            }).to.throw('Argument 2 to configureLoaderRule() must be a callback function.');
+
+            expect(() => {
+                config.configureLoaderRule('eslint', {});
+            }).to.throw('Argument 2 to configureLoaderRule() must be a callback function.');
+        });
+    });
 });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1161,7 +1161,7 @@ describe('WebpackConfig object', () => {
 
             expect(() => {
                 config.configureLoaderRule('reason');
-            }).to.throw('Loader "reason" is not configurable. Valid loaders are "javascript", "js", "css", "images", "fonts", "sass", "scss", "less", "stylus", "vue", "eslint", "typescript", "ts", "handlebars".');
+            }).to.throw('Loader "reason" is not configurable. Valid loaders are "javascript", "css", "images", "fonts", "sass", "less", "stylus", "vue", "eslint", "typescript", "handlebars" and the aliases "js", "ts", "scss".');
         });
 
         it('Call method with not a valid callback', () => {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1161,7 +1161,7 @@ describe('WebpackConfig object', () => {
 
             expect(() => {
                 config.configureLoaderRule('vue');
-            }).to.throw('Loader "vue" is not configurable. Either open an issue or a pull request.');
+            }).to.throw('Loader "vue" is not configurable. Valid loaders are "eslint".');
         });
 
         it('Call method with not a valid callback', () => {

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1089,25 +1089,25 @@ describe('The config-generator function', () => {
         it('configure rule for "sass"', () => {
             config.enableSassLoader();
             config.configureLoaderRule('sass', (loaderRule) => {
-                loaderRule.use[2].options.fooBar = 'fooBar';
+                loaderRule.oneOf[1].use[2].options.fooBar = 'fooBar';
             });
 
             const webpackConfig = configGenerator(config);
             const rule = findRule(/\.s[ac]ss$/, webpackConfig.module.rules);
 
-            expect(rule.use[2].options.fooBar).to.equal('fooBar');
+            expect(rule.oneOf[1].use[2].options.fooBar).to.equal('fooBar');
         });
 
         it('configure rule for the alias "scss"', () => {
             config.enableSassLoader();
             config.configureLoaderRule('scss', (loaderRule) => {
-                loaderRule.use[2].options.fooBar = 'fooBar';
+                loaderRule.oneOf[1].use[2].options.fooBar = 'fooBar';
             });
 
             const webpackConfig = configGenerator(config);
             const rule = findRule(/\.s[ac]ss$/, webpackConfig.module.rules);
 
-            expect(rule.use[2].options.fooBar).to.equal('fooBar');
+            expect(rule.oneOf[1].use[2].options.fooBar).to.equal('fooBar');
         });
 
         it('configure rule for "less"', () => {
@@ -1115,14 +1115,14 @@ describe('The config-generator function', () => {
                 options.optionA = 'optionA';
             });
             config.configureLoaderRule('less', (loaderRule) => {
-                loaderRule.use[2].options.optionB = 'optionB';
+                loaderRule.oneOf[1].use[2].options.optionB = 'optionB';
             });
 
             const webpackConfig = configGenerator(config);
             const rule = findRule(/\.less/, webpackConfig.module.rules);
 
-            expect(rule.use[2].options.optionA).to.equal('optionA');
-            expect(rule.use[2].options.optionB).to.equal('optionB');
+            expect(rule.oneOf[1].use[2].options.optionA).to.equal('optionA');
+            expect(rule.oneOf[1].use[2].options.optionB).to.equal('optionB');
         });
 
         it('configure rule for "stylus"', () => {
@@ -1130,14 +1130,14 @@ describe('The config-generator function', () => {
                 options.optionA = 'optionA';
             });
             config.configureLoaderRule('stylus', (loaderRule) => {
-                loaderRule.use[2].options.optionB = 'optionB';
+                loaderRule.oneOf[1].use[2].options.optionB = 'optionB';
             });
 
             const webpackConfig = configGenerator(config);
             const rule = findRule(/\.styl/, webpackConfig.module.rules);
 
-            expect(rule.use[2].options.optionA).to.equal('optionA');
-            expect(rule.use[2].options.optionB).to.equal('optionB');
+            expect(rule.oneOf[1].use[2].options.optionA).to.equal('optionA');
+            expect(rule.oneOf[1].use[2].options.optionB).to.equal('optionB');
         });
 
         it('configure rule for "vue"', () => {

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1014,4 +1014,30 @@ describe('The config-generator function', () => {
             });
         });
     });
+
+    describe('Test configureLoaderRule()', () => {
+        it('configure rule for "eslint"', () => {
+            const config = createConfig();
+            config.setPublicPath('/');
+            config.enableEslintLoader();
+            config.configureLoaderRule('eslint', (loader) => {
+                loader.test = /\.(jsx?|vue)/;
+            });
+
+            const webpackConfig = configGenerator(config);
+            const eslintLoader = webpackConfig.module.rules.find(rule => rule.loader === 'eslint-loader');
+
+            expect(eslintLoader).to.deep.equals({
+                test: /\.(jsx?|vue)/,
+                enforce: 'pre',
+                exclude: /node_modules/,
+                loader: 'eslint-loader',
+                options: {
+                    cache: true,
+                    emitWarning: true,
+                    parser: 'babel-eslint'
+                }
+            });
+        });
+    });
 });

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1016,18 +1016,26 @@ describe('The config-generator function', () => {
     });
 
     describe('Test configureLoaderRule()', () => {
-        it('configure rule for "eslint"', () => {
-            const config = createConfig();
+        let config;
+
+        const getLoader = (loaderName) => {
+            const webpackConfig = configGenerator(config);
+            return webpackConfig.module.rules.find(rule => rule.loader === loaderName);
+        };
+
+        beforeEach(() => {
+            config = createConfig();
+            config.outputPath = '/tmp/public/build';
             config.setPublicPath('/');
+        });
+
+        it('configure rule for "eslint"', () => {
             config.enableEslintLoader();
             config.configureLoaderRule('eslint', (loader) => {
                 loader.test = /\.(jsx?|vue)/;
             });
 
-            const webpackConfig = configGenerator(config);
-            const eslintLoader = webpackConfig.module.rules.find(rule => rule.loader === 'eslint-loader');
-
-            expect(eslintLoader).to.deep.equals({
+            expect(getLoader('eslint-loader')).to.deep.equals({
                 test: /\.(jsx?|vue)/,
                 enforce: 'pre',
                 exclude: /node_modules/,

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1025,11 +1025,23 @@ describe('The config-generator function', () => {
             config.enableSingleRuntimeChunk();
         });
 
-        it('configure rule for "javascript and "js"', () => {
+        it('configure rule for "javascript"', () => {
             config.configureLoaderRule('javascript', (loaderRule) => {
                 loaderRule.test = /\.m?js$/;
+                loaderRule.use[0].options.fooBar = 'fooBar';
             });
+
+            const webpackConfig = configGenerator(config);
+            const rule = findRule(/\.m?js$/, webpackConfig.module.rules);
+
+            expect('file.js').to.match(rule.test);
+            expect('file.mjs').to.match(rule.test);
+            expect(rule.use[0].options.fooBar).to.equal('fooBar');
+        });
+
+        it('configure rule for the alias "js"', () => {
             config.configureLoaderRule('js', (loaderRule) => {
+                loaderRule.test = /\.m?js$/;
                 loaderRule.use[0].options.fooBar = 'fooBar';
             });
 
@@ -1074,20 +1086,28 @@ describe('The config-generator function', () => {
             expect(rule.options.name).to.equal('dirname-fonts/[hash:42].[ext]');
         });
 
-        it('configure rule for "sass" and "scss"', () => {
+        it('configure rule for "sass"', () => {
             config.enableSassLoader();
             config.configureLoaderRule('sass', (loaderRule) => {
-                loaderRule.use.push('Option pushed when configuring Sass.');
-            });
-            config.configureLoaderRule('scss', (loaderRule) => {
-                loaderRule.use.push('Option pushed when configuring SCSS.');
+                loaderRule.use[2].options.fooBar = 'fooBar';
             });
 
             const webpackConfig = configGenerator(config);
             const rule = findRule(/\.s[ac]ss$/, webpackConfig.module.rules);
 
-            expect(rule.use.pop()).to.equal('Option pushed when configuring SCSS.');
-            expect(rule.use.pop()).to.equal('Option pushed when configuring Sass.');
+            expect(rule.use[2].options.fooBar).to.equal('fooBar');
+        });
+
+        it('configure rule for the alias "scss"', () => {
+            config.enableSassLoader();
+            config.configureLoaderRule('scss', (loaderRule) => {
+                loaderRule.use[2].options.fooBar = 'fooBar';
+            });
+
+            const webpackConfig = configGenerator(config);
+            const rule = findRule(/\.s[ac]ss$/, webpackConfig.module.rules);
+
+            expect(rule.use[2].options.fooBar).to.equal('fooBar');
         });
 
         it('configure rule for "less"', () => {
@@ -1159,8 +1179,20 @@ describe('The config-generator function', () => {
             config.configureLoaderRule('typescript', (loaderRule) => {
                 loaderRule.use[1].options.happyPackMode = true;
             });
+
+            const webpackConfig = configGenerator(config);
+            const rule = findRule(/\.tsx?$/, webpackConfig.module.rules);
+
+            expect(rule.use[1].options.silent).to.be.true;
+            expect(rule.use[1].options.happyPackMode).to.be.true;
+        });
+
+        it('configure rule for the alias "ts"', () => {
+            config.enableTypeScriptLoader((options) => {
+                options.silent = true;
+            });
             config.configureLoaderRule('ts', (loaderRule) => {
-                loaderRule.use[1].options.logInfoToStdOut = true;
+                loaderRule.use[1].options.happyPackMode = true;
             });
 
             const webpackConfig = configGenerator(config);
@@ -1168,7 +1200,6 @@ describe('The config-generator function', () => {
 
             expect(rule.use[1].options.silent).to.be.true;
             expect(rule.use[1].options.happyPackMode).to.be.true;
-            expect(rule.use[1].options.logInfoToStdOut).to.be.true;
         });
 
         it('configure rule for "handlebars"', () => {

--- a/test/loaders/eslint.js
+++ b/test/loaders/eslint.js
@@ -12,9 +12,7 @@
 const expect = require('chai').expect;
 const WebpackConfig = require('../../lib/WebpackConfig');
 const RuntimeConfig = require('../../lib/config/RuntimeConfig');
-const configGenerator = require('../../lib/config-generator');
 const eslintLoader = require('../../lib/loaders/eslint');
-const isWindows = (process.platform === 'win32');
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -78,30 +76,5 @@ describe('loaders/eslint', () => {
 
         const actualOptions = eslintLoader.getOptions(config);
         expect(actualOptions).to.deep.equals({ foo: true });
-    });
-
-    it('configure ESLint loader rule', () => {
-        const config = createConfig();
-        config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
-        config.setPublicPath('/');
-        config.enableEslintLoader();
-        config.configureLoaderRule('eslint', (loader) => {
-            loader.test = /\.(jsx?|vue)/;
-        });
-
-        const webpackConfig = configGenerator(config);
-        const eslintLoader = webpackConfig.module.rules.find(rule => rule.loader === 'eslint-loader');
-
-        expect(eslintLoader).to.deep.equals({
-            test: /\.(jsx?|vue)/,
-            enforce: 'pre',
-            exclude: /node_modules/,
-            loader: 'eslint-loader',
-            options: {
-                cache: true,
-                emitWarning: true,
-                parser: 'babel-eslint'
-            }
-        });
     });
 });


### PR DESCRIPTION
This PR is a proposal to resolve #473 and #504 in a clean way.

`Encore.configureLoaderRule()` is a low-level function, and has for goal to let the user having full access to Webpack loaders rules (what we push into `module.rules`) and configure them.

This is the implementation of the idea I had in https://github.com/symfony/webpack-encore/pull/504#discussion_r252145493.

For resolving Vue files linting issue, the next example would be the ideal solution  I think:
```js
Encore
  .configureLoaderRule('eslint', loader => {
    loader.test = /\.(jsx?|vue)$/
  });

// actually, the equivalent code is something like this:
const webpackConfig = Encore.getWebpackConfig();
const eslintLoader = webpackConfig.module.rules.find(rule => rule.loader === 'eslint-loader');

eslintLoader.test = /\.(jsx?|vue)$/;

return webpackConfig;
```

For now, only ESLint loader is supported, but we can easily add other loaders.

Let me know what you think of this solution, thanks!