### PR TITLE
Add a boolean parameter to Encore.disableCssExtraction()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1299,11 +1299,11 @@ class Encore {
      *
      * Internally, this disables the mini-css-extract-plugin
      * and uses the style-loader instead.
-     *
+     * @param {boolean} disabled
      * @returns {Encore}
      */
-    disableCssExtraction() {
-        webpackConfig.disableCssExtraction();
+    disableCssExtraction(disabled = true) {
+        webpackConfig.disableCssExtraction(disabled);
 
         return this;
     }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -810,8 +810,8 @@ class WebpackConfig {
         this.useFontsLoader = false;
     }
 
-    disableCssExtraction() {
-        this.extractCss = false;
+    disableCssExtraction(disabled = true) {
+        this.extractCss = !disabled;
     }
 
     configureFilenames(configuredFilenames = {}) {

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1223,12 +1223,27 @@ describe('WebpackConfig object', () => {
             expect(config.extractCss).to.be.true;
         });
 
-        it('Calling it disables the CSS extraction', () => {
+        it('Calling it with no params disables the CSS extraction', () => {
             const config = createConfig();
             config.disableCssExtraction();
 
             expect(config.extractCss).to.be.false;
         });
+
+        it('Calling it with boolean set to true disables CSS extraction', () => {
+            const config = createConfig();
+            config.disableCssExtraction(true);
+
+            expect(config.extractCss).to.be.false;
+        });
+
+        it('Calling it with boolean set to false enables CSS extraction', () => {
+            const config = createConfig();
+            config.disableCssExtraction(false);
+
+            expect(config.extractCss).to.be.true;
+        });
+
     });
 
     describe('configureFilenames', () => {


### PR DESCRIPTION
Branch? | master
-- | --
Bug fix? | no
New feature? | yes
Deprecations? | no
Tickets | none
License | MIT
Allows for environment specific uses of disableCssExtraction that match conventions used in webpack.config.js by other methods such as enableSourceMaps or enableVersioning

