### PR TITLE
bumping preset-env to version that depends on @babel/plugin-proposal-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/core": "^7.7.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.10.0",
     "assets-webpack-plugin": "^5.1.1",
     "babel-loader": "^8.0.0",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,7 +747,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/preset-env@^7.4.0":
+"@babel/preset-env@^7.10.0":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.11.tgz#55d5f7981487365c93dbbc84507b1c7215e857f9"
   integrity sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==


### PR DESCRIPTION
This helps fix https://github.com/symfony/stimulus-bridge/pull/16

Basically, in the Encore recipe, we add the `@babel/plugin-proposal-class-properties` plugin in `webpack.config.js`. But, this is not necessarily in the user's project. But 7.10 of `@babel/preset-env` started including this package.

So it's a bit of an odd solution, as we're bumping this dependency so that users can do something simpler in userland config, but I think it's the simplest path. This is basically why most users already are able to use Stimulus (and the class properties it uses) without issues, as most people probably already have `@babel/preset-env` 7.10 or higher.