### PR TITLE
fix: preact compat

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -105,8 +105,8 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.usePreact && this.webpackConfig.preactOptions.preactCompat) {
-            config.resolve.alias['react'] = 'preact-compat';
-            config.resolve.alias['react-dom'] = 'preact-compat';
+            config.resolve.alias['react'] = 'preact/compat';
+            config.resolve.alias['react-dom'] = 'preact/compat';
         }
 
         Object.assign(config.resolve.alias, this.webpackConfig.aliases);

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -493,7 +493,7 @@ describe('The config-generator function', () => {
                 'foo': 'bar',
                 'vue$': 'new-vue$',
                 'react-dom': 'new-react-dom',
-                'react': 'preact-compat' // Keeps predefined aliases that are not overwritten
+                'react': 'preact/compat' // Keeps predefined aliases that are not overwritten
             });
         });
     });


### PR DESCRIPTION
With the realease of the version 10 of preact, preact compat was migrated inside preact library removing the need for preact-compat.

https://preactjs.com/guide/v10/switching-to-preact/