### PR TITLE
fix(stimulus): don't require an optional dependency if it's not used

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -147,6 +147,14 @@ const features = {
             { name: 'handlebars-loader', enforce_version: true }
         ],
         description: 'load Handlebars files'
+    },
+    stimulus: {
+        method: 'enableStimulusBridge()',
+        packages: [
+            { name: '@symfony/stimulus-bridge' },
+            { name: 'stimulus' }
+        ],
+        description: 'enable Stimulus bridge'
     }
 };
 

--- a/lib/plugins/stimulus-bridge.js
+++ b/lib/plugins/stimulus-bridge.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
-const createPlugin = require('@symfony/stimulus-bridge/webpack-helper');
+const loaderFeatures = require('../features');
 const fs = require('fs');
 
 /**
@@ -20,6 +20,10 @@ const fs = require('fs');
  */
 module.exports = function(plugins, webpackConfig) {
     if (webpackConfig.useStimulusBridge) {
+        loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stimulus');
+
+        const createPlugin = require('@symfony/stimulus-bridge/webpack-helper');
+
         plugins.push({
             plugin: createPlugin(JSON.parse(fs.readFileSync(webpackConfig.stimulusOptions.controllersJsonPath))),
         });


### PR DESCRIPTION
Fix #861 

Testing my modification on a new Symfony repository but removing `@symfony/stimulus-bridge` and `stimulus` dependencies.

If you try to use `.useStimulusBridge()` without those depdendencies installed, you now have this friendly error message:

![image](https://user-images.githubusercontent.com/2103975/101016415-082df580-3569-11eb-850d-e49115d8b621.png)

When you install the dependencies, everything is okay:
![image](https://user-images.githubusercontent.com/2103975/101016826-930ef000-3569-11eb-8e05-b80dc8f19458.png)

When you don't use `.useStimulusBridge()` and don't have installed Stimulus dependencies, you have no errors anymore about those missing deps, since they are not required. 
Here, the errors are coming from the app code (from the Symfony recipe) I didn't have update, but it's fine:
![image](https://user-images.githubusercontent.com/2103975/101017128-f731b400-3569-11eb-8302-d2d120119884.png)

cc @fabpot @weaverryan 