### PR TITLE
build(deps): remove explicit dependency to "terser-webpack-plugin"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "resolve-url-loader": "^3.0.1",
     "semver": "^7.3.2",
     "style-loader": "^1.1.3",
-    "terser-webpack-plugin": "^1.1.0",
     "tmp": "^0.2.1",
     "webpack": "^4.36.0",
     "webpack-cli": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8439,7 +8439,7 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.4.3:
+terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
   integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==


### PR DESCRIPTION
Webpack already [depends of `terser-webpack-plugin`](https://github.com/webpack/webpack/blob/v4.36.0/package.json#L28), so I don't think this is revelant to require here too.

WDYT?