### PR TITLE
Fix "Missing loader" detection in Webpack 4.34.0+

### DIFF
--- a/lib/friendly-errors/transformers/missing-loader.js
+++ b/lib/friendly-errors/transformers/missing-loader.js
@@ -16,7 +16,7 @@ function isMissingLoaderError(e) {
         return false;
     }
 
-    if (!e.message.includes('You may need an appropriate loader')) {
+    if (!/You may need an (appropriate|additional) loader/.test(e.message)) {
         return false;
     }
 


### PR DESCRIPTION
In `webpack@4.34.0` having a missing loader can trigger a "You may need an **additional** loader" error message instead of the one we are currently looking for ("You may need an **appropriate** loader"), which causes one of our CI jobs to fail.

This PR fixes it by detecting both versions.

Related commit: https://github.com/webpack/webpack/commit/45582c51e7faf2d7c1ee0f39a4f763accb367b8a#diff-34f95d7b09e1170360b8660f36c8b96fR26