### PR TITLE
Don't use babel-loader's cacheDirectory for production

### DIFF
--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -20,9 +20,12 @@ module.exports = {
     getLoaders(webpackConfig) {
         let babelConfig = {
             // improves performance by caching babel compiles
-            // we add this option ALWAYS
+            // this option is always added but is set to FALSE in
+            // production to avoid cache invalidation issues caused
+            // by some Babel presets/plugins (for instance the ones
+            // that use browserslist)
             // https://github.com/babel/babel-loader#options
-            cacheDirectory: true
+            cacheDirectory: !webpackConfig.isProduction()
         };
 
         // configure babel (unless the user is specifying .babelrc)

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -49,6 +49,18 @@ describe('loaders/babel', () => {
         });
     });
 
+    it('getLoaders() for production', () => {
+        const config = createConfig();
+        config.runtimeConfig.babelRcFileExists = true;
+        config.runtimeConfig.environment = 'production';
+
+        const actualLoaders = babelLoader.getLoaders(config);
+        // cacheDirectory is disabled in production mode
+        expect(actualLoaders[0].options).to.deep.equal({
+            cacheDirectory: false
+        });
+    });
+
     it('getLoaders() with react', () => {
         const config = createConfig();
         config.enableReactPreset();


### PR DESCRIPTION
Currently `cacheDirectory` is always set to `true` in `babel-loader`'s options.

This can be an issue because the cache identifier is only based on direct Babel options, but not on external configs such as `.browserslistrc` files or if a `browserslist` key was added to the `package.json` (see https://github.com/babel/babel-loader/issues/690).

Disabling that cache entirely in Encore while waiting for a proper solution in `babel` or `babel-loader` would probably not be a good idea, but we could mitigate the problem by disabling it only for the prod environment.

Closes #514