### PR TITLE
Add missing call to done() in the Stimulus functional test

### DIFF
--- a/test/functional.js
+++ b/test/functional.js
@@ -2072,7 +2072,7 @@ module.exports = {
             });
         });
 
-        it('Symfony - Stimulus standard app is built correctly', () => {
+        it('Symfony - Stimulus standard app is built correctly', (done) => {
             const appDir = testSetup.createTestAppDir();
 
             const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
@@ -2097,6 +2097,8 @@ module.exports = {
                 webpackAssert.assertOutputFileContains('main.js', 'app-controller');
                 webpackAssert.assertOutputFileContains('main.js', 'mock-module-controller');
                 webpackAssert.assertOutputFileContains('main.css', 'body {}');
+
+                done();
             });
         });
 


### PR DESCRIPTION
One of the new tests is currently missing a call to `done()` which breaks the output of the next tests:

![image](https://user-images.githubusercontent.com/850046/101048113-aaa6a280-3582-11eb-8189-1267145f38b5.png)
