### PR TITLE
Fix the documentation about autoProvidejQuery

### DIFF
--- a/index.js
+++ b/index.js
@@ -757,7 +757,8 @@ class Encore {
      * ```
      * WebpackConfig.autoProvideVariables({
      *     $: 'jquery',
-     *     jQuery: 'jquery'
+     *     jQuery: 'jquery',
+     *     'window.jQuery': 'jquery'
      * });
      * ```
      *


### PR DESCRIPTION
The implementation actually defines 3 provided variables, not only 2.