### PR TITLE
Add CSS modules support in Vue.js for Sass/Less/Stylus

### DIFF
--- a/fixtures/vuejs-css-modules/App.vue
+++ b/fixtures/vuejs-css-modules/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="red" :class="$style.italic"></div>
+  <div id="app" class="red large justified lowercase" :class="[$css.italic, $scss.bold, $less.underline, $stylus.rtl]"></div>
 </template>
 
 <style>
@@ -8,8 +8,42 @@
   }
 </style>
 
-<style module>
+<style lang="scss">
+  .large {
+    font-size: 50px;
+  }
+</style>
+
+<style lang="less">
+  .justified {
+    text-align: justify;
+  }
+</style>
+
+<style lang="styl">
+  .lowercase
+    text-transform: lowercase
+</style>
+
+<style module="$css">
   .italic {
     font-style: italic;
   }
+</style>
+
+<style lang="scss" module="$scss">
+  .bold {
+    font-weight: bold;
+  }
+</style>
+
+<style lang="less" module="$less">
+  .underline {
+    text-decoration: underline;
+  }
+</style>
+
+<style lang="styl" module="$stylus">
+  .rtl
+    direction: rtl;
 </style>

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -306,21 +306,45 @@ class ConfigGenerator {
         if (this.webpackConfig.useSassLoader) {
             rules.push({
                 test: /\.s[ac]ss$/,
-                use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig))
+                oneOf: [
+                    {
+                        resourceQuery: /module/,
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig, true))
+                    },
+                    {
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig))
+                    }
+                ]
             });
         }
 
         if (this.webpackConfig.useLessLoader) {
             rules.push({
                 test: /\.less/,
-                use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig))
+                oneOf: [
+                    {
+                        resourceQuery: /module/,
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig, true))
+                    },
+                    {
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig))
+                    }
+                ]
             });
         }
 
         if (this.webpackConfig.useStylusLoader) {
             rules.push({
                 test: /\.styl/,
-                use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig))
+                oneOf: [
+                    {
+                        resourceQuery: /module/,
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig, true))
+                    },
+                    {
+                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig))
+                    }
+                ]
             });
         }
 

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -15,11 +15,11 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @param {bool} ignorePostCssLoader If true, postcss-loader will never be added
+ * @param {bool} useCssModules
  * @return {Array} of loaders to use for Less files
  */
 module.exports = {
-    getLoaders(webpackConfig, ignorePostCssLoader = false) {
+    getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('less');
 
         const config = {
@@ -27,7 +27,7 @@ module.exports = {
         };
 
         return [
-            ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),
+            ...cssLoader.getLoaders(webpackConfig, useCssModules),
             {
                 loader: 'less-loader',
                 options: applyOptionsCallback(webpackConfig.lessLoaderOptionsCallback, config)

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -15,14 +15,14 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @param {Object} sassOption Options to pass to the loader
+ * @param {bool} useCssModules
  * @return {Array} of loaders to use for Sass files
  */
 module.exports = {
-    getLoaders(webpackConfig, sassOptions = {}) {
+    getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('sass');
 
-        const sassLoaders = [...cssLoader.getLoaders(webpackConfig)];
+        const sassLoaders = [...cssLoader.getLoaders(webpackConfig, useCssModules)];
         if (true === webpackConfig.sassOptions.resolveUrlLoader) {
             // responsible for resolving Sass url() paths
             // without this, all url() paths must be relative to the
@@ -35,7 +35,7 @@ module.exports = {
             });
         }
 
-        const config = Object.assign({}, sassOptions, {
+        const config = Object.assign({}, {
             // needed by the resolve-url-loader
             sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps
         });

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -15,11 +15,11 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @param {bool} ignorePostCssLoader If true, postcss-loader will never be added
+ * @param {bool} useCssModules
  * @return {Array} of loaders to use for Stylus files
  */
 module.exports = {
-    getLoaders(webpackConfig, ignorePostCssLoader = false) {
+    getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stylus');
 
         const config = {
@@ -27,7 +27,7 @@ module.exports = {
         };
 
         return [
-            ...cssLoader.getLoaders(webpackConfig, ignorePostCssLoader),
+            ...cssLoader.getLoaders(webpackConfig, useCssModules),
             {
                 loader: 'stylus-loader',
                 options: applyOptionsCallback(webpackConfig.stylusLoaderOptionsCallback, config)

--- a/test/functional.js
+++ b/test/functional.js
@@ -1354,7 +1354,7 @@ module.exports = {
             });
         });
 
-        it('Vue.js supports CSS modules', (done) => {
+        it('Vue.js supports CSS/Sass/Less/Stylus modules', (done) => {
             const appDir = testSetup.createTestAppDir();
             const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
             config.enableSingleRuntimeChunk();
@@ -1363,6 +1363,7 @@ module.exports = {
             config.enableVueLoader();
             config.enableSassLoader();
             config.enableLessLoader();
+            config.enableStylusLoader();
             config.configureCssLoader(options => {
                 // Remove hashes from local ident names
                 // since they are not always the same.
@@ -1378,17 +1379,22 @@ module.exports = {
                     'runtime.js',
                 ]);
 
-                // Standard CSS
-                webpackAssert.assertOutputFileContains(
-                    'main.css',
-                    '.red {'
-                );
+                const expectClassDeclaration = (className) => {
+                    webpackAssert.assertOutputFileContains(
+                        'main.css',
+                        `.${className} {`
+                    );
+                };
 
-                // CSS modules
-                webpackAssert.assertOutputFileContains(
-                    'main.css',
-                    '.italic_foo {'
-                );
+                expectClassDeclaration('red'); // Standard CSS
+                expectClassDeclaration('large'); // Standard SCSS
+                expectClassDeclaration('justified'); // Standard Less
+                expectClassDeclaration('lowercase'); // Standard Stylus
+
+                expectClassDeclaration('italic_foo'); // CSS Module
+                expectClassDeclaration('bold_foo'); // SCSS Module
+                expectClassDeclaration('underline_foo'); // Less Module
+                expectClassDeclaration('rtl_foo'); // Stylus Module
 
                 testSetup.requestTestPage(
                     path.join(config.getContext(), 'www'),
@@ -1397,11 +1403,15 @@ module.exports = {
                         'build/main.js'
                     ],
                     (browser) => {
-                        // Standard CSS
-                        browser.assert.hasClass('#app', 'red');
+                        browser.assert.hasClass('#app', 'red'); // Standard CSS
+                        browser.assert.hasClass('#app', 'large'); // Standard SCSS
+                        browser.assert.hasClass('#app', 'justified'); // Standard Less
+                        browser.assert.hasClass('#app', 'lowercase'); // Standard Stylus
 
-                        // CSS modules
-                        browser.assert.hasClass('#app', 'italic_foo');
+                        browser.assert.hasClass('#app', 'italic_foo'); // CSS module
+                        browser.assert.hasClass('#app', 'bold_foo'); // SCSS module
+                        browser.assert.hasClass('#app', 'underline_foo'); // Less module
+                        browser.assert.hasClass('#app', 'rtl_foo'); // Stylus module
 
                         done();
                     }

--- a/test/loaders/less.js
+++ b/test/loaders/less.js
@@ -30,12 +30,13 @@ describe('loaders/less', () => {
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        sinon.stub(cssLoader, 'getLoaders')
+        const cssLoaderStub = sinon.stub(cssLoader, 'getLoaders')
             .callsFake(() => []);
 
         const actualLoaders = lessLoader.getLoaders(config);
         expect(actualLoaders).to.have.lengthOf(1);
         expect(actualLoaders[0].options.sourceMap).to.be.true;
+        expect(cssLoaderStub.getCall(0).args[1]).to.be.false;
 
         cssLoader.getLoaders.restore();
     });
@@ -79,6 +80,22 @@ describe('loaders/less', () => {
 
         const actualLoaders = lessLoader.getLoaders(config);
         expect(actualLoaders[0].options).to.deep.equals({ foo: true });
+        cssLoader.getLoaders.restore();
+    });
+
+    it('getLoaders() with CSS modules enabled', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        // make the cssLoader return nothing
+        const cssLoaderStub = sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        const actualLoaders = lessLoader.getLoaders(config, true);
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options.sourceMap).to.be.true;
+        expect(cssLoaderStub.getCall(0).args[1]).to.be.true;
+
         cssLoader.getLoaders.restore();
     });
 });

--- a/test/loaders/stylus.js
+++ b/test/loaders/stylus.js
@@ -30,12 +30,13 @@ describe('loaders/stylus', () => {
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        sinon.stub(cssLoader, 'getLoaders')
+        const cssLoaderStub = sinon.stub(cssLoader, 'getLoaders')
             .callsFake(() => []);
 
         const actualLoaders = stylusLoader.getLoaders(config);
         expect(actualLoaders).to.have.lengthOf(1);
         expect(actualLoaders[0].options.sourceMap).to.be.true;
+        expect(cssLoaderStub.getCall(0).args[1]).to.be.false;
 
         cssLoader.getLoaders.restore();
     });
@@ -79,6 +80,22 @@ describe('loaders/stylus', () => {
 
         const actualLoaders = stylusLoader.getLoaders(config);
         expect(actualLoaders[0].options).to.deep.equals({ foo: true });
+        cssLoader.getLoaders.restore();
+    });
+
+    it('getLoaders() with CSS modules enabled', () => {
+        const config = createConfig();
+        config.enableSourceMaps(true);
+
+        // make the cssLoader return nothing
+        const cssLoaderStub = sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        const actualLoaders = stylusLoader.getLoaders(config, true);
+        expect(actualLoaders).to.have.lengthOf(1);
+        expect(actualLoaders[0].options.sourceMap).to.be.true;
+        expect(cssLoaderStub.getCall(0).args[1]).to.be.true;
+
         cssLoader.getLoaders.restore();
     });
 });


### PR DESCRIPTION
As noted in https://github.com/symfony/webpack-encore/pull/508#issuecomment-460426555, that previous PR actually only added support for standard CSS modules, but didn't work for other languages.

This new PR makes it so it also works with the Scss, Less and Stylus syntaxes (using the same principle).

Ping @Chesskingt :)