### PR TITLE
Fix typo in Vue features

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -87,7 +87,7 @@ const features = {
             { name: 'vue-loader', enforce_version: true },
             { name: 'vue-template-compiler' }
         ],
-        description: 'load VUE files'
+        description: 'load Vue files'
     },
     eslint: {
         method: 'enableEslintLoader()',


### PR DESCRIPTION
Just a minor typo, renaming `VUE` to `Vue`.