### PR TITLE
fix(copy-files): use context realpath

### DIFF
--- a/lib/webpack/copy-files-loader.js
+++ b/lib/webpack/copy-files-loader.js
@@ -13,6 +13,7 @@ const LoaderDependency = require('webpack/lib/dependencies/LoaderDependency');
 const fileLoader = require('file-loader');
 const loaderUtils = require('loader-utils');
 const path = require('path');
+const fs = require('fs');
 
 module.exports.raw = true; // Needed to avoid corrupted binary files
 
@@ -48,7 +49,7 @@ module.exports.default = function loader(source) {
 
     // Retrieve the real path of the resource, relative
     // to the context used by copyFiles(...)
-    const context = options.context;
+    const context = fs.realpathSync(options.context);
     const resourcePath = this.resourcePath;
     const relativeResourcePath = path.relative(context, resourcePath);
 


### PR DESCRIPTION
In scenarios where context is within a symlink, `path.relative()` will return an undesired path because the resource path follows symlinks. We resolve this by using `fs.realpathSync(options.context)`.