### PR TITLE
Allow node 10.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/symfony/webpack-encore/issues"
   },
   "engines": {
-    "node": "^10.22.1 || ^12.0.0 || >=14.0.0"
+    "node": "^10.19.0 || ^12.0.0 || >=14.0.0"
   },
   "homepage": "https://github.com/symfony/webpack-encore",
   "dependencies": {


### PR DESCRIPTION
This was bumped in https://github.com/symfony/webpack-encore/pull/645
Ubuntu LTS [ships node 10.19](https://packages.ubuntu.com/focal/nodejs) by default.
If we can, let's save ppl (aka me) from installing yet another ppa.