### PR TITLE
Add support for .postcss files

### DIFF
--- a/fixtures/css/postcss_extension.postcss
+++ b/fixtures/css/postcss_extension.postcss
@@ -1,0 +1,1 @@
+@import "autoprefixer_test.css";

--- a/fixtures/vuejs-css-modules/App.vue
+++ b/fixtures/vuejs-css-modules/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="red large justified lowercase" :class="[$css.italic, $scss.bold, $less.underline, $stylus.rtl]"></div>
+  <div id="app" class="red large justified lowercase block" :class="[$css.italic, $scss.bold, $less.underline, $stylus.rtl, $postcss.hidden]"></div>
 </template>
 
 <style>
@@ -25,6 +25,13 @@
     text-transform: lowercase
 </style>
 
+<style lang="postcss">
+  .block {
+    display: block;
+  }
+</style>
+
+
 <style module="$css">
   .italic {
     font-style: italic;
@@ -46,4 +53,10 @@
 <style lang="styl" module="$stylus">
   .rtl
     direction: rtl;
+</style>
+
+<style lang="postcss" module="$postcss">
+  .hidden {
+    visibility: hidden;
+  }
 </style>

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -236,6 +236,15 @@ class ConfigGenerator {
             return applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks[name], defaultRules);
         };
 
+        // When the PostCSS loader is enabled, allow to use
+        // files with the `.postcss` extension. It also
+        // makes it possible to use `lang="postcss"` in Vue
+        // files.
+        const cssExtensions = ['css'];
+        if (this.webpackConfig.usePostCssLoader) {
+            cssExtensions.push('postcss');
+        }
+
         let rules = [
             applyRuleConfigurationCallback('javascript', {
                 // match .js and .jsx
@@ -246,9 +255,9 @@ class ConfigGenerator {
             applyRuleConfigurationCallback('css', {
                 resolve: {
                     mainFields: ['style', 'main'],
-                    extensions: ['.css'],
+                    extensions: cssExtensions.map(ext => `.${ext}`),
                 },
-                test: /\.css$/,
+                test: new RegExp(`\\.(${cssExtensions.join('|')})$`),
                 oneOf: [
                     {
                         resourceQuery: /module/,

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1052,7 +1052,7 @@ describe('The config-generator function', () => {
             });
 
             const webpackConfig = configGenerator(config);
-            const rule = findRule(/\.css$/, webpackConfig.module.rules);
+            const rule = findRule(/\.(css)$/, webpackConfig.module.rules);
 
             expect(rule.camelCase).to.be.true;
         });
@@ -1208,6 +1208,44 @@ describe('The config-generator function', () => {
 
             expect(rule.use[0].options.debug).to.be.true;
             expect(rule.use[0].options.fooBar).to.be.equal('fooBar');
+        });
+    });
+
+    describe('enablePostCssLoader() makes the CSS rule process .postcss file', () => {
+        it('without enablePostCssLoader()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.enableSingleRuntimeChunk();
+            config.addEntry('main', './main');
+            // do not call disableImagesLoader
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
+                findRule(/\.(css)$/, actualConfig.module.rules);
+            }).not.to.throw();
+            expect(function() {
+                findRule(/\.(css|postcss)$/, actualConfig.module.rules);
+            }).to.throw();
+        });
+
+        it('with enablePostCssLoader()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            config.enableSingleRuntimeChunk();
+            config.enablePostCssLoader();
+
+            const actualConfig = configGenerator(config);
+
+            expect(function() {
+                findRule(/\.(css)$/, actualConfig.module.rules);
+            }).to.throw();
+            expect(function() {
+                findRule(/\.(css|postcss)$/, actualConfig.module.rules);
+            }).to.not.throw();
         });
     });
 });


### PR DESCRIPTION
This PR closes #592 by making the `.css` rule also process `.postcss` files when `Encore.enablePostCssLoader()` has been called.

It seems that it can be useful in a Vue.js context in order to have proper syntax highlighting in IDEs by using `lang="postcss"`, as explained on https://vue-loader-v14.vuejs.org/en/features/postcss.html:

> Since vue-loader handles PostCSS on its styles internally, you only need to apply postcss-loader to standalone CSS files. There's no need to specify lang="postcss" on a style block if there is a PostCSS config file in your project.
>
> Sometimes the user may want to use lang="postcss" only for syntax highlighting purposes. 