### PR TITLE
Allow to set a custom context in copyFiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,7 +493,8 @@ class Encore {
      *          { from: './txt', pattern: /\.txt$/ },
      *      ]);
      *
-     *      // Set the context path
+     *      // Set the context path: files will be copied
+     *      // into an images/ directory in the output dir
      *      Encore.copyFiles({
      *          from: './assets/images',
      *          to: '[path][name].[hash:8].[ext]',

--- a/index.js
+++ b/index.js
@@ -493,6 +493,13 @@ class Encore {
      *          { from: './txt', pattern: /\.txt$/ },
      *      ]);
      *
+     *      // Set the context path
+     *      Encore.copyFiles({
+     *          from: './assets/images',
+     *          to: '[path][name].[hash:8].[ext]',
+     *          context: './assets'
+     *      });
+     *
      * Notes:
      *      * No transformation is applied to the copied files (for instance
      *        copying a CSS file won't minify it)
@@ -508,6 +515,8 @@ class Encore {
      *              https://github.com/webpack-contrib/file-loader#placeholders
      *      * {boolean} includeSubdirectories (default: true)
      *              Whether or not the copy should include subdirectories.
+     *      * {string} context (default: path of the source directory)
+     *              The context to use as a root path when copying files.
      *
      * @param {object|Array} configs
      * @returns {Encore}

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -437,7 +437,8 @@ class WebpackConfig {
             from: null,
             pattern: /.*/,
             to: null,
-            includeSubdirectories: true
+            includeSubdirectories: true,
+            context: null,
         };
 
         for (const config of configs) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -183,7 +183,8 @@ class ConfigGenerator {
                         copyTo = this.webpackConfig.useVersioning ? '[path][name].[hash:8].[ext]' : '[path][name].[ext]';
                     }
 
-                    const requireContextParam = `!${require.resolve('file-loader')}?context=${copyFrom}&name=${copyTo}!${copyFrom}`;
+                    const copyContext = entry.context ? path.resolve(this.webpackConfig.getContext(), entry.context) : copyFrom;
+                    const requireContextParam = `!${require.resolve('file-loader')}?context=${copyContext}&name=${copyTo}!${copyFrom}`;
 
                     return buffer + `
                         const context_${index} = require.context(

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -394,17 +394,20 @@ describe('WebpackConfig object', () => {
                 from: './foo',
                 pattern: /.*/,
                 to: null,
-                includeSubdirectories: true
+                includeSubdirectories: true,
+                context: null,
             }, {
                 from: './bar',
                 pattern: /abc/,
                 to: 'bar',
-                includeSubdirectories: false
+                includeSubdirectories: false,
+                context: null,
             }, {
                 from: './baz',
                 pattern: /.*/,
                 to: null,
-                includeSubdirectories: true
+                includeSubdirectories: true,
+                context: null,
             }]);
         });
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -1823,6 +1823,61 @@ module.exports = {
                     done();
                 });
             });
+
+            it('Copy with a custom context', (done) => {
+                const config = createWebpackConfig('www/build', 'production');
+                config.addEntry('main', './js/no_require');
+                config.setPublicPath('/build');
+                config.copyFiles({
+                    from: './images',
+                    to: '[path][name].[hash:8].[ext]',
+                    includeSubdirectories: true,
+                    context: './',
+                });
+
+                testSetup.runWebpack(config, (webpackAssert) => {
+                    expect(config.outputPath).to.be.a.directory()
+                        .with.files([
+                            'entrypoints.json',
+                            'runtime.js',
+                            'main.js',
+                            'manifest.json',
+                        ]);
+
+                    expect(path.join(config.outputPath, 'images')).to.be.a.directory()
+                        .with.files([
+                            'symfony_logo.ea1ca6f7.png',
+                            'symfony_logo_alt.f27119c2.png',
+                        ]);
+
+                    expect(path.join(config.outputPath, 'images', 'same_filename')).to.be.a.directory()
+                        .with.files([
+                            'symfony_logo.f27119c2.png',
+                        ]);
+
+                    webpackAssert.assertManifestPath(
+                        'build/main.js',
+                        '/build/main.js'
+                    );
+
+                    webpackAssert.assertManifestPath(
+                        'build/images/symfony_logo.png',
+                        '/build/images/symfony_logo.ea1ca6f7.png'
+                    );
+
+                    webpackAssert.assertManifestPath(
+                        'build/images/symfony_logo_alt.png',
+                        '/build/images/symfony_logo_alt.f27119c2.png'
+                    );
+
+                    webpackAssert.assertManifestPath(
+                        'build/images/same_filename/symfony_logo.png',
+                        '/build/images/same_filename/symfony_logo.f27119c2.png'
+                    );
+
+                    done();
+                });
+            });
         });
 
         describe('entrypoints.json & splitChunks()', () => {


### PR DESCRIPTION
The current behavior of `copyFiles()` is to use the value of the `from` option as a context when copying files.

This means that when doing the following:

```js
Encore.copyFiles({
  from: './assets/images',
  to: '[path][name].[ext]',
  includeSubdirectories: false,
});
```

Will end-up putting all the files from `./assets/images` directly at the root of the output directory.

Sometimes this is not the desired behavior (see https://github.com/symfony/webpack-encore/issues/490#issuecomment-453982520) which is why this PRs adds a `context` option to `copyFiles()` entries (closes #490).

For instance:

```js
Encore.copyFiles({
  from: './assets/images',
  to: '[path][name].[ext]',
  includeSubdirectories: false,
  context: './',
});
```

Will put all the copied files inside of an `./assets/images` folder in the output directory.