### PR TITLE
normalizing width of logger categories

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -47,7 +47,7 @@ module.exports = {
         messages.debug.push(message);
 
         if (config.isVerbose) {
-            log(`${chalk.bgBlack.white('   DEBUG   ')} ${message}`);
+            log(`${chalk.bgBlack.white(' DEBUG ')} ${message}`);
         }
     },
 
@@ -60,13 +60,13 @@ module.exports = {
     warning(message) {
         messages.warning.push(message);
 
-        log(`${chalk.bgYellow.black('  WARNING  ')} ${chalk.yellow(message)}`);
+        log(`${chalk.bgYellow.black(' WARNING ')} ${chalk.yellow(message)}`);
     },
 
     deprecation(message) {
         messages.deprecation.push(message);
 
-        log(`${chalk.bgYellow.black('DEPRECATION')} ${chalk.yellow(message)}`);
+        log(`${chalk.bgYellow.black(' DEPRECATION ')} ${chalk.yellow(message)}`);
     },
 
     getMessages() {


### PR DESCRIPTION
This was originally done so that they all lined up nicely in a column. But I noticed that Webpack (at least v5) consistently uses just one space around each.