### PR TITLE
Fix babel config file detection

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -396,7 +396,7 @@ class WebpackConfig {
             }
 
             if (this.doesBabelRcFileExist()) {
-                logger.warning('The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json"). Use null as a first argument to remove that warning.');
+                logger.warning('The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babelrc.config.js" file or "babel" key in "package.json"). Use null as a first argument to remove that warning.');
             }
         }
 
@@ -415,7 +415,7 @@ class WebpackConfig {
             }
 
             if (this.doesBabelRcFileExist() && !allowedOptionsWithExternalConfig.includes(normalizedOptionKey)) {
-                logger.warning(`The "${normalizedOptionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json").`);
+                logger.warning(`The "${normalizedOptionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babelrc.config.js" file or "babel" key in "package.json").`);
                 continue;
             }
 
@@ -462,7 +462,7 @@ class WebpackConfig {
         }
 
         if (this.doesBabelRcFileExist()) {
-            throw new Error('The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (a ".babelrc" file, ".babelrc.js" file or "babel" key in "package.json").');
+            throw new Error('The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babelrc.config.js" file or "babel" key in "package.json").');
         }
 
         this.babelPresetEnvOptionsCallback = callback;

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -87,21 +87,21 @@ module.exports = function(argv, cwd) {
 
     const partialConfig = babel.loadPartialConfig({
         /*
-         * This is a small mystery. Even if we set the cwd & root
-         * options, deep in babel, if the filename option is not
-         * set, then it doesn't see the "cwd" directory as a valid
-         * directory where it should look for the .babelrc file.
-         * The fact that this is set to webpack.config.js is not
-         * significant at all - you could even invent a filename.
-         * However, as I'm not sure the side effects (the filename
-         * option is documented as "for error messages"), we're
-         * setting it to a realistic filename.
+         * There are two types of babel configuration:
+         * - project-wide configuration in babel.config.* files
+         * - file-relative configuration in .babelrc.* files
+         *   or package.json files with a "babel" key
+         *
+         * To detect the file-relative configuration we need
+         * to set the following values. The filename is needed
+         * for Babel as an example so that it knows where it
+         * needs to search the relative config for.
          */
         root: cwd,
         cwd: cwd,
         filename: path.join(cwd, 'webpack.config.js')
     });
-    runtimeConfig.babelRcFileExists = (typeof partialConfig.babelrc === 'string');
+    runtimeConfig.babelRcFileExists = partialConfig.hasFilesystemConfig();
 
     return runtimeConfig;
 };

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -96,10 +96,34 @@ describe('parse-runtime', () => {
         expect(config.context).to.equal('/tmp/custom-context');
     });
 
+    it('babel config in package.json detected when present', () => {
+        const projectDir = createTestDirectory();
+        fs.writeFileSync(
+            path.join(projectDir, 'package.json'),
+            '{"babel": {}}'
+        );
+
+        const config = parseArgv(createArgv(['dev']), projectDir);
+
+        expect(config.babelRcFileExists).to.be.true;
+    });
+
     it('.babelrc detected when present', () => {
         const projectDir = createTestDirectory();
         fs.writeFileSync(
             path.join(projectDir, '.babelrc'),
+            '{}'
+        );
+
+        const config = parseArgv(createArgv(['dev']), projectDir);
+
+        expect(config.babelRcFileExists).to.be.true;
+    });
+
+    it('babel.config.json detected when present', () => {
+        const projectDir = createTestDirectory();
+        fs.writeFileSync(
+            path.join(projectDir, 'babel.config.json'),
             '{}'
         );
 


### PR DESCRIPTION
Since v7 [Babel supports two types of config formats](https://babeljs.io/docs/en/config-files):
- Project-wide configuration
  - `babel.config` files, with the different extensions (`json`, `js`, `cjs`, `mjs`)
- File-relative configuration
  - `.babelrc` files, with the different extensions (none, `json`, `js`, `cjs`, `mjs`)
  - `package.json` files with a "babel" key

Encore, however, only checks for the existence of **file-relative** config files.

This is a problem if you want to compile packages from the `node_modules` folder (via `.configureBabel(null, {includeNodeModules: ['...']})`) because **project-wide** configuration files are needed for this.

This means that if you only have a `.babelrc.js` file, the package from the `node_modules` folder **will** be compiled by Babel, but **without** the settings defined in the `.babelrc.js` file.

If you now rename the `.babelrc.js` to `babel.config.js`, Encore fails to detect it and applies its default Babel config, which results in everything being complied without the settings defined in `babel.config.js`.

> Note: Configuring babel through Encore is not an option for me, because I want to make use of Babels [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) which is not available in Encore afaik.
And apart from that I prefer to have the configuration in dedicated files.

So my solution for now is to keep an empty `.babelrc.js` to make Encore think there is a Babel config file, and have an additional `babel.config.js` file with the real config. This results in both the application code and node modules being compiled with the desired settings.

---

But of course I dug a little deeper into Encore and Babel to fix the problem and the fix is using the `hasFilesystemConfig()` method instead of checking the `babelrc` property (the wording in the comment is a bit outdated, I already created a PR for that ;)):
https://github.com/babel/babel/blob/af669297efd775016725ee39318cdb391cf00a21/packages/babel-core/src/config/partial.js#L191-L200

I added some tests, too. I'm not sure if it's worth it to add tests for the different config file extensions, though.

I tried to improve the error messages as well. Tell me if you want another wording or different file examples and I'll change it.