### PR TITLE
Add extra checks to the copyFiles feature

### DIFF
--- a/fixtures/copy/foo.png
+++ b/fixtures/copy/foo.png
@@ -1,0 +1,1 @@
+This is an invalid content to check that the file is still copied

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -183,14 +183,23 @@ class ConfigGenerator {
                         copyTo = this.webpackConfig.useVersioning ? '[path][name].[hash:8].[ext]' : '[path][name].[ext]';
                     }
 
-                    const copyFilesLoader = require.resolve('./webpack/copy-files-loader');
-                    const fileLoader = require.resolve('file-loader');
-                    const copyContext = entry.context ? path.resolve(this.webpackConfig.getContext(), entry.context) : copyFrom;
-                    const requireContextParam = `!${copyFilesLoader}!${fileLoader}?context=${copyContext}&name=${copyTo}!${copyFrom}`;
+                    const copyFilesLoaderPath = require.resolve('./webpack/copy-files-loader');
+                    const copyFilesLoaderConfig = `${copyFilesLoaderPath}?${JSON.stringify({
+                        // file-loader options
+                        context: entry.context ? path.resolve(this.webpackConfig.getContext(), entry.context) : copyFrom,
+                        name: copyTo,
+
+                        // custom copy-files-loader options
+                        // the patternSource is base64 encoded in case
+                        // it contains characters that don't work with
+                        // the "inline loader" syntax
+                        patternSource: Buffer.from(entry.pattern.source).toString('base64'),
+                        patternFlags: entry.pattern.flags,
+                    })}`;
 
                     return buffer + `
                         const context_${index} = require.context(
-                            '${stringEscaper(requireContextParam)}',
+                            '${stringEscaper(`!${copyFilesLoaderConfig}!${copyFrom}`)}',
                             ${!!entry.includeSubdirectories},
                             ${entry.pattern}
                         );

--- a/lib/webpack/copy-files-loader.js
+++ b/lib/webpack/copy-files-loader.js
@@ -10,8 +10,13 @@
 'use strict';
 
 const LoaderDependency = require('webpack/lib/dependencies/LoaderDependency');
+const fileLoader = require('file-loader');
+const loaderUtils = require('loader-utils');
+const path = require('path');
 
-module.exports = function loader(source) {
+module.exports.raw = true; // Needed to avoid corrupted binary files
+
+module.exports.default = function loader(source) {
     // This is a hack that allows `Encore.copyFiles()` to support
     // JSON files using the file-loader (which is not something
     // that is supported in Webpack 4, see https://github.com/symfony/webpack-encore/issues/535)
@@ -39,5 +44,31 @@ module.exports = function loader(source) {
         this._module.parser = factory.getParser(requiredType);
     }
 
-    return source;
+    const options = loaderUtils.getOptions(this);
+
+    // Retrieve the real path of the resource, relative
+    // to the context used by copyFiles(...)
+    const context = options.context;
+    const resourcePath = this.resourcePath;
+    const relativeResourcePath = path.relative(context, resourcePath);
+
+    // Retrieve the pattern used in copyFiles(...)
+    // The "source" part of the regexp is base64 encoded
+    // in case it contains characters that don't work with
+    // the "inline loader" syntax
+    const pattern = new RegExp(
+        Buffer.from(options.patternSource, 'base64').toString(),
+        options.patternFlags
+    );
+
+    // If the pattern does not match the ressource's path
+    // it probably means that the import was resolved using the
+    // "resolve.extensions" parameter of Webpack (for instance
+    // if "./test.js" was matched by "./test").
+    if (!pattern.test(relativeResourcePath)) {
+        return 'module.exports = "";';
+    }
+
+    // If everything is OK, let the file-loader do the copy
+    return fileLoader.bind(this)(source);
 };


### PR DESCRIPTION
This PR adds some extra checks to make sure that files *really* match the pattern used in `copyFiles(...)` before the `file-loader` is called (closes #556).

For a full description of the issue see https://github.com/symfony/webpack-encore/issues/556#issuecomment-481440004, but here is a TL;DR:

Currently, if you have a folder that contains a `foo.js` file and calls `copyFile(...)` with a pattern that excludes `.js` files, that file will still be copied.

This is caused by the `resolve.extensions` mechanism of Webpack that also applies to `require.context(...)` calls (on which this feature relies) and includes `./foo` (without the extensions) to the list of files that should be imported.