### PR TITLE
Fix stimulus version bug

### DIFF
--- a/fixtures/stimulus/assets/controllers.json
+++ b/fixtures/stimulus/assets/controllers.json
@@ -2,7 +2,7 @@
     "controllers": {
         "@symfony/mock-module": {
             "mock": {
-                "webpackMode": "lazy",
+                "fetch": "lazy",
                 "enabled": true,
                 "autoimport": {
                     "@symfony/mock-module/dist/style.css": true

--- a/lib/plugins/stimulus-bridge.js
+++ b/lib/plugins/stimulus-bridge.js
@@ -14,27 +14,32 @@ const loaderFeatures = require('../features');
 const fs = require('fs');
 const packageHelper = require('../package-helper');
 const semver = require('semver');
+const logger = require('../logger');
 
 /**
  * Support for @symfony/stimulus-bridge 1.1 or lower.
  *
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @deprecated
  * @return {void}
  */
 module.exports = function(plugins, webpackConfig) {
     if (webpackConfig.useStimulusBridge) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stimulus');
 
-        const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
-        if (semver.satisfies(version, '^2.0.0')) {
+        try {
+            require.resolve('@symfony/stimulus-bridge/webpack-helper'); // eslint-disable-line node/no-unpublished-require, node/no-missing-require
+        } catch (e) {
             // package is new and doesn't require this plugin
+            const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
+            if (semver.satisfies(version, '^1.0.0')) {
+                logger.deprecation('Your version of @symfony/stimulus-bridge is out-of-date. Please upgrade to the latest version');
+            }
 
             return;
         }
 
-        const createPlugin = require('@symfony/stimulus-bridge/webpack-helper'); // eslint-disable-line node/no-unpublished-require
+        const createPlugin = require('@symfony/stimulus-bridge/webpack-helper'); // eslint-disable-line node/no-unpublished-require, node/no-missing-require
 
         plugins.push({
             plugin: createPlugin(JSON.parse(fs.readFileSync(webpackConfig.stimulusOptions.controllersJsonPath))),

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
     "@symfony/mock-module": "file:fixtures/stimulus/mock-module",
-    "@symfony/stimulus-bridge": "^1.1.0",
+    "@symfony/stimulus-bridge": "^1.1.0 || ^2.0.0",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.0.0",
     "@vue/compiler-sfc": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,12 +995,12 @@
 "@symfony/mock-module@file:fixtures/stimulus/mock-module":
   version "1.0.0"
 
-"@symfony/stimulus-bridge@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@symfony/stimulus-bridge/-/stimulus-bridge-1.1.0.tgz#34548c633fe49bcda84cc812939f63640e698af7"
-  integrity sha512-Sz8iwKQHBjrgCnxCGwH87S/J/Min0gX3EuXJaHi4vpibY3BjVm+WYuP8+OYPkMIROPyNZKYgTffFfJLBAFLwFQ==
+"@symfony/stimulus-bridge@^1.1.0 || ^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@symfony/stimulus-bridge/-/stimulus-bridge-2.0.0.tgz#52cbf5c8524dec1a6c154a535bc82fedf1987b06"
+  integrity sha512-sq8FMQDmG5rtcmXwK+SQ2o5dEEqjaxpFjP/EYzl3qbGnED099XxOQDPnbrtVSIRRPlWEsuoTalD9B1fAdeFp0Q==
   dependencies:
-    webpack-virtual-modules "^0.3.2"
+    acorn "^8.0.5"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -1473,7 +1473,7 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4:
+acorn@^8.0.4, acorn@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.5.tgz#a3bfb872a74a6a7f661bc81b9849d9cac12601b7"
   integrity sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==
@@ -2616,7 +2616,7 @@ debug@4.2.0:
   dependencies:
     ms "2.1.2"
 
-debug@^3.0.0, debug@^3.1.1, debug@^3.2.6:
+debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -7578,13 +7578,6 @@ webpack-sources@^2.1.1, webpack-sources@^2.2.0:
   dependencies:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
-
-webpack-virtual-modules@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.3.2.tgz#b7baa30971a22d99451f897db053af48ec29ad2c"
-  integrity sha512-RXQXioY6MhzM4CNQwmBwKXYgBs6ulaiQ8bkNQEl2J6Z+V+s7lgl/wGvaI/I0dLnYKB8cKsxQc17QOAVIphPLDw==
-  dependencies:
-    debug "^3.0.0"
 
 webpack@^5.12:
   version "5.18.0"


### PR DESCRIPTION
stimulus-bridge 2.0 has been released!

This fixes a bug where I forgot to allow v2. It also stops relying on the version (which wouldn't work when v3 comes out) to determine if the plugin (from v1) should be used or not. It also issues a deprecation warning to help users upgrade.