### PR TITLE
Updated - mini-css-extract-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "file-loader": "^1.1.10",
     "friendly-errors-webpack-plugin": "^2.0.0-beta.1",
     "loader-utils": "^1.1.0",
-    "mini-css-extract-plugin": ">=0.4.0 <0.4.3",
+    "mini-css-extract-plugin": ">=0.8.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pkg-up": "^1.0.0",
     "pretty-error": "^2.1.1",


### PR DESCRIPTION
The latest versions of Vuetify need newer versions of mini-css-extract-plugin, they require version 0.8