### PR TITLE
Include the .pcss extension for PostCSS files

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -245,6 +245,7 @@ class ConfigGenerator {
         // files.
         const cssExtensions = ['css'];
         if (this.webpackConfig.usePostCssLoader) {
+            cssExtensions.push('pcss');
             cssExtensions.push('postcss');
         }
 

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -1340,7 +1340,7 @@ describe('The config-generator function', () => {
                 findRule(/\.(css)$/, actualConfig.module.rules);
             }).not.to.throw();
             expect(function() {
-                findRule(/\.(css|postcss)$/, actualConfig.module.rules);
+                findRule(/\.(css|pcss|postcss)$/, actualConfig.module.rules);
             }).to.throw();
         });
 
@@ -1358,7 +1358,7 @@ describe('The config-generator function', () => {
                 findRule(/\.(css)$/, actualConfig.module.rules);
             }).to.throw();
             expect(function() {
-                findRule(/\.(css|postcss)$/, actualConfig.module.rules);
+                findRule(/\.(css|pcss|postcss)$/, actualConfig.module.rules);
             }).to.not.throw();
         });
     });


### PR DESCRIPTION
This PR adds support for the `.pcss` file extension for PostCSS files.

I've got this to work by overriding the CSS Loader `test` within my webpack.config.js using the `.configureLoaderRule()` as documented in https://www.oliverdavies.uk/articles/using-the-pcss-extension-with-webpack-encore.

But it would be nice to have this supported by default to make things simpler and not having to see the `Be careful when using Encore.configureLoaderRule()` message on each build.