### PR TITLE
fix: don't override process variable in DefinePlugin configuration

### DIFF
--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -21,9 +21,9 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
  */
 module.exports = function(plugins, webpackConfig) {
     const definePluginOptions = {
-        'process.env': {
-            NODE_ENV: webpackConfig.isProduction() ? '"production"' : '"development"'
-        }
+        'process.env.NODE_ENV': webpackConfig.isProduction()
+            ? '"production"'
+            : '"development"',
     };
 
     plugins.push({

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -225,7 +225,7 @@ describe('The config-generator function', () => {
             const actualConfig = configGenerator(config);
 
             const definePlugin = findPlugin(webpack.DefinePlugin, actualConfig.plugins);
-            expect(definePlugin.definitions['process.env'].NODE_ENV).to.equal('"development"');
+            expect(definePlugin.definitions['process.env.NODE_ENV']).to.equal('"development"');
 
             expect(actualConfig.optimization.minimizer).to.be.undefined;
         });
@@ -241,7 +241,7 @@ describe('The config-generator function', () => {
             const actualConfig = configGenerator(config);
 
             const definePlugin = findPlugin(webpack.DefinePlugin, actualConfig.plugins);
-            expect(definePlugin.definitions['process.env'].NODE_ENV).to.equal('"production"');
+            expect(definePlugin.definitions['process.env.NODE_ENV']).to.equal('"production"');
 
             expect(actualConfig.optimization.minimizer[0]).to.not.be.undefined;
         });

--- a/test/plugins/define.js
+++ b/test/plugins/define.js
@@ -32,7 +32,7 @@ describe('plugins/define', () => {
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
-        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('development'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).to.equal(JSON.stringify('development'));
     });
 
     it('production environment with default settings', () => {
@@ -42,7 +42,7 @@ describe('plugins/define', () => {
         definePluginUtil(plugins, config);
         expect(plugins.length).to.equal(1);
         expect(plugins[0].plugin).to.be.instanceof(webpack.DefinePlugin);
-        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).to.equal(JSON.stringify('production'));
     });
 
     it('production environment with options callback', () => {
@@ -51,7 +51,7 @@ describe('plugins/define', () => {
 
         config.configureDefinePlugin((options) => {
             options['foo'] = true;
-            options['process.env'].bar = true;
+            options['process.env.bar'] = true;
         });
 
         definePluginUtil(plugins, config);
@@ -60,10 +60,10 @@ describe('plugins/define', () => {
 
         // Allows to add new definitions
         expect(plugins[0].plugin.definitions.foo).to.equal(true);
-        expect(plugins[0].plugin.definitions['process.env'].bar).to.equal(true);
+        expect(plugins[0].plugin.definitions['process.env.bar']).to.equal(true);
 
         // Doesn't remove default definitions
-        expect(plugins[0].plugin.definitions['process.env'].NODE_ENV).to.equal(JSON.stringify('production'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).to.equal(JSON.stringify('production'));
     });
 
     it('production environment with options callback that returns an object', () => {


### PR DESCRIPTION
Following the warning on https://webpack.js.org/plugins/define-plugin/:

> When defining values for process prefer
> `'process.env.NODE_ENV': JSON.stringify('production')` over
> `process: { env: { NODE_ENV: JSON.stringify('production') } }`.
> Using the latter will overwrite the process object which can break
> compatibility with some modules that expect other values on the
> process object to be defined.

This fixed a conflict warning I had when using [`dotenv-webpack` plugin](https://github.com/mrsteele/dotenv-webpack):

```
DefinePlugin
Conflicting values for 'process.env'
```