### PR TITLE
Do not allow webpack-dev-server to find an open port

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -606,7 +606,11 @@ class ConfigGenerator {
             client: {
                 // see https://github.com/symfony/webpack-encore/issues/931#issuecomment-784483725
                 host: this.webpackConfig.runtimeConfig.devServerHost,
-            }
+            },
+            // see https://github.com/symfony/webpack-encore/issues/941#issuecomment-787568811
+            // we cannot let webpack-dev-server find an open port, because we need
+            // to know the port for sure at Webpack config build time
+            port: this.webpackConfig.runtimeConfig.devServerPort,
         };
 
         return applyOptionsCallback(


### PR DESCRIPTION
Addresses on issue on #941 

This disallows the "find an open port" feature in webpack-dev-server. This is unfortunate, as this is a nice feature of webpack-dev-server where if port 8080 is open, it will try 8081, etc.

However, because we need to build a manifest.json file, we need to know what
the port is for sure at Webpack config build time. Even going through the same
async process of using the "find-port" package isn't really doable... as it
would make the entire config generation async (this may be possible, but would
change a ton of things in Encore & in userland `webpack.config.js` files).

Cheers!