### PR TITLE
bug #638 sass-loader should not do css minification

### DIFF
--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -41,7 +41,9 @@ module.exports = {
 
         const config = Object.assign({}, {
             // needed by the resolve-url-loader
-            sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps
+            sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps,
+            // CSS minification is handled with mini-css-extract-plugin
+            outputStyle: 'expanded'
         });
 
         sassLoaders.push({

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -120,6 +120,7 @@ describe('loaders/sass', () => {
 
         expect(actualLoaders[1].options).to.deep.equals({
             sourceMap: true,
+            outputStyle: 'expanded',
             custom_optiona: 'baz',
             other_option: true
         });


### PR DESCRIPTION
Fixes a BC break from the sass-loader minifying the CSS which is already done with mini-css-extract-plugin.

I chose to use outputStyle 'expanded' so it's also compatible with Dart Sass.