### PR TITLE
Update Stimulus test to use an ES syntax

### DIFF
--- a/fixtures/stimulus/controllers/index.js
+++ b/fixtures/stimulus/controllers/index.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
     '@symfony/mock-module/mock': import(/* webpackMode: "eager" */ '@symfony/mock-module/dist/controller'),
 };


### PR DESCRIPTION
Following the proposal of https://github.com/symfony/stimulus-bridge/pull/1, this PR checks ES module syntax work as expected.