### PR TITLE
Adding ifProd() and ifDev() methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1597,6 +1597,46 @@ class Encore {
     }
 
     /**
+     * Use to conditionally configure or enable features only in production.
+     *
+     * ```
+     * Encore
+     *     // ...
+     *     .ifProduction((Encore) => Encore.enableVersioning()))
+     * ```
+     *
+     * @param {function} callback
+     * @return {Encore}
+     */
+    ifProduction(callback) {
+        if (this.isProduction()) {
+            callback(this);
+        }
+
+        return this;
+    }
+
+    /**
+     * Use to conditionally configure or enable features for dev only.
+     *
+     * ```
+     * Encore
+     *     // ...
+     *     .ifDev((Encore) => Encore.enableBuildCache({ config: [__filename] }))
+     * ```
+     *
+     * @param {function} callback
+     * @return {Encore}
+     */
+    ifDev(callback) {
+        if (!this.isProduction()) {
+            callback(this);
+        }
+
+        return this;
+    }
+
+    /**
      * Use this at the bottom of your webpack.config.js file:
      *
      * ```

--- a/test/index.js
+++ b/test/index.js
@@ -454,6 +454,55 @@ describe('Public API', () => {
 
     });
 
+    describe('ifProduction', () => {
+        it('callback IS executed in production mode', () => {
+            api.configureRuntimeEnvironment('production', {}, false);
+            let wasExecuted = false;
+            api.ifProduction((Encore) => {
+                wasExecuted = true;
+            });
+            expect(wasExecuted).to.be.true;
+        });
+
+        it('callback is NOT executed in dev mode', () => {
+            api.configureRuntimeEnvironment('dev', {}, false);
+            let wasExecuted = false;
+            api.ifProduction((Encore) => {
+                wasExecuted = true;
+            });
+            expect(wasExecuted).to.be.false;
+        });
+    });
+
+    describe('ifDev', () => {
+        it('callback IS executed in dev mode', () => {
+            api.configureRuntimeEnvironment('dev', {}, false);
+            let wasExecuted = false;
+            api.ifDev((Encore) => {
+                wasExecuted = true;
+            });
+            expect(wasExecuted).to.be.true;
+        });
+
+        it('callback IS executed in dev-server mode', () => {
+            api.configureRuntimeEnvironment('dev-server', {}, false);
+            let wasExecuted = false;
+            api.ifDev((Encore) => {
+                wasExecuted = true;
+            });
+            expect(wasExecuted).to.be.true;
+        });
+
+        it('callback is NOT executed in production mode', () => {
+            api.configureRuntimeEnvironment('production', {}, false);
+            let wasExecuted = false;
+            api.ifDev((Encore) => {
+                wasExecuted = true;
+            });
+            expect(wasExecuted).to.be.false;
+        });
+    });
+
     describe('isRuntimeEnvironmentConfigured', () => {
 
         it('should return true if the runtime environment has been configured', () => {


### PR DESCRIPTION
Hi!

This occurred to me when I was trying to add `Encore.enableBuildCache()` to the official recipe. I was thinking that it might be best to enable it *except* when doing a production build. Currently, that's only possible by breaking the chaining:

```js
Encore
    // .alotOfCalls()
;

if (!Encore.isProduction()) {
    Encore.enableBuildCache({
        config: [__filename],
    })
}
```

We have always handled making this easier on a method-by-method basis, which is still probably nice in many cases (e.g. .`.enableVersioning(Encore.isProduction())` reads really nice. But these new methods make it possible to keep chaining with anything else we don't support in this way:

```js
Encore
    // .alotOfCalls()

    .ifDev((Encore) => Encore.enableBuildCache({ config: [__filename] }))
;
```

Cheers!