### PR TITLE
Improve 'Install x to use y' and 'Unrecognized method' error messages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1279,7 +1279,13 @@ const EncoreProxy = new Proxy(new Encore(), {
             // Find the property with the closest Levenshtein distance
             let similarProperty;
             let minDistance = Number.MAX_VALUE;
-            for (const apiProperty in target) {
+
+            for (const apiProperty of Object.getOwnPropertyNames(Encore.prototype)) {
+                // Ignore class constructor
+                if (apiProperty === 'constructor') {
+                    continue;
+                }
+
                 const distance = levenshtein.get(apiProperty, prop);
                 if (distance <= minDistance) {
                     similarProperty = apiProperty;
@@ -1292,8 +1298,14 @@ const EncoreProxy = new Proxy(new Encore(), {
                 errorMessage += ` Did you mean ${chalk.green(`Encore.${similarProperty}`)}?`;
             }
 
+            // Prettify the error message.
+            // Only keep the 2nd line of the stack trace:
+            // - First line should be this file (index.js)
+            // - Second line should be the Webpack config file
+            const pe = new PrettyError();
+            pe.skip((traceLine, lineNumber) => lineNumber !== 1);
             const error = new Error(errorMessage);
-            console.log(new PrettyError().render(error));
+            console.log(pe.render(error));
             process.exit(1); // eslint-disable-line
         }
 

--- a/lib/package-helper.js
+++ b/lib/package-helper.js
@@ -18,11 +18,10 @@ function ensurePackagesExist(packagesConfig, requestedFeature) {
     const missingPackagesRecommendation = getMissingPackageRecommendations(packagesConfig, requestedFeature);
 
     if (missingPackagesRecommendation) {
-        throw new Error(`
+        throw `
 ${missingPackagesRecommendation.message}
   ${missingPackagesRecommendation.installCommand}
-`
-        );
+`;
     }
 
     // check for invalid versions & warn

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -193,4 +193,41 @@ module.exports = Encore.getWebpackConfig();
             done();
         });
     });
+
+    it('Display an error when calling an unknown method', (done) => {
+        testSetup.emptyTmpDir();
+        const testDir = testSetup.createTestAppDir();
+
+        fs.writeFileSync(
+            path.join(testDir, 'package.json'),
+            `{
+                "devDependencies": {
+                    "@symfony/webpack-encore": "*"
+                }
+            }`
+        );
+
+        fs.writeFileSync(
+            path.join(testDir, 'webpack.config.js'),
+            `
+const Encore = require('../../index.js');
+Encore
+    .setOutputPath('build/')
+    .setPublicPath('/build')
+    .enableSingleRuntimeChuck()
+    .addEntry('main', './js/no_require')
+;
+
+module.exports = Encore.getWebpackConfig();
+            `
+        );
+
+        const binPath = path.resolve(__dirname, '../', '../', 'bin', 'encore.js');
+        exec(`node ${binPath} dev --context=${testDir}`, { cwd: testDir }, (err, stdout, stderr) => {
+            expect(err).not.to.be.null;
+            expect(stdout).to.contain('is not a recognized property or method');
+            expect(stdout).to.contain('Did you mean');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR:

- Removes the stacktrace from the "_Install x to use y_" error message by throwing a string instead of an `Error` (fixes #420)
- Only keeps the second line of the stacktrace for the "_Unrecognized method_" error message (since this is most likely the one related to the `webpack.config.js` file)
- Fixes the "_Did you mean xxxx_" advice that was broken since the `Encore` object became a `class`

---

**Install x to use y**

Before: 
![2019-02-11_16-43-47](https://user-images.githubusercontent.com/850046/52579209-03450280-2e26-11e9-81a0-712ef6cec5fd.png)

After:
![2019-02-11_16-42-13](https://user-images.githubusercontent.com/850046/52579241-0fc95b00-2e26-11e9-8bf4-9c98d628bff7.png)

---

**Unrecognized method**

Before:
![2019-02-11_16-44-43](https://user-images.githubusercontent.com/850046/52579263-1952c300-2e26-11e9-8e68-b489089ad383.png)

After:
![2019-02-11_16-41-18](https://user-images.githubusercontent.com/850046/52579286-22dc2b00-2e26-11e9-8011-13807d33870b.png)

