### PR TITLE
Remove webpack-chunk-hash plugin

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -732,10 +732,6 @@ class WebpackConfig {
             }
         }
 
-        if (typeof configuredFilenames.js !== 'undefined' && configuredFilenames.js.includes('[chunkhash')) {
-            logger.deprecation('Using the [chunkhash] placeholder in any filenames is deprecated: use [contenthash] instead.');
-        }
-
         this.configuredFilenames = configuredFilenames;
     }
 

--- a/lib/plugins/plugin-priorities.js
+++ b/lib/plugins/plugin-priorities.js
@@ -14,7 +14,6 @@ module.exports = {
     DeleteUnusedEntriesJSPlugin: 130,
     WebpackManifestPlugin: 120,
     LoaderOptionsPlugin: 110,
-    WebpackChunkHash: 100,
     ProvidePlugin: 90,
     CleanWebpackPlugin: 80,
     DefinePlugin: 70,

--- a/lib/plugins/versioning.js
+++ b/lib/plugins/versioning.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const webpack = require('webpack');
-const WebpackChunkHash = require('webpack-chunk-hash');
 const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
 const PluginPriorities = require('./plugin-priorities');
 
@@ -48,13 +47,5 @@ module.exports = function(plugins, webpackConfig) {
     } else {
         // No plugin is added. But, see the "optimizations" config,
         // for inclusion of the "named modules".
-    }
-
-    if (webpackConfig.useVersioning) {
-        // enables the [chunkhash] ability, which is deprecated
-        plugins.push({
-            plugin: new WebpackChunkHash(),
-            priority: PluginPriorities.WebpackChunkHash
-        });
     }
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "terser-webpack-plugin": "^1.1.0",
     "tmp": "^0.0.33",
     "webpack": "^4.20.0",
-    "webpack-chunk-hash": "^0.6.0",
     "webpack-cli": "^3.0.0",
     "webpack-dev-server": "^3.1.14",
     "webpack-manifest-plugin": "^2.0.2",

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1113,23 +1113,6 @@ describe('WebpackConfig object', () => {
                 });
             }).to.throw('"foo" is not a valid key');
         });
-
-        it('Using chunkhash is deprecated', () => {
-            logger.reset();
-            logger.quiet();
-
-            after(() => {
-                logger.quiet(false);
-            });
-
-            const config = createConfig();
-
-            config.configureFilenames({
-                js: 'file.[chunkhash:16].js'
-            });
-
-            expect(logger.getMessages().deprecation).to.not.be.empty;
-        });
     });
 
     describe('configureUrlLoader', () => {

--- a/test/functional.js
+++ b/test/functional.js
@@ -431,8 +431,8 @@ describe('Functional tests using webpack', function() {
                 config.addStyleEntry('styles', './css/h1_style.css');
                 config.enableVersioning(true);
                 config.configureFilenames({
-                    js: '[name].js?[chunkhash:16]',
-                    css: '[name].css?[chunkhash:16]'
+                    js: '[name].js?[contenthash:16]',
+                    css: '[name].css?[contenthash:16]'
                 });
 
                 testSetup.runWebpack(config, (webpackAssert) => {
@@ -448,7 +448,7 @@ describe('Functional tests using webpack', function() {
                     );
                     webpackAssert.assertManifestPath(
                         'styles.css',
-                        '/styles.css?91597a40238e0e66'
+                        '/styles.css?8ec316547cc77b39'
                     );
 
                     done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,11 +696,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@types/anymatch@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
-  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -729,29 +724,6 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
-
-"@types/tapable@*":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
-  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
-
-"@types/uglify-js@*":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
-  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
-  dependencies:
-    source-map "^0.6.1"
-
-"@types/webpack@^3.0.0 || ^4.0.0":
-  version "4.32.1"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.32.1.tgz#6e95010e806f808abd6551c112097ac09035aacf"
-  integrity sha512-9n38CBx9uga1FEAdTipnt0EkbKpsCJFh7xJb1LE65FFb/A6OOLFX022vYsGC1IyVCZ/GroNg9u/RMmlDxGcLIw==
-  dependencies:
-    "@types/anymatch" "*"
-    "@types/node" "*"
-    "@types/tapable" "*"
-    "@types/uglify-js" "*"
-    source-map "^0.6.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0", "@vue/babel-helper-vue-jsx-merge-props@^1.0.0-beta.3":
   version "1.0.0"
@@ -8369,13 +8341,6 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-webpack-chunk-hash@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/webpack-chunk-hash/-/webpack-chunk-hash-0.6.0.tgz#eca36aff76e327d08a18a3e7990eb46e68376818"
-  integrity sha512-FsOg1RpW2nf3nYpGTy/Qs59RZ7gYG+sI4VrCE8TIBQYh/Kogi04xD39Pj9zUEeUcNx9HeTVPGSO3mtmpLeX9eQ==
-  dependencies:
-    "@types/webpack" "^3.0.0 || ^4.0.0"
 
 webpack-cli@^3.0.0:
   version "3.3.6"


### PR DESCRIPTION
This PR removes the `webpack-chunk-hash` plugin since:

* using `[chunkhash]` was deprecated a while ago (in #463)
* it seems to be causing issues even when `[chunkhash]` is not used at all (fixes #605)