### PR TITLE
Fix old integrity hashes being added to the entrypoints.json with --watch

### DIFF
--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -28,8 +28,10 @@ function processOutput(webpackConfig) {
         // the original assets (so, assets.entrypoints) + the new
         // assets (which will have their original structure). We
         // delete the entrypoints key, and then process the new assets
-        // like normal below
+        // like normal below. The same reasoning applies to the
+        // integrity key.
         delete assets.entrypoints;
+        delete assets.integrity;
 
         // This will iterate over all the entry points and convert the
         // one file entries into an array of one entry since that was how the entry point file was before this change.


### PR DESCRIPTION
This PR fixes a really small issue that I noticed while working on #608.

When using `--watch` and `enableIntegrityHashes()` together it works fine for the first compilation, but on the next ones the old hashes also get added to the `entrypoints.json` file.

**First compilation:**

```json
{
  "entrypoints": {
    "main": {
      "js": [
        "/build/main.js"
      ]
    }
  },
  "integrity": {
    "/build/main.js": "<OLDHASH>"
  }
}
```

**Second compilation:**

```json
{
  "entrypoints": {
    "integrity": {
      "/build/main.js": ["<OLDHASH>"]
    },
    "main": {
      "js": [
        "/build/main.js"
      ]
    }
  },
  "integrity": {
    "/build/main.js": "<NEWHASH>"
  }
}
```