### PR TITLE
Locking assets-webpack-plugin to less than 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.7.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.10.0",
-    "assets-webpack-plugin": "^7.0.0",
+    "assets-webpack-plugin": "7.0.*",
     "babel-loader": "^8.2.2",
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,7 +1687,7 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
-assets-webpack-plugin@^7.0.0:
+assets-webpack-plugin@7.0.*:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/assets-webpack-plugin/-/assets-webpack-plugin-7.0.0.tgz#c61ed7466f35ff7a4d90d7070948736f471b8804"
   integrity sha512-DMZ9r6HFxynWeONRMhSOFTvTrmit5dovdoUKdJgCG03M6CC7XiwNImPH+Ad1jaVrQ2n59e05lBhte52xPt4MSA==


### PR DESCRIPTION
https://github.com/ztoben/assets-webpack-plugin/pull/392 makes our integrity calculation no longer work, as the files have not been emitted by the time processOutput() is called.

A better fix will need to be created. I'll create an issue after merging this for that.

The most obvious would be to - if possible - use the existing https://github.com/ztoben/assets-webpack-plugin#integrity 

If it IS possible (I don't know if it exposes all the same info we do), then we would need to deprecate the current format of the entrypoints.json file in favor of this new one.