### PR TITLE
doc: add badge for lowest supported Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/symfony/webpack-encore.svg?branch=master)](https://travis-ci.org/symfony/webpack-encore)
 [![NPM Version](https://badge.fury.io/js/%40symfony%2Fwebpack-encore.svg)](https://badge.fury.io/js/%40symfony%2Fwebpack-encore)
+![Node](https://img.shields.io/node/v/@symfony/webpack-encore.svg)
 
 Webpack Encore is a simpler way to integrate [Webpack](https://webpack.js.org/) into your
 application. It *wraps* Webpack, giving you a clean & powerful API


### PR DESCRIPTION
Following of #571, it can be nice to have a badge that shows the lowest supported version of Node.

Under the hood, it uses `engines.node` from [`package.json`](https://github.com/symfony/webpack-encore/blob/master/package.json#L24)