### PR TITLE
Update friendly-errors-webpack-plugin to ^2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "css-loader": "^2.1.1",
     "fast-levenshtein": "^2.0.6",
     "file-loader": "^1.1.10",
-    "friendly-errors-webpack-plugin": "^1.7.0",
+    "friendly-errors-webpack-plugin": "^2.0.0-beta.1",
     "fs-extra": "^2.0.0",
     "loader-utils": "^1.1.0",
     "lodash": ">=3.5 <5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,7 +2816,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-stack-parser@^2.0.0:
+error-stack-parser@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.2.tgz#4ae8dbaa2bf90a8b450707b9149dcabca135520d"
   integrity sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==
@@ -3468,14 +3468,15 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-friendly-errors-webpack-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz#efc86cbb816224565861a1be7a9d84d0aafea136"
-  integrity sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==
+friendly-errors-webpack-plugin@^2.0.0-beta.1:
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-2.0.0-beta.1.tgz#b65341ac0c9b5f48fed76e8cdfaedfb8a39ef07e"
+  integrity sha512-dx01rzBAIQWjZp3I+DJ/9ot+qbdfAf34bsjpriEblPFvGpNA7fC9gUfqjA8pk+3zQiGTRl4E7xM/XAC4wgD19Q==
   dependencies:
-    chalk "^1.1.3"
-    error-stack-parser "^2.0.0"
+    chalk "^2.4.2"
+    error-stack-parser "^2.0.2"
     string-width "^2.0.0"
+    strip-ansi "^5"
 
 from2@^2.1.0:
   version "2.3.0"
@@ -7530,7 +7531,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5, strip-ansi@^5.0.0, strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==


### PR DESCRIPTION
A version `^2.0.0-beta.1` of `friendly-webpack-plugin` was released recently, the API doesn't seem to change at all and it fixes a bunch of things, including #445.

The major version bump is only there because they dropped support for Webpack 3, which shouldn't impact us at all.