### PR TITLE
Setting CleanWebpackPlugin's cleanStaleWebpackAssets: false

### DIFF
--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -29,7 +29,9 @@ module.exports = function(plugins, webpackConfig) {
 
     const cleanWebpackPluginOptions = {
         verbose: false,
-        cleanOnceBeforeBuildPatterns: webpackConfig.cleanWebpackPluginPaths
+        cleanOnceBeforeBuildPatterns: webpackConfig.cleanWebpackPluginPaths,
+        // disabled to avoid a bug where some files were incorrectly deleted on watch rebuild
+        cleanStaleWebpackAssets: false
     };
 
     plugins.push({


### PR DESCRIPTION
There is currently a bug where, on a "watch" rebuild, sometimes an image that's referenced from a CSS file won't be "noticed" and will be mistakenly deleted.

Reproducer: https://github.com/weaverryan/clean_webpack_assets_watch_bug

I haven't had time yet to "distill" that reproducer down to a raw `webpack.config.js` file (without Encore) so that I can submit an issue. But, since this behavior can be quite damaging (I was pulling out my hair trying to figure out why an image file was there sometimes and gone other times) and because the `cleanStaleWebpackAssets` is so *minor* (it removes extra files on `watch` rebuilds), I think we should just disable it by default.