### PR TITLE
Don't make @babel/preset-env force all transforms in prod

### DIFF
--- a/fixtures/js/async_function.js
+++ b/fixtures/js/async_function.js
@@ -1,0 +1,7 @@
+async function foo() {
+    console.log('foo');
+}
+
+foo().then(() => {
+    console.log('bar');
+});

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -42,7 +42,6 @@ module.exports = {
                 // https://babeljs.io/docs/en/babel-preset-env#modules
                 modules: false,
                 targets: {},
-                forceAllTransforms: webpackConfig.isProduction(),
                 useBuiltIns: webpackConfig.babelOptions.useBuiltIns,
                 corejs: webpackConfig.babelOptions.corejs,
             };

--- a/test/functional.js
+++ b/test/functional.js
@@ -1148,6 +1148,41 @@ module.exports = {
             });
         });
 
+        it('Babel does not force transforms if they are not needed', (done) => {
+            const cwd = process.cwd();
+            after(() => {
+                process.chdir(cwd);
+            });
+
+            const appDir = testSetup.createTestAppDir();
+            process.chdir(appDir);
+
+            fs.writeFileSync(
+                path.join(appDir, 'package.json'),
+
+                // Chrome 55 supports async and arrow functions
+                '{"browserslist": "Chrome 55"}'
+            );
+
+            const config = createWebpackConfig('www/build', 'prod');
+            config.setPublicPath('/build');
+            config.addEntry('async', './js/async_function.js');
+            config.configureBabel(null, {
+                useBuiltIns: 'usage',
+                corejs: 3,
+            });
+
+            testSetup.runWebpack(config, async(webpackAssert) => {
+                webpackAssert.assertOutputFileContains(
+                    'async.js',
+                    'async function(){console.log("foo")}().then(()=>{console.log("bar")})'
+                );
+
+                done();
+            });
+        });
+
+
         it('When enabled, react JSX is transformed!', (done) => {
             const config = createWebpackConfig('www/build', 'dev');
             config.setPublicPath('/build');


### PR DESCRIPTION
This PR removes the `forceAllTransforms: webpackConfig.isProduction()` line that is currently added to `@babel/preset-env`'s options.

That setting was previously needed because UglifyJS did not support ES6 which meant that if you, for instance, had `async` functions in your code and targeted a recent browsers, they would have to be transformed for the minification process to be successful.

Nowadays we're using Terser which supports ES6, so there shouldn't be any issue keeping these kind of things in the final code anymore.