### PR TITLE
Add .babelrc error to configureBabelPresetEnv and remove some deprecations

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -405,10 +405,6 @@ class WebpackConfig {
                 normalizedOptionKey = 'includeNodeModules';
             }
 
-            if (['useBuiltIns', 'corejs'].includes(optionKey)) {
-                logger.deprecation(`configureBabel: "${optionKey}" is deprecated. Please use configureBabelPresetEnv() instead.`);
-            }
-
             if (this.doesBabelRcFileExist() && !allowedOptionsWithExternalConfig.includes(normalizedOptionKey)) {
                 logger.warning(`The "${normalizedOptionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json").`);
                 continue;
@@ -454,6 +450,10 @@ class WebpackConfig {
     configureBabelPresetEnv(callback) {
         if (typeof callback !== 'function') {
             throw new Error('Argument 1 to configureBabelPresetEnv() must be a callback function.');
+        }
+
+        if (this.doesBabelRcFileExist()) {
+            throw new Error('The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json").');
         }
 
         this.babelPresetEnvOptionsCallback = callback;

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -642,6 +642,41 @@ describe('WebpackConfig object', () => {
         });
     });
 
+    describe('configureBabelPresetEnv', () => {
+        beforeEach(() => {
+            logger.reset();
+            logger.quiet();
+        });
+
+        afterEach(() => {
+            logger.quiet(false);
+        });
+
+        it('Calling method sets it', () => {
+            const config = createConfig();
+            const testCallback = () => {};
+            config.configureBabelPresetEnv(testCallback);
+            expect(config.babelPresetEnvOptionsCallback).to.equal(testCallback);
+        });
+
+        it('Calling with non-callback throws an error', () => {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureBabelPresetEnv('FOO');
+            }).to.throw('must be a callback function');
+        });
+
+        it('Calling with a callback when .babelrc is present throws an error', () => {
+            const config = createConfig();
+            config.runtimeConfig.babelRcFileExists = true;
+
+            expect(() => {
+                config.configureBabelPresetEnv(() => {});
+            }).to.throw('your app already provides an external Babel configuration');
+        });
+    });
+
     describe('configureCssLoader', () => {
         it('Calling method sets it', () => {
             const config = createConfig();


### PR DESCRIPTION
Since we do not configure `@babel/preset-env` if there is a `.babelrc` file (or something similar) it makes sense to add the same warning we already have for the `Encore.configureBabel()` function to `Encore.configureBabelPresetEnv()`:

> The "callback" argument of \<function\> will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json

This PR also removes some deprecation that were added by #642.
We talked about them with @weaverryan and it's probably not worth removing the `useBuiltIns` and `corejs` options of `Encore.configureBabel()`:
* they are currently recommended by the flex recipe
* it allows us to document them/check them easier than with a callback