### PR TITLE
Validator should allow copyFiles() without other entries.

### DIFF
--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -42,8 +42,11 @@ class Validator {
             throw new Error('Missing public path: Call setPublicPath() to control the public path relative to where the files are written (the output path).');
         }
 
-        if (this.webpackConfig.entries.size === 0 && this.webpackConfig.styleEntries.size === 0) {
-            throw new Error('No entries found! You must call addEntry() or addStyleEntry() at least once - otherwise... there is nothing to webpack!');
+        if (this.webpackConfig.entries.size === 0
+            && this.webpackConfig.styleEntries.size === 0
+            && this.webpackConfig.copyFilesConfigs.length === 0
+        ) {
+            throw new Error('No entries found! You must call addEntry() or addStyleEntry() or copyFiles() at least once - otherwise... there is nothing to webpack!');
         }
     }
 

--- a/test/config/validator.js
+++ b/test/config/validator.js
@@ -34,6 +34,19 @@ describe('The validator function', () => {
         }).to.throw('No entries found!');
     });
 
+    it('should accept use with copyFiles() only', () => {
+        const config = createConfig();
+        config.setOutputPath('/tmp');
+        config.setPublicPath('/tmp');
+        config.copyFiles({ from: './' });
+
+        expect(() => {
+            validator(config);
+        }).not.throw();
+
+        expect(Object.keys(config.copyFilesConfigs).length).to.equal(1);
+    });
+
     it('throws an error if there is no output path', () => {
         const config = createConfig();
         config.publicPath = '/';


### PR DESCRIPTION
Fix for #830 