### PR TITLE
Allow setOutputPath to create nested directories

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -129,11 +129,23 @@ class WebpackConfig {
         }
 
         if (!fs.existsSync(outputPath)) {
-            // for safety, we won't recursively create directories
-            // this might be a sign that the user has specified
-            // an incorrect path
-            if (!fs.existsSync(path.dirname(outputPath))) {
-                throw new Error(`outputPath directory does not exist: ${outputPath}. Please check the path you're passing to setOutputPath() or create this directory`);
+            // If the parent of the output directory does not exist either
+            // check if it is located under the context directory before
+            // creating it and its parent.
+            const parentPath = path.dirname(outputPath);
+            if (!fs.existsSync(parentPath)) {
+                const context = path.resolve(this.getContext());
+                if (outputPath.indexOf(context) !== 0) {
+                    throw new Error(`outputPath directory "${outputPath}" does not exist and is not located under the context directory "${context}". Please check the path you're passing to setOutputPath() or create this directory.`);
+                }
+
+                parentPath.split(path.sep).reduce((previousPath, directory) => {
+                    const newPath = path.resolve(previousPath, directory);
+                    if (!fs.existsSync(newPath)) {
+                        fs.mkdirSync(newPath);
+                    }
+                    return newPath;
+                }, path.sep);
             }
 
             fs.mkdirSync(outputPath);


### PR DESCRIPTION
This PR changes the check that is currently made when calling `setOutputPath` in order to allow the creation of nested directories (closes #189).

Note that it doesn't remove it entirely since it still prevents the creation of more than one level when the output path is located outside of the context path.

For instance, given the context is `/home/foo/bar/`:

```js
// Will work
Encore.setOutputPath('build');

// Will work, even if "/home/foo/bar/public" does not exist
Encore.setOutputPath('public/build/output');

// Will work, even if "/home/foo/public" does not exist
Encore.setOutputPath('../public');

// Will work if only "/home/foo/public/build" does not exist
// ... but **won't** work if "/home/foo/public" does not exist
Encore.setOutputPath('../public/build');
```
