### PR TITLE
fixing 2 issues related to webpack-dev-server and HMR

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -597,6 +597,16 @@ class ConfigGenerator {
             headers: { 'Access-Control-Allow-Origin': '*' },
             compress: true,
             historyApiFallback: true,
+            // In webpack-dev-server v4 beta 0, liveReload always causes
+            // the page to refresh, not allowing HMR to update the page.
+            // This is somehow related to the "static" option, but it's
+            // unknown if there is a better option.
+            // See https://github.com/webpack/webpack-dev-server/issues/2893
+            liveReload: false,
+            client: {
+                // see https://github.com/symfony/webpack-encore/issues/931#issuecomment-784483725
+                host: this.webpackConfig.runtimeConfig.devServerHost,
+            }
         };
 
         return applyOptionsCallback(

--- a/test/functional.js
+++ b/test/functional.js
@@ -2212,11 +2212,11 @@ module.exports = {
                 testSetup.runWebpack(config, (webpackAssert) => {
                     webpackAssert.assertDirectoryContents([
                         'entrypoints.json',
-                        'runtime.fbc90386.js',
-                        'main.06a6c20f.js',
+                        'runtime.[hash:8].js',
+                        'main.[hash:8].js',
                         'manifest.json',
-                        'symfony_logo.91beba37.png',
-                        'symfony_logo_alt.f880ba14.png',
+                        'symfony_logo.[hash:8].png',
+                        'symfony_logo_alt.[hash:8].png',
                     ]);
 
                     webpackAssert.assertManifestPath(


### PR DESCRIPTION
Fixes #931

* `liveReload` currently causes the page to ALWAYS reload: HMR never has a chance to update the content. Disabling by default. This will mean people that currently like the liveReload won't have it anymore unless they re-enable it. But allowing HMR to be broken is not ok. See: https://github.com/symfony/webpack-encore/issues/931#issuecomment-784483725

* The hostname used for the web socket changed in Webpack 4. For most users it doesn't matter... they use localhost everywhere. But this PR explicitly sets the web socket hostname to the hostname of the dev-server.

TODO: fix/add tests

Cheers!