### PR TITLE
Update 0.29.0 changelog regarding CommonJS imports following the file-loader update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
 
    * `file-loader` upgraded from 1.1 to 6  - #731 thanks to @weaverryan.
      [CHANGELOG](https://github.com/webpack-contrib/file-loader/blob/master/CHANGELOG.md#600-2020-03-17)
-     Unless you're doing custom configuration, it's unlikely you're affected.
+     If you are importing images/fonts using the CommonJS syntax (`require('foo.png')`),
+     you will now need to explicitely retrieve the default export (`require('foo.png').default`)
+     in order to get the path of the file.
+     Imports done using the `import` keyword should not be affected.
 
    * `url-loader` upgraded from allowing version 1 or 2 to allowing version 4 - #731 thanks to @weaverryan.
      [CHANGELOG](https://github.com/webpack-contrib/url-loader/blob/master/CHANGELOG.md#400-2020-03-17)


### PR DESCRIPTION
As noted in https://github.com/symfony/webpack-encore/issues/743 the file-loader update we did in 0.29.0 has a breaking change when files are imported using the CommonJS syntax.

Since the loader is now exporting ES modules by default, importing them with `require(...)` retrieves the whole module and not only the default export.

We'll also have to update the Github changelog after merging this (closes #743).