### PR TITLE
minor #583 chore: replace some `.indexOf() === -1` with `.includes()` (Kocal)

### DIFF
--- a/lib/EncoreProxy.js
+++ b/lib/EncoreProxy.js
@@ -40,7 +40,7 @@ module.exports = {
                         'isRuntimeEnvironmentConfigured',
                     ];
 
-                    if (!Encore.isRuntimeEnvironmentConfigured() && (safeMethods.indexOf(prop) === -1)) {
+                    if (!Encore.isRuntimeEnvironmentConfigured() && !safeMethods.includes(prop)) {
                         throw new Error(`Encore.${prop}() cannot be called yet because the runtime environment doesn't appear to be configured. Make sure you're using the encore executable or call Encore.configureRuntimeEnvironment() first if you're purposely not calling Encore directly.`);
                     }
 

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -727,7 +727,7 @@ class WebpackConfig {
         // Check allowed keys
         const validKeys = ['js', 'css', 'images', 'fonts'];
         for (const key of Object.keys(configuredFilenames)) {
-            if (validKeys.indexOf(key) === -1) {
+            if (!validKeys.includes(key)) {
                 throw new Error(`"${key}" is not a valid key for configureFilenames(). Valid keys: ${validKeys.join(', ')}.`);
             }
         }
@@ -747,7 +747,7 @@ class WebpackConfig {
         // Check allowed keys
         const validKeys = ['images', 'fonts'];
         for (const key of Object.keys(urlLoaderOptions)) {
-            if (validKeys.indexOf(key) === -1) {
+            if (!validKeys.includes(key)) {
                 throw new Error(`"${key}" is not a valid key for configureUrlLoader(). Valid keys: ${validKeys.join(', ')}.`);
             }
         }

--- a/lib/config/path-util.js
+++ b/lib/config/path-util.js
@@ -109,7 +109,7 @@ module.exports = {
          *
          * For that reason, we force you to choose your manifestKeyPrefix().
          */
-        if (outputPath.indexOf(publicPath) === -1) {
+        if (!outputPath.includes(publicPath)) {
             const suggestion = publicPath.substr(publicPath.lastIndexOf('/') + 1) + '/';
 
             throw new Error(`Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. ${suggestion}) to use when building your manifest keys. This is caused by setOutputPath() (${outputPath}) and setPublicPath() (${publicPath}) containing paths that don't seem compatible.`);

--- a/lib/friendly-errors/transformers/missing-css-file.js
+++ b/lib/friendly-errors/transformers/missing-css-file.js
@@ -16,7 +16,7 @@ function isMissingConfigError(e) {
         return false;
     }
 
-    if (e.message.indexOf('Module not found: Error: Can\'t resolve') === -1) {
+    if (!e.message.includes('Module not found: Error: Can\'t resolve')) {
         return false;
     }
 

--- a/lib/friendly-errors/transformers/missing-loader.js
+++ b/lib/friendly-errors/transformers/missing-loader.js
@@ -16,7 +16,7 @@ function isMissingLoaderError(e) {
         return false;
     }
 
-    if (e.message.indexOf('You may need an appropriate loader') === -1) {
+    if (!e.message.includes('You may need an appropriate loader')) {
         return false;
     }
 

--- a/lib/friendly-errors/transformers/missing-postcss-config.js
+++ b/lib/friendly-errors/transformers/missing-postcss-config.js
@@ -16,7 +16,7 @@ function isMissingConfigError(e) {
         return false;
     }
 
-    if (e.message.indexOf('No PostCSS Config found') === -1) {
+    if (!e.message.includes('No PostCSS Config found')) {
         return false;
     }
 

--- a/lib/package-helper.js
+++ b/lib/package-helper.js
@@ -43,7 +43,7 @@ function getInstallCommand(packageConfigs) {
 
         // e.g. ^4.0||^5.0: use the latest version
         let recommendedVersion = firstPackage.version;
-        if (recommendedVersion.indexOf('||') !== -1) {
+        if (recommendedVersion.includes('||')) {
             recommendedVersion = recommendedVersion.split('|').pop().trim();
         }
 


### PR DESCRIPTION
Some small internal changes.

It replaces some calls to `.indexOf()` with `.includes()` which is more readable:
- `a.indexOf(b) === -1` -> `!a.includes(b)`
- `a.indexOf(b) !== -1` -> `a.includes(b)`