### PR TITLE
Allow to configure the resolve-url-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -754,6 +754,9 @@ class Encore {
      *              when disabled, all url()'s are resolved relative
      *              to the original entry file... not whatever file
      *              the url() appears in.
+     *      * {object} resolveUrlLoaderOptions (default={})
+     *              Options parameters for resolve-url-loader
+     *              // https://www.npmjs.com/package/resolve-url-loader#options
      *
      * @param {function} sassLoaderOptionsCallback
      * @param {object} encoreOptions

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -116,13 +116,7 @@ class WebpackConfig {
         this.copyFilesConfigs = [];
         this.sassOptions = {
             resolveUrlLoader: true,
-            resolveUrlLoaderOptions: {
-                engine: 'postcss',
-                keepQuery: false,
-                removeCR: false,
-                debug: false,
-                silent: false
-            }
+            resolveUrlLoaderOptions: {}
         };
         this.preactOptions = {
             preactCompat: false

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -115,7 +115,14 @@ class WebpackConfig {
         // Features/Loaders options
         this.copyFilesConfigs = [];
         this.sassOptions = {
-            resolveUrlLoader: true
+            resolveUrlLoader: true,
+            resolveUrlLoaderOptions: {
+                engine: 'postcss',
+                keepQuery: false,
+                removeCR: false,
+                debug: false,
+                silent: false
+            }
         };
         this.preactOptions = {
             preactCompat: false

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -32,7 +32,7 @@ module.exports = {
                 loader: 'resolve-url-loader',
                 options: {
                     sourceMap: webpackConfig.useSourceMaps,
-                    removeCR: true
+                    ...webpackConfig.sassOptions.resolveUrlLoaderOptions
                 }
             });
         }

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -30,10 +30,12 @@ module.exports = {
             // entry file, not the file that contains the url()
             sassLoaders.push({
                 loader: 'resolve-url-loader',
-                options: {
-                    sourceMap: webpackConfig.useSourceMaps,
-                    ...webpackConfig.sassOptions.resolveUrlLoaderOptions
-                }
+                options: Object.assign(
+                    {
+                        sourceMap: webpackConfig.useSourceMaps
+                    },
+                    webpackConfig.sassOptions.resolveUrlLoaderOptions
+                )
             });
         }
 

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -31,7 +31,8 @@ module.exports = {
             sassLoaders.push({
                 loader: 'resolve-url-loader',
                 options: {
-                    sourceMap: webpackConfig.useSourceMaps
+                    sourceMap: webpackConfig.useSourceMaps,
+                    removeCR: true
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pkg-up": "^1.0.0",
     "pretty-error": "^2.1.1",
-    "resolve-url-loader": "^3.0.1",
+    "resolve-url-loader": "^3.1.0",
     "semver": "^5.5.0",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pkg-up": "^1.0.0",
     "pretty-error": "^2.1.1",
-    "resolve-url-loader": "^3.1.0",
+    "resolve-url-loader": "^3.0.1",
     "semver": "^5.5.0",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^1.1.0",

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -65,6 +65,26 @@ describe('loaders/sass', () => {
         cssLoader.getLoaders.restore();
     });
 
+    it('getLoaders() with resolve-url-loader options', () => {
+        const config = createConfig();
+        config.enableSassLoader(() => {}, {
+            resolveUrlLoaderOptions: {
+                removeCR: true
+            }
+        });
+
+        // make the cssLoader return nothing
+        sinon.stub(cssLoader, 'getLoaders')
+            .callsFake(() => []);
+
+        const actualLoaders = sassLoader.getLoaders(config);
+        expect(actualLoaders).to.have.lengthOf(2);
+        expect(actualLoaders[0].loader).to.equal('resolve-url-loader');
+        expect(actualLoaders[0].options.removeCR).to.be.true;
+
+        cssLoader.getLoaders.restore();
+    });
+
     it('getLoaders() without resolve-url-loader', () => {
         const config = createConfig();
         config.enableSassLoader(() => {}, {


### PR DESCRIPTION
This PR solve the error below, occuring on some cases:
```
Error: resolve-url-loader: CSS error
  source-map information is not available at url() declaration (found orphan CR, try removeCR option)
```
See discussion: bholloway/resolve-url-loader#107