### PR TITLE
Fix failing 'Lowest versions' tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
     "ts-loader": "^5.3.0",
-    "typescript": "^2.3.4",
+    "typescript": ">=2.9",
     "url-loader": "^1.0.1 || ^2.0.1",
     "vue": "^2.3.4",
     "vue-loader": "^15.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8104,10 +8104,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^2.3.4:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@>=2.9:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.6.1"


### PR DESCRIPTION
I think it suddenly failed because a `@types/*` package required by another dependency got updated and was not compatible with our lowest allowed version of Typescript anymore.