### PR TITLE
Add Encore.configureBabelPresetEnv() to the public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -896,6 +896,31 @@ class Encore {
     }
 
     /**
+     * Configure @babel/preset-env
+     *
+     * https://babeljs.io/docs/en/babel-preset-env
+     *
+     * ```
+     * Encore.configureBabelPresetEnv(function(options) {
+     *     // change the @babel/preset-env config
+     *     // if you use an external Babel configuration
+     *     // this callback will NOT be used
+     *     // options.corejs = 3;
+     *     // options.useBuiltIns = 'usage';
+     *     // ...
+     * });
+     * ```
+     *
+     * @param {function} callback
+     * @returns {Encore}
+     */
+    configureBabelPresetEnv(callback) {
+        webpackConfig.configureBabelPresetEnv(callback);
+
+        return this;
+    }
+
+    /**
      * Configure the css-loader.
      *
      * https://github.com/webpack-contrib/css-loader#options

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -933,6 +933,39 @@ describe('The config-generator function', () => {
         });
     });
 
+    describe('Test configureBabelPresetEnv()', () => {
+        it('without configureBabelPresetEnv()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+
+            const actualConfig = configGenerator(config);
+
+            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
+            const babelLoader = jsRule.use.find(loader => loader.loader === 'babel-loader');
+            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === '@babel/preset-env');
+            expect(babelEnvPreset[1].useBuiltIns).to.equal(false);
+        });
+
+        it('with configureBabelPresetEnv()', () => {
+            const config = createConfig();
+            config.outputPath = '/tmp/output/public-path';
+            config.publicPath = '/public-path';
+            config.addEntry('main', './main');
+            config.configureBabelPresetEnv(options => {
+                options.useBuiltIns = 'usage';
+            });
+
+            const actualConfig = configGenerator(config);
+
+            const jsRule = findRule(/\.jsx?$/, actualConfig.module.rules);
+            const babelLoader = jsRule.use.find(loader => loader.loader === 'babel-loader');
+            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === '@babel/preset-env');
+            expect(babelEnvPreset[1].useBuiltIns).to.equal('usage');
+        });
+    });
+
     describe('Test shouldSplitEntryChunks', () => {
         it('Not production', () => {
             const config = createConfig();

--- a/test/index.js
+++ b/test/index.js
@@ -243,6 +243,15 @@ describe('Public API', () => {
 
     });
 
+    describe('configureBabelPresetEnv', () => {
+
+        it('must return the API object', () => {
+            const returnedValue = api.configureBabelPresetEnv(() => {});
+            expect(returnedValue).to.equal(api);
+        });
+
+    });
+
     describe('enableReactPreset', () => {
 
         it('must return the API object', () => {


### PR DESCRIPTION
This PR adds the missing method `configureBabelPresetEnv()` to the `index.js` file (fixes #666).