### PR TITLE
Omit cache key entirely when build cache is disabled

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -67,10 +67,13 @@ class ConfigGenerator {
             },
             plugins: this.buildPluginsConfig(),
             optimization: this.buildOptimizationConfig(),
-            cache: this.buildCacheConfig(),
             watchOptions: this.buildWatchOptionsConfig(),
             devtool: false,
         };
+
+        if (this.webpackConfig.usePersistentCache) {
+            config.cache = this.buildCacheConfig();
+        }
 
         if (this.webpackConfig.useSourceMaps) {
             if (this.webpackConfig.isProduction()) {
@@ -511,10 +514,6 @@ class ConfigGenerator {
     }
 
     buildCacheConfig() {
-        if (!this.webpackConfig.usePersistentCache) {
-            return false;
-        }
-
         const cache = {};
 
         cache.type = 'filesystem';


### PR DESCRIPTION
Fixes an issue where `yarn watch` or `yarn dev-server` had super slow "rebuilds" - as long as the initial build, which is much different than the pre-1.0 version of Encore. 

It appears that cache: false is different than omitting the cache key entirely. Using cache: false appears to even disable in-memory caching that Webpack does when rebuilding in "watch" mode or for the dev-server