### PR TITLE
Allow to configure babel env preset

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -140,6 +140,7 @@ class WebpackConfig {
         this.lessLoaderOptionsCallback = () => {};
         this.stylusLoaderOptionsCallback = () => {};
         this.babelConfigurationCallback = () => {};
+        this.babelPresetEnvOptionsCallback = () => {};
         this.cssLoaderConfigurationCallback = () => {};
         this.splitChunksConfigurationCallback = () => {};
         this.watchOptionsConfigurationCallback = () => {};
@@ -404,6 +405,10 @@ class WebpackConfig {
                 normalizedOptionKey = 'includeNodeModules';
             }
 
+            if (['useBuiltIns', 'corejs'].includes(optionKey)) {
+                logger.deprecation(`configureBabel: "${optionKey}" is deprecated. Please use configureBabelPresetEnv() instead.`);
+            }
+
             if (this.doesBabelRcFileExist() && !allowedOptionsWithExternalConfig.includes(normalizedOptionKey)) {
                 logger.warning(`The "${normalizedOptionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json").`);
                 continue;
@@ -444,6 +449,14 @@ class WebpackConfig {
                 this.babelOptions[normalizedOptionKey] = options[optionKey];
             }
         }
+    }
+
+    configureBabelPresetEnv(callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('Argument 1 to configureBabelPresetEnv() must be a callback function.');
+        }
+
+        this.babelPresetEnvOptionsCallback = callback;
     }
 
     configureCssLoader(callback) {

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -36,7 +36,7 @@ module.exports = {
         // configure babel (unless the user is specifying .babelrc)
         // todo - add a sanity check for their babelrc contents
         if (!webpackConfig.doesBabelRcFileExist()) {
-            const presetEnvOptions = {
+            let presetEnvOptions = {
                 // modules don't need to be transformed - webpack will parse
                 // the modules for us. This is a performance improvement
                 // https://babeljs.io/docs/en/babel-preset-env#modules
@@ -45,6 +45,11 @@ module.exports = {
                 useBuiltIns: webpackConfig.babelOptions.useBuiltIns,
                 corejs: webpackConfig.babelOptions.corejs,
             };
+
+            presetEnvOptions = applyOptionsCallback(
+                webpackConfig.babelPresetEnvOptionsCallback,
+                presetEnvOptions
+            );
 
             Object.assign(babelConfig, {
                 presets: [

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -146,4 +146,24 @@ describe('loaders/babel', () => {
             'foo'
         ]);
     });
+
+    it('getLoaders() with configured babel env preset', () => {
+        const config = createConfig();
+        config.runtimeConfig.babelRcFileExists = false;
+
+        config.configureBabel(function(config) {
+            config.corejs = null;
+        });
+
+        config.configureBabelPresetEnv(function(config) {
+            config.corejs = 3;
+            config.include = ['bar'];
+        });
+
+        const actualLoaders = babelLoader.getLoaders(config);
+
+        // options are overridden
+        expect(actualLoaders[0].options.presets[0][1].corejs).to.equal(3);
+        expect(actualLoaders[0].options.presets[0][1].include).to.have.members(['bar']);
+    });
 });


### PR DESCRIPTION
This PR allows you to configure `@babel/preset-env` by calling `Encore.configureBabelPresetEnv()` without the need to create a `.babelrc` and lose the ability to activate presets automatically.

```js
Encore
    .configureBabelPresetEnv((config) => {
        config.corejs = 3;
        config.useBuiltIns = 'usage';
        config.include = ['foo-plugin'];
    });
```
The options `corejs` and `useBuiltIns` of `Encore.configureBabel()` should be deprecated.