### PR TITLE
Update the JSDoc of configureBabel to warn about .babelrc and node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -931,14 +931,19 @@ class Encore {
      *              determines which files and folders should not be
      *              processed by Babel (https://webpack.js.org/configuration/module/#condition).
      *              Can be used even if you have an external Babel configuration
-     *              (a .babelrc file for instance)
+     *              (a babel.config.json file for instance)
+     *              Warning: .babelrc config files don't apply to node_modules. Use
+     *              babel.config.json instead to apply the same config to modules if
+     *              they are not excluded anymore.
      *              Cannot be used if the "includeNodeModules" option is
      *              also set.
      *      * {string[]} includeNodeModules
      *              If set that option will include the given Node modules to
      *              the files that are processed by Babel.
      *              Can be used even if you have an external Babel configuration
-     *              (a .babelrc file for instance).
+     *              (a babel.config.json file for instance). 
+     *              Warning: .babelrc config files don't apply to node_modules. Use
+     *              babel.config.json instead to apply the same config to these modules.
      *              Cannot be used if the "exclude" option is also set
      *      * {'usage'|'entry'|false} useBuiltIns (default=false)
      *              Set the "useBuiltIns" option of @babel/preset-env that changes


### PR DESCRIPTION
Babel supports 2 different types of config files:

- `.babelrc` stops at package boundaries
- `babel.config.*` applies to the whole project, including `node_modules`

Once node_modules is not excluded anymore in the babel-loader configuration, this distinction matters.

Refs #785