### PR TITLE
Fix the color of error messages when they are displayed on a light theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
 const WebpackConfig = require('./lib/WebpackConfig');
 const configGenerator = require('./lib/config-generator');
 const validator = require('./lib/config/validator');
-const PrettyError = require('pretty-error');
+const prettyError = require('./lib/utils/pretty-error');
 const logger = require('./lib/logger');
 const parseRuntime = require('./lib/config/parse-runtime');
 const chalk = require('chalk');
@@ -1289,10 +1289,7 @@ const EncoreProxy = new Proxy(new Encore(), {
                     const res = target[prop](...parameters);
                     return (res === target) ? EncoreProxy : res;
                 } catch (error) {
-                    // prettifies errors thrown by our library
-                    const pe = new PrettyError();
-
-                    console.log(pe.render(error));
+                    prettyError(error);
                     process.exit(1); // eslint-disable-line
                 }
             };
@@ -1325,10 +1322,11 @@ const EncoreProxy = new Proxy(new Encore(), {
             // Only keep the 2nd line of the stack trace:
             // - First line should be this file (index.js)
             // - Second line should be the Webpack config file
-            const pe = new PrettyError();
-            pe.skip((traceLine, lineNumber) => lineNumber !== 1);
-            const error = new Error(errorMessage);
-            console.log(pe.render(error));
+            prettyError(
+                new Error(errorMessage),
+                { skipTrace: (traceLine, lineNumber) => lineNumber !== 1 }
+            );
+
             process.exit(1); // eslint-disable-line
         }
 

--- a/lib/utils/pretty-error.js
+++ b/lib/utils/pretty-error.js
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const PrettyError = require('pretty-error');
+
+/**
+ * Render a pretty version of the given error.
+ *
+ * Supported options:
+ *      * {function} skipTrace
+ *              An optional callback that defines whether
+ *              or not each line of the eventual stacktrace
+ *              should be kept. First argument is the content
+ *              of the line, second argument is the line number.
+ *
+ * @param {*} error
+ * @param {object} options
+ *
+ * @returns {void}
+ */
+module.exports = function(error, options = {}) {
+    const pe = new PrettyError();
+
+    // Use the default terminal's color
+    // for the error message.
+    pe.appendStyle({
+        'pretty-error > header > message': { color: 'none' }
+    });
+
+    // Allow to skip some parts of the
+    // stacktrace if there is one.
+    if (options.skipTrace) {
+        pe.skip(options.skipTrace);
+    }
+
+    console.log(pe.render(error));
+};


### PR DESCRIPTION
This PR fixes #533 by slightly modifying the default theme of `pretty-error` so it doesn't use a color for the error message.

**Before:**

![image](https://user-images.githubusercontent.com/850046/54559916-6dbb0680-49c1-11e9-963c-946495788315.png)

**After:**

![image](https://user-images.githubusercontent.com/850046/54559933-76134180-49c1-11e9-919e-61e69ac6cfe2.png)

