### PR TITLE
next stimulus-bridge will actually be 2.0

### DIFF
--- a/lib/plugins/stimulus-bridge.js
+++ b/lib/plugins/stimulus-bridge.js
@@ -28,7 +28,7 @@ module.exports = function(plugins, webpackConfig) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stimulus');
 
         const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
-        if (semver.satisfies(version, '^1.2.0')) {
+        if (semver.satisfies(version, '^2.0.0')) {
             // package is new and doesn't require this plugin
 
             return;

--- a/test/functional.js
+++ b/test/functional.js
@@ -1920,7 +1920,7 @@ module.exports = {
             const appDir = testSetup.createTestAppDir();
 
             const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
-            if (!semver.satisfies(version, '^1.2.0')) {
+            if (!semver.satisfies(version, '^2.0.0')) {
                 // we support the old version, but it's not tested
                 this.skip();
 


### PR DESCRIPTION
Discussing with @tgalopin, to make life simpler (and more semver, even though stimulus-bridge is experimental), the stimulus-bridge that contains the plugin/loader changes will be 2.0.