### PR TITLE
Add babel option to pre-include polyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -848,6 +848,9 @@ class Encore {
      *     // core-js to your project using Yarn or npm and
      *     // inform Babel of the version it will use.
      *     corejs: 3
+     *
+     *     // pre-include needed polyfills
+     *     polyfills: []
      * });
      * ```
      *

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -128,6 +128,7 @@ class WebpackConfig {
             exclude: /(node_modules|bower_components)/,
             useBuiltIns: false,
             corejs: null,
+            polyfills: [],
         };
         this.vueOptions = {
             useJsx: false,

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -45,6 +45,7 @@ module.exports = {
                 forceAllTransforms: webpackConfig.isProduction(),
                 useBuiltIns: webpackConfig.babelOptions.useBuiltIns,
                 corejs: webpackConfig.babelOptions.corejs,
+                include: webpackConfig.babelOptions.polyfills,
             };
 
             Object.assign(babelConfig, {


### PR DESCRIPTION
This PR adds an `polyfills` option to `Encore.configureBabel()` to configure the [`include`][1] option of `@babel/preset-env`. It's inspired by the [`polyfills`][2] option of `@vue/babel-preset-app`.

This option is useful to include polyfills that are required by project dependencies and therefore cannot be convered by `useBuiltIns: 'usage'`.

[1]: https://babeljs.io/docs/en/babel-preset-env#include
[2]: https://cli.vuejs.org/guide/browser-compatibility.html#usebuiltins-usage