### PR TITLE
Working around missing manifest.json bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1421,11 +1421,11 @@ class Encore {
      *     // common values: asset, asset/resource, asset/inline
      *     // Using "asset" will allow smaller images to be "inlined"
      *     // instead of copied.
-     *     // javascript/auto caan be used to disable asset images (see next example)
+     *     // javascript/auto can be used to disable asset images (see next example)
      *     type: 'asset/resource',
      *
      *     // applicable when for "type: asset": files smaller than this
-     *     // size will be "inlined" into CSS, larer files will be extracted
+     *     // size will be "inlined" into CSS, larger files will be extracted
      *     // into independent files
      *     maxSize: 4 * 1024, // 4 kb
      *

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -27,6 +27,11 @@ module.exports = function(plugins, webpackConfig) {
         return;
     }
 
+    const cleanOnceBeforeBuildPatterns = webpackConfig.cleanWebpackPluginPaths;
+    // works around a bug where manifest.json is emitted when
+    // using dev-server... but then CleanWebpackPlugin deletes it
+    cleanOnceBeforeBuildPatterns.push('!manifest.json');
+
     const cleanWebpackPluginOptions = {
         verbose: false,
         cleanOnceBeforeBuildPatterns: webpackConfig.cleanWebpackPluginPaths,

--- a/test/plugins/clean.js
+++ b/test/plugins/clean.js
@@ -41,7 +41,7 @@ describe('plugins/clean', () => {
         cleanPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0].plugin).to.be.instanceof(CleanWebpackPlugin);
-        expect(plugins[0].plugin.cleanOnceBeforeBuildPatterns).to.deep.equal(['**/*']);
+        expect(plugins[0].plugin.cleanOnceBeforeBuildPatterns).to.deep.equal(['**/*', '!manifest.json']);
         expect(plugins[0].plugin.dry).to.equal(false);
     });
 
@@ -56,7 +56,7 @@ describe('plugins/clean', () => {
         cleanPluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0].plugin).to.be.instanceof(CleanWebpackPlugin);
-        expect(plugins[0].plugin.cleanOnceBeforeBuildPatterns).to.deep.equal(['**/*.js', '**/*.css']);
+        expect(plugins[0].plugin.cleanOnceBeforeBuildPatterns).to.deep.equal(['**/*.js', '**/*.css', '!manifest.json']);
         expect(plugins[0].plugin.dry).to.equal(true);
     });
 


### PR DESCRIPTION
This fixes the 2nd part of #893 - https://github.com/symfony/webpack-encore/issues/893#issuecomment-769488763

On Webpack 5, there is some miscommunication between the CleanWebpackPlugin and the WebpackManifestPlugin when using `dev-server`.

The `WebpackManifestPlugin` *does* emit the physical `manifest.json` file, but CleanWebpackPlugin then deletes it. CleanWebpackPlugin should just remove files *before* we start, and not delete anything that's emitted. I'm not sure which plugin has the bug. But, the work around is quite clean.