### PR TITLE
v1.1.2  missing commits from main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symfony/webpack-encore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Webpack Encore is a simpler way to integrate Webpack into your application",
   "main": "index.js",
   "scripts": {

--- a/test/functional.js
+++ b/test/functional.js
@@ -2651,7 +2651,7 @@ module.exports = {
                 });
             });
 
-            it.only('Use splitChunks in production mode', (done) => {
+            it('Use splitChunks in production mode', (done) => {
                 const config = createWebpackConfig('web/build', 'production');
                 config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
                 config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2666,18 +2666,18 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['/build/runtime.js', '/build/[id].js', '/build/[id].js', '/build/main.js'],
-                                css: ['/build/[id].css']
+                                js: ['/build/runtime.js', '/build/961.js', '/build/38.js', '/build/main.js'],
+                                css: ['/build/38.css']
                             },
                             other: {
-                                js: ['/build/runtime.js', '/build/[id].js', '/build/[id].js', '/build/other.js'],
-                                css: ['/build/[id].css']
+                                js: ['/build/runtime.js', '/build/961.js', '/build/38.js', '/build/other.js'],
+                                css: ['/build/38.css']
                             }
                         }
                     });
 
                     // make split chunks are correct in manifest
-                    webpackAssert.assertManifestPath('build/[id].js', '/build/[id].[hash:8].js');
+                    webpackAssert.assertManifestKeyExists('build/961.js');
 
                     done();
                 });

--- a/test/functional.js
+++ b/test/functional.js
@@ -2651,7 +2651,7 @@ module.exports = {
                 });
             });
 
-            it('Use splitChunks in production mode', (done) => {
+            it.only('Use splitChunks in production mode', (done) => {
                 const config = createWebpackConfig('web/build', 'production');
                 config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
                 config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2666,18 +2666,18 @@ module.exports = {
                     webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                         entrypoints: {
                             main: {
-                                js: ['/build/runtime.js', '/build/961.js', '/build/38.js', '/build/main.js'],
-                                css: ['/build/38.css']
+                                js: ['/build/runtime.js', '/build/[id].js', '/build/[id].js', '/build/main.js'],
+                                css: ['/build/[id].css']
                             },
                             other: {
-                                js: ['/build/runtime.js', '/build/961.js', '/build/38.js', '/build/other.js'],
-                                css: ['/build/38.css']
+                                js: ['/build/runtime.js', '/build/[id].js', '/build/[id].js', '/build/other.js'],
+                                css: ['/build/[id].css']
                             }
                         }
                     });
 
                     // make split chunks are correct in manifest
-                    webpackAssert.assertManifestKeyExists('build/961.js');
+                    webpackAssert.assertManifestPath('build/[id].js', '/build/[id].[hash:8].js');
 
                     done();
                 });


### PR DESCRIPTION
Hi!

When I tagged 1.1.2, I mistakenly included 1 commit that was not on main. That commit, plus the commit that bumps `package.json`, were never pushed to main. Thanks to @Kocal for pointing this out - it was an error in my release process. Fortunately, the extra commit was just to a test file.

This PR adds those 2 commits, and reverts the test commit. This add the 2 missing commits into `main` and revert the code change that was never intended.

Cheers!