### PR TITLE
Add an enableIntegrityHashes() method to the public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1145,6 +1145,40 @@ class Encore {
     }
 
     /**
+     * If enabled, add integrity hashes to the entrypoints.json
+     * file for all the files it references.
+     *
+     * These hashes can then be used, for instance, in the "integrity"
+     * attributes of <script> and <style> tags to enable subresource-
+     * integrity checks in the browser.
+     *
+     * https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+     *
+     * For example:
+     *
+     *     Encore.enableIntegrityHashes(
+     *         Encore.isProduction(),
+     *         'sha384'
+     *     );
+     *
+     * Or with multiple algorithms:
+     *
+     *     Encore.enableIntegrityHashes(
+     *         Encore.isProduction(),
+     *         ['sha256', 'sha384', 'sha512']
+     *     );
+     *
+     * @param {bool} enabled
+     * @param {string|Array} algorithms
+     * @returns {Encore}
+     */
+    enableIntegrityHashes(enabled = true, algorithms = ['sha384']) {
+        webpackConfig.enableIntegrityHashes(enabled, algorithms);
+
+        return this;
+    }
+
+    /**
      * Is this currently a "production" build?
      *
      * @returns {boolean}

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -11,6 +11,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 const logger = require('./logger');
 
 /**
@@ -48,6 +49,7 @@ class WebpackConfig {
         this.configuredFilenames = {};
         this.aliases = {};
         this.externals = [];
+        this.integrityAlgorithms = [];
 
         // Features/Loaders flags
         this.useVersioning = false;
@@ -748,6 +750,25 @@ class WebpackConfig {
         }
 
         this.loaderConfigurationCallbacks[name] = callback;
+    }
+
+    enableIntegrityHashes(enabled = true, algorithms = ['sha384']) {
+        if (!Array.isArray(algorithms)) {
+            algorithms = [algorithms];
+        }
+
+        const availableHashes = crypto.getHashes();
+        for (const algorithm of algorithms) {
+            if (typeof algorithm !== 'string') {
+                throw new Error('Argument 2 to enableIntegrityHashes() must be a string or an array of strings.');
+            }
+
+            if (!availableHashes.includes(algorithm)) {
+                throw new Error(`Invalid hash algorithm "${algorithm}" passed to enableIntegrityHashes().`);
+            }
+        }
+
+        this.integrityAlgorithms = enabled ? algorithms : [];
     }
 
     useDevServer() {

--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -13,32 +13,71 @@ const PluginPriorities = require('./plugin-priorities');
 const sharedEntryTmpName = require('../utils/sharedEntryTmpName');
 const copyEntryTmpName = require('../utils/copyEntryTmpName');
 const AssetsPlugin = require('assets-webpack-plugin');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 
-function processOutput(assets) {
-    for (const entry of [copyEntryTmpName, sharedEntryTmpName]) {
-        delete assets[entry];
-    }
+function processOutput(webpackConfig) {
+    return (assets) => {
+        for (const entry of [copyEntryTmpName, sharedEntryTmpName]) {
+            delete assets[entry];
+        }
 
-    // with --watch or dev-server, subsequent calls will include
-    // the original assets (so, assets.entrypoints) + the new
-    // assets (which will have their original structure). We
-    // delete the entrypoints key, and then process the new assets
-    // like normal below
-    delete assets.entrypoints;
+        // with --watch or dev-server, subsequent calls will include
+        // the original assets (so, assets.entrypoints) + the new
+        // assets (which will have their original structure). We
+        // delete the entrypoints key, and then process the new assets
+        // like normal below
+        delete assets.entrypoints;
 
-    // This will iterate over all the entry points and convert the
-    // one file entries into an array of one entry since that was how the entry point file was before this change.
-    for (const asset in assets) {
-        for (const fileType in assets[asset]) {
-            if (!Array.isArray(assets[asset][fileType])) {
-                assets[asset][fileType] = [assets[asset][fileType]];
+        // This will iterate over all the entry points and convert the
+        // one file entries into an array of one entry since that was how the entry point file was before this change.
+        const integrity = {};
+        const integrityAlgorithms = webpackConfig.integrityAlgorithms;
+        const publicPath = webpackConfig.getRealPublicPath();
+
+        for (const asset in assets) {
+            for (const fileType in assets[asset]) {
+                if (!Array.isArray(assets[asset][fileType])) {
+                    assets[asset][fileType] = [assets[asset][fileType]];
+                }
+
+                if (integrityAlgorithms.length) {
+                    for (const file of assets[asset][fileType]) {
+                        if (file in integrity) {
+                            continue;
+                        }
+
+                        const filePath = path.resolve(
+                            webpackConfig.outputPath,
+                            file.replace(publicPath, '')
+                        );
+
+                        if (fs.existsSync(filePath)) {
+                            const fileHashes = [];
+
+                            for (const algorithm of webpackConfig.integrityAlgorithms) {
+                                const hash = crypto.createHash(algorithm);
+                                const fileContent = fs.readFileSync(filePath, 'utf8');
+                                hash.update(fileContent, 'utf8');
+
+                                fileHashes.push(`${algorithm}-${hash.digest('base64')}`);
+                            }
+
+                            integrity[file] = fileHashes.join(' ');
+                        }
+                    }
+                }
             }
         }
-    }
 
-    return JSON.stringify({
-        entrypoints: assets
-    }, null, 2);
+        const manifestContent = { entrypoints: assets };
+        if (integrityAlgorithms.length) {
+            manifestContent.integrity = integrity;
+        }
+
+        return JSON.stringify(manifestContent, null, 2);
+    };
 }
 
 /**
@@ -53,7 +92,7 @@ module.exports = function(plugins, webpackConfig) {
             filename: 'entrypoints.json',
             includeAllFileTypes: true,
             entrypoints: true,
-            processOutput: processOutput
+            processOutput: processOutput(webpackConfig)
         }),
         priority: PluginPriorities.AssetsPlugin
     });

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1173,4 +1173,42 @@ describe('WebpackConfig object', () => {
             }).to.throw('Argument 2 to configureLoaderRule() must be a callback function.');
         });
     });
+
+    describe('enableIntegrityHashes', () => {
+        it('Calling it without any option', () => {
+            const config = createConfig();
+            config.enableIntegrityHashes();
+
+            expect(config.integrityAlgorithms).to.deep.equal(['sha384']);
+        });
+
+        it('Calling it without false as a first argument disables it', () => {
+            const config = createConfig();
+            config.enableIntegrityHashes(false, 'sha1');
+
+            expect(config.integrityAlgorithms).to.deep.equal([]);
+        });
+
+        it('Calling it with a single algorithm', () => {
+            const config = createConfig();
+            config.enableIntegrityHashes(true, 'sha1');
+
+            expect(config.integrityAlgorithms).to.deep.equal(['sha1']);
+        });
+
+        it('Calling it with multiple algorithms', () => {
+            const config = createConfig();
+            config.enableIntegrityHashes(true, ['sha1', 'sha256', 'sha512']);
+
+            expect(config.integrityAlgorithms).to.deep.equal(['sha1', 'sha256', 'sha512']);
+        });
+
+        it('Calling it with an invalid algorithm', () => {
+            const config = createConfig();
+            expect(() => config.enableIntegrityHashes(true, {})).to.throw('must be a string or an array of strings');
+            expect(() => config.enableIntegrityHashes(true, [1])).to.throw('must be a string or an array of strings');
+            expect(() => config.enableIntegrityHashes(true, 'foo')).to.throw('Invalid hash algorithm "foo"');
+            expect(() => config.enableIntegrityHashes(true, ['sha1', 'foo', 'sha256'])).to.throw('Invalid hash algorithm "foo"');
+        });
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -414,6 +414,15 @@ describe('Public API', () => {
 
     });
 
+    describe('enableIntegrityHashes', () => {
+
+        it('should return the API object', () => {
+            const returnedValue = api.enableIntegrityHashes();
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
     describe('isRuntimeEnvironmentConfigured', () => {
 
         it('should return true if the runtime environment has been configured', () => {


### PR DESCRIPTION
This PR adds an `Encore.enableIntegrityHashes()` method that allows to compute integrity hashes of all the files referenced in the `entrypoints.json` (closes #418).

For instance:

```js
// Enable it for all builds with the
// default hash algorithm (sha384)
Encore.enableIntegrityHashes();

// Enable it only in production with
// a custom hash algorithm
Encore.enableIntegrityHashes(
    Encore.isProduction(),
    'sha512'
);
```

And here is the resulting `entrypoints.json` file:
```json
{
  "entrypoints": {
    "main": {
      "css": [
        "/main.3d1dcb7e.css"
      ],
      "js": [
        "/main.7c6b7c81.js"
      ]
    }
  },
  "integrity": {
    "/main.3d1dcb7e.css": "sha384-ce7d1nV3CFoSIfinwm53befb9CMHNAAlPEb61deOf3zBvpXK9lct44/U2ieSOKt4",
    "/main.7c6b7c81.js": "sha384-kHFhNTJlbSuDijSTimOHZGTxKzlLYCWc03AmmRSAE3b173SMlGiQG6uasAzl29+0"
  }
}
```