### PR TITLE
Ignore hot-update files in the SharedEntryConcatPlugin

### DIFF
--- a/lib/webpack/shared-entry-concat-plugin.js
+++ b/lib/webpack/shared-entry-concat-plugin.js
@@ -18,13 +18,14 @@ function SharedEntryConcatPlugin(sharedEntryName) {
 
 function getChunkFilename(compilation, chunkName) {
     const chunk = compilation.namedChunks.get(chunkName);
+    const additionalChunkAssets = compilation.additionalChunkAssets || [];
 
     if (!chunk) {
         throw new Error(`Cannot find chunk ${chunkName}`);
     }
 
     const jsFiles = chunk.files.filter(filename => {
-        return /\.js$/.test(filename);
+        return /\.js$/.test(filename) && !additionalChunkAssets.includes(filename);
     });
 
     if (jsFiles.length !== 1) {

--- a/lib/webpack/shared-entry-concat-plugin.js
+++ b/lib/webpack/shared-entry-concat-plugin.js
@@ -18,6 +18,7 @@ function SharedEntryConcatPlugin(sharedEntryName) {
 
 function getChunkFilename(compilation, chunkName) {
     const chunk = compilation.namedChunks.get(chunkName);
+    // any "additional" files - like .hot-update.js when using --hot
     const additionalChunkAssets = compilation.additionalChunkAssets || [];
 
     if (!chunk) {


### PR DESCRIPTION
This PR fixes #493.

When using `dev-server --hot` an additional `.hot-update.js` file can be [added to the list of files associated to a chunk](https://github.com/webpack/webpack/blob/7076c05353bae6d788247cfcaa94704f34cca292/lib/HotModuleReplacementPlugin.js#L287). If that list contains another JS file the current version of Encore throws an Error that causes the compilation to fail.

The good news is that the `.hot-update.js` file is also [added to the `additionalChunkAssets`](https://github.com/webpack/webpack/blob/7076c05353bae6d788247cfcaa94704f34cca292/lib/HotModuleReplacementPlugin.js#L284) property of the `compilation` object. This allows us to ignore it and only keep the JS file that we need.


