### PR TITLE
Require vue-loader 15.9.5 to work with Encore 1.0

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -93,7 +93,7 @@ const features = {
         // vue-template-compiler is a peer dep of vue-loader
         packages: [
             { name: 'vue', version: '^2.5' },
-            { name: 'vue-loader', version: '^15' },
+            { name: 'vue-loader', version: '^15.9.5' },
             { name: 'vue-template-compiler' }
         ],
         description: 'load Vue files'


### PR DESCRIPTION
Due to the `generator` we use with asset modules, we need 15.9.5 (if you're using Vue 2, or any vue-loader 16 stable version) so we have this fix: https://github.com/vuejs/vue-loader/commit/f79bb087f9211c3ea19d63c1dcfd758d6dbad095

Cheers!