### PR TITLE
Fixing hashes in tests

### DIFF
--- a/test/functional.js
+++ b/test/functional.js
@@ -404,7 +404,7 @@ describe('Functional tests using webpack', function() {
                                 'styles.8ec31654.css',
                                 'manifest.json',
                                 'entrypoints.json',
-                                'runtime.191f859b.js',
+                                'runtime.b2470f76.js',
                             ]);
                     }
 
@@ -510,7 +510,7 @@ describe('Functional tests using webpack', function() {
                             'bg.0ec2735b.css',
                             'manifest.json',
                             'entrypoints.json',
-                            'runtime.a59dcd0a.js',
+                            'runtime.0f36ae93.js',
                         ]);
                 }
 
@@ -1989,8 +1989,8 @@ module.exports = {
                         expect(config.outputPath).to.be.a.directory()
                             .with.files([
                                 'entrypoints.json',
-                                'runtime.e59078a6.js',
-                                'main.172bc009.js',
+                                'runtime.e75311e7.js',
+                                'main.3213b14e.js',
                                 'manifest.json',
                                 'symfony_logo.ea1ca6f7.png',
                                 'symfony_logo_alt.f27119c2.png',
@@ -1998,7 +1998,7 @@ module.exports = {
 
                         webpackAssert.assertManifestPath(
                             'build/main.js',
-                            '/build/main.172bc009.js'
+                            '/build/main.3213b14e.js'
                         );
                     }
 
@@ -2585,7 +2585,7 @@ module.exports = {
                     testSetup.runWebpack(config, () => {
                         const integrityData = getIntegrityData(config);
                         const expectedHashes = {
-                            '/build/runtime.js': 'sha384-hQKsj4QnosLWUGewEvh5KeLgoer9lhQNpaLEV/Mx7Pi9PEA6wCiwswVuA1+0ejtD',
+                            '/build/runtime.js': 'sha384-GhoJXFTd5hHxARTOCT3RTrcOdggU7hmL/esw02KNiVIWsdumxg20TRjgdzXBMGfE',
                             '/build/main.js': 'sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J',
                             '/build/main~other.js': 'sha384-4g+Zv0iELStVvA4/B27g4TQHUMwZttA5TEojjUyB8Gl5p7sarU4y+VTSGMrNab8n',
                             '/build/main~other.css': 'sha384-hfZmq9+2oI5Cst4/F4YyS2tJAAYdGz7vqSMP8cJoa8bVOr2kxNRLxSw6P8UZjwUn',
@@ -2618,7 +2618,7 @@ module.exports = {
                     testSetup.runWebpack(config, () => {
                         const integrityData = getIntegrityData(config);
                         const expectedHashes = {
-                            'http://localhost:8090/assets/runtime.js': 'sha256-I/+XM54E6L5G+HC8LNV4Wk9PGsUq6hMFH+10M/OWBUM=',
+                            'http://localhost:8090/assets/runtime.js': 'sha256-qW5QarAS9yWb4YTF5gVKNF24g4p5GayDErYme10iu7A=',
                             'http://localhost:8090/assets/main.js': 'sha256-RtW3TYA1SBHUGuBnIBBJZ7etIGyYisjargouvET4sFE=',
                             'http://localhost:8090/assets/main~other.js': 'sha256-q9xPQWa0UBbMPUNmhDaDuBFjV2gZU6ICiKzLN7jPccc=',
                             'http://localhost:8090/assets/main~other.css': 'sha256-KVo9sI0v6MnbxPg/xZMSn2XE7qIChWiDh1uED1tP5Fo=',
@@ -2650,7 +2650,7 @@ module.exports = {
                     testSetup.runWebpack(config, () => {
                         const integrityData = getIntegrityData(config);
                         const expectedHashes = {
-                            '/build/runtime.js': 'sha256-uVZ2UUsGl+gGxXKpst4QbGYFRFI0dUaWtvvlP8NUhRY= sha512-2iiJgccOcw7xzz6FpdAkdxttvVS3TprWW0WqIyq0w2+uoVNSmoVdNGnIz08huvHXbzLvDex9uraKS1F8PZlHig==',
+                            '/build/runtime.js': 'sha256-wxWX1GOm4edacCjvQsqZ1hG9tls4ZtuUOGQ8goGNg54= sha512-eiQrrAyaBpUlypIGVURWONjsAW8sImJllkwQ6NSDK6tIVNy/lInthruFT30x/OGRfHa4aYEaOHriEjisoxcw1Q==',
                             '/build/main.js': 'sha256-RtW3TYA1SBHUGuBnIBBJZ7etIGyYisjargouvET4sFE= sha512-/wl1U/L6meBga5eeRTxPz5BxFiLmwL/kjy1NTcK0DNdxV3oUI/zZ9DEDU43Cl7XqGMnUH8pJhhFJR+1k9vZrYQ==',
                             '/build/main~other.js': 'sha256-q9xPQWa0UBbMPUNmhDaDuBFjV2gZU6ICiKzLN7jPccc= sha512-1xuC/Y+goI01JUPVYBQOpPY36ttTXnZFOBsTgNPCJu53b2/ccFqzeW3abV3KG5mFzo4cfSUOS7AXjj8ajp/MjA==',
                             '/build/main~other.css': 'sha256-6AltZJTjdVuLywCBE8qQevkscxazmWyh/19OL6cxkwY= sha512-zE1kAcqJ/jNnycEwELK7BfauEgRlK6cGrN+9urz4JI1K+s5BpglYFF9G0VOiSA7Kj3w46XX1WcjZ5w5QohBFEw==',


### PR DESCRIPTION
The runtime changes are probably due to the yarn.lock bump, which now includes
https://github.com/webpack/webpack/pull/9493

The one main.js change is a mystery.