### PR TITLE
Allow to overwrite pre-defined aliases using addAliases()

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -96,7 +96,7 @@ class ConfigGenerator {
 
         config.resolve = {
             extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx', '.vue', '.ts', '.tsx'],
-            alias: Object.assign({}, this.webpackConfig.aliases)
+            alias: {}
         };
 
         if (this.webpackConfig.useVueLoader) {
@@ -107,6 +107,8 @@ class ConfigGenerator {
             config.resolve.alias['react'] = 'preact-compat';
             config.resolve.alias['react-dom'] = 'preact-compat';
         }
+
+        Object.assign(config.resolve.alias, this.webpackConfig.aliases);
 
         config.externals = [...this.webpackConfig.externals];
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -453,6 +453,28 @@ describe('The config-generator function', () => {
                 'testB': 'src/testB'
             });
         });
+
+        it('with addAliases() that overwrites pre-defined aliases', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.enableVueLoader(); // Adds the 'vue$' alias
+            config.enablePreactPreset({ preactCompat: true }); // Adds the 'react' and 'react-dom' aliases
+            config.addAliases({
+                'foo': 'bar',
+                'vue$': 'new-vue$',
+                'react-dom': 'new-react-dom',
+            });
+
+            const actualConfig = configGenerator(config);
+
+            expect(actualConfig.resolve.alias).to.deep.equals({
+                'foo': 'bar',
+                'vue$': 'new-vue$',
+                'react-dom': 'new-react-dom',
+                'react': 'preact-compat' // Keeps predefined aliases that are not overwritten
+            });
+        });
     });
 
     describe('addExternals() adds new externals', () => {


### PR DESCRIPTION
Currently pre-defined aliases (used by `vue` and `preact-compat`) are added after the ones from `Encore.addAliases(...)`, which prevents overwriting them using this method.

It makes more sense to change that order so aliases from `Encore.addAliases(...)` are always added last (fixes #625).