### PR TITLE
feat: upgrade sass-loader support to ^8

### DIFF
--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -42,8 +42,10 @@ module.exports = {
         const config = Object.assign({}, {
             // needed by the resolve-url-loader
             sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps,
-            // CSS minification is handled with mini-css-extract-plugin
-            outputStyle: 'expanded'
+            sassOptions: {
+                // CSS minification is handled with mini-css-extract-plugin
+                outputStyle: 'expanded'
+            }
         });
 
         sassLoaders.push({

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^1.1.3",
     "terser-webpack-plugin": "^1.1.0",
     "tmp": "^0.0.33",
-    "webpack": "^4.20.0",
+    "webpack": "^4.36.0",
     "webpack-cli": "^3.0.0",
     "webpack-dev-server": "^3.1.14",
     "webpack-manifest-plugin": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^1.1.3",
     "terser-webpack-plugin": "^1.1.0",
     "tmp": "^0.0.33",
-    "webpack": "^4.36.0",
+    "webpack": "^4.36.1",
     "webpack-cli": "^3.0.0",
     "webpack-dev-server": "^3.1.14",
     "webpack-manifest-plugin": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "preact": "^8.2.1",
     "preact-compat": "^3.17.0",
     "sass": "^1.17.0",
-    "sass-loader": "^7.0.1",
+    "sass-loader": "^8.0.0",
     "sinon": "^2.3.4",
     "strip-ansi": "^5.0.0",
     "stylus": "^0.54.5",

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -842,7 +842,7 @@ describe('WebpackConfig object', () => {
 
         it('Pass options callback', () => {
             const config = createConfig();
-            const callback = (sassOptions) => {};
+            const callback = (options) => {};
             config.enableSassLoader(callback);
 
             expect(config.sassLoaderOptionsCallback).to.equal(callback);

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -111,18 +111,20 @@ describe('loaders/sass', () => {
         sinon.stub(cssLoader, 'getLoaders')
             .callsFake(() => []);
 
-        config.enableSassLoader(function(sassOptions) {
-            sassOptions.custom_optiona = 'baz';
-            sassOptions.other_option = true;
+        config.enableSassLoader(function(options) {
+            options.sassOptions.custom_option = 'baz';
+            options.sassOptions.other_option = true;
         });
 
         const actualLoaders = sassLoader.getLoaders(config);
 
         expect(actualLoaders[1].options).to.deep.equals({
             sourceMap: true,
-            outputStyle: 'expanded',
-            custom_optiona: 'baz',
-            other_option: true
+            sassOptions: {
+                outputStyle: 'expanded',
+                custom_option: 'baz',
+                other_option: true
+            }
         });
         cssLoader.getLoaders.restore();
     });
@@ -134,8 +136,8 @@ describe('loaders/sass', () => {
         sinon.stub(cssLoader, 'getLoaders')
             .callsFake(() => []);
 
-        config.enableSassLoader(function(sassOptions) {
-            sassOptions.custom_option = 'baz';
+        config.enableSassLoader(function(options) {
+            options.custom_option = 'baz';
 
             // This should override the original config
             return { foo: true };

--- a/test/package-helper.js
+++ b/test/package-helper.js
@@ -123,7 +123,7 @@ describe('package-helper', () => {
     describe('The getInvalidPackageVersionRecommendations correctly checks installed versions', () => {
         it('Check package that *is* the correct version', () => {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
-                { name: 'sass-loader', version: '^7.0.1' },
+                { name: 'sass-loader', version: '^8.0.0' },
                 { name: 'preact', version: '^8.1.0' }
             ]);
 
@@ -132,7 +132,7 @@ describe('package-helper', () => {
 
         it('Check package with a version too low', () => {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
-                { name: 'sass-loader', version: '^8.0.1' },
+                { name: 'sass-loader', version: '^9.0.0' },
                 { name: 'preact', version: '9.0.0' }
             ]);
 
@@ -140,9 +140,9 @@ describe('package-helper', () => {
             expect(versionProblems[0]).to.contain('is too old');
         });
 
-        it('Check package with a version too low', () => {
+        it('Check package with a version too new', () => {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
-                { name: 'sass-loader', version: '^6.9.11' },
+                { name: 'sass-loader', version: '^7.0.1' },
                 { name: 'preact', version: '7.0.0' }
             ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8725,16 +8725,16 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.36.0:
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.1.tgz#ae707baf091f5ca3ef9c38b884287cfe8f1983ef"
-  integrity sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==
+webpack@^4.36.1:
+  version "4.43.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
+  integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.2.1"
+    acorn "^6.4.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"
@@ -8751,7 +8751,7 @@ webpack@^4.36.0:
     schema-utils "^1.0.0"
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.0"
+    watchpack "^1.6.1"
     webpack-sources "^1.4.1"
 
 websocket-driver@>=0.5.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8725,16 +8725,16 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.20.0:
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
-  integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
+webpack@^4.36.0:
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.1.tgz#ae707baf091f5ca3ef9c38b884287cfe8f1983ef"
+  integrity sha512-SGfYMigqEfdGchGhFFJ9KyRpQKnipvEvjc1TwrXEPCM6H5Wywu10ka8o3KGrMzSMxMQKt8aCHUFh5DaQ9UmyRg==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
+    acorn "^6.2.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"
@@ -8751,7 +8751,7 @@ webpack@^4.20.0:
     schema-utils "^1.0.0"
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.1"
+    watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
 websocket-driver@>=0.5.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,7 +5110,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -7324,15 +7324,15 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass-loader@^7.0.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
-  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+sass-loader@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
   dependencies:
     clone-deep "^4.0.1"
-    loader-utils "^1.0.1"
-    neo-async "^2.5.0"
-    pify "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.6.1"
     semver "^6.3.0"
 
 sass@^1.17.0:
@@ -7356,10 +7356,18 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.6.5, schema-utils@^2.6.6:
+schema-utils@^2.6.1, schema-utils@^2.6.6:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
   integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+  dependencies:
+    ajv "^6.12.0"
+    ajv-keywords "^3.4.1"
+
+schema-utils@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.5.tgz#c758f0a7e624263073d396e29cd40aa101152d8a"
+  integrity sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==
   dependencies:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"


### PR DESCRIPTION
Close #654 

Breaking changes from [`sass-loader` changelog](https://github.com/webpack-contrib/sass-loader/blob/master/CHANGELOG.md#800-2019-08-29): 
- minimum required `webpack` version is 4.36.0: done in 4411c45, however [a test is failing with lowest dependencies](https://travis-ci.org/github/symfony/webpack-encore/jobs/676799821#L11322)
- minimum required `node.js` version is 8.9.0: not an issue since we don't support Node 8 anymore (#731)
- sass options has been moved in `sassOptions` option: ok

@Lyrkan do you have an idea oh what to do with the failing test? Use  `DISABLE_UNSTABLE_CHECKS` on it?

Thanks!