### PR TITLE
#936: Fix manifest key problem when using copy files

### DIFF
--- a/lib/webpack-manifest-plugin/hooks.js
+++ b/lib/webpack-manifest-plugin/hooks.js
@@ -129,12 +129,16 @@ const normalModuleLoaderHook = ({ moduleAssets }, loaderContext, module) => {
   const { emitFile } = loaderContext;
 
   // eslint-disable-next-line no-param-reassign
-  loaderContext.emitFile = (file, content, sourceMap) => {
+  loaderContext.emitFile = (file, content, sourceMap, assetInfo) => {
+    const info = Object.assign({}, assetInfo);
+
     if (module.userRequest && !moduleAssets[file]) {
-      Object.assign(moduleAssets, { [file]: join(dirname(file), basename(module.userRequest)) });
+      info.sourceFilename = join(dirname(file), basename(module.userRequest));
+
+      Object.assign(moduleAssets, { [file]: info.sourceFilename });
     }
 
-    return emitFile.call(module, file, content, sourceMap);
+    return emitFile.call(module, file, content, sourceMap, info);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Webpack Encore is a simpler way to integrate Webpack into your application",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --reporter spec test --recursive",
+    "test": "yarn run test:main && yarn run test:persistent-cache",
+    "test:main": "mocha --reporter spec test --recursive --ignore test/persistent-cache/*",
+    "test:persistent-cache": "node run-persistent-tests",
     "lint": "eslint lib test index.js .eslintrc.js",
-    "travis:lint": "npm run lint"
+    "travis:lint": "yarn run lint"
   },
   "bin": {
     "encore": "bin/encore.js"

--- a/run-persistent-tests.js
+++ b/run-persistent-tests.js
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const { emptyTmpDir } = require('./test/helpers/setup');
+
+emptyTmpDir();
+for (let i = 0; i < 2; i++) {
+    execSync('mocha --reporter spec test/persistent-cache --recursive', { stdio: 'inherit' });
+}

--- a/test/functional.js
+++ b/test/functional.js
@@ -753,23 +753,6 @@ describe('Functional tests using webpack', function() {
             });
         });
 
-        it('Persistent caching does not cause problems', (done) => {
-            const config = createWebpackConfig('www/build', 'dev');
-            config.setPublicPath('/build');
-            config.addEntry('main', './js/code_splitting');
-            config.enableBuildCache({ config: [__filename] });
-
-            testSetup.runWebpack(config, (webpackAssert) => {
-                // sanity check
-                webpackAssert.assertManifestPath(
-                    'build/main.js',
-                    '/build/main.js'
-                );
-
-                done();
-            });
-        });
-
         describe('addCacheGroup()', () => {
             it('addCacheGroup() to extract a vendor into its own chunk', (done) => {
                 const config = createWebpackConfig('www/build', 'dev');
@@ -1294,7 +1277,6 @@ module.exports = {
                 done();
             });
         });
-
 
         it('When enabled, react JSX is transformed!', (done) => {
             const config = createWebpackConfig('www/build', 'dev');

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -25,8 +25,8 @@ const testFixturesDir = path.join(__dirname, '../', '../', 'fixtures');
 
 let servers = [];
 
-function createTestAppDir(rootDir = tmpDir) {
-    const testAppDir = path.join(rootDir, Math.random().toString(36).substring(7));
+function createTestAppDir(rootDir = null, subDir = null) {
+    const testAppDir = path.join(rootDir ? rootDir : tmpDir, subDir ? subDir : Math.random().toString(36).substring(7));
 
     // copy the fixtures into this new directory
     fs.copySync(testFixturesDir, testAppDir);

--- a/test/persistent-cache/functional.js
+++ b/test/persistent-cache/functional.js
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const chai = require('chai');
+chai.use(require('chai-fs'));
+chai.use(require('chai-subset'));
+const path = require('path');
+const testSetup = require('../helpers/setup');
+
+function createWebpackConfig(outputDirName = '', testName, command, argv = {}) {
+    // We need a static named test dir for the cache to work
+    let testAppDir = testSetup.createTestAppDir(null, testName + '/test');
+    const webpackConfig = testSetup.createWebpackConfig(
+        testAppDir,
+        outputDirName,
+        command,
+        argv,
+    );
+
+    webpackConfig.enableSingleRuntimeChunk();
+    webpackConfig.enableBuildCache({ config: [__filename] }, (cache) => {
+        cache.cacheDirectory = path.resolve(testAppDir, '..', '.webpack-cache');
+    });
+
+    return webpackConfig;
+}
+
+describe('Functional persistent cache tests using webpack', function() {
+    // being functional tests, these can take quite long
+    this.timeout(10000);
+
+    describe('Basic scenarios.', () => {
+        it('Persistent caching does not cause problems', (done) => {
+            const config = createWebpackConfig('www/build', 'basic_cache', 'dev');
+            config.setPublicPath('/build');
+            config.addEntry('main', './js/code_splitting');
+
+            testSetup.runWebpack(config, (webpackAssert) => {
+                // sanity check
+                webpackAssert.assertManifestPath(
+                    'build/main.js',
+                    '/build/main.js',
+                );
+
+                done();
+            });
+        });
+    });
+
+    describe('copyFiles() allows to copy files and folders', () => {
+        it('Persistent caching does not cause problems', (done) => {
+            const config = createWebpackConfig('www/build', 'copy_files_cache', 'production');
+            config.addEntry('main', './js/no_require');
+            config.setPublicPath('/build');
+            config.enableVersioning(true);
+            config.copyFiles([{
+                from: './images',
+                includeSubdirectories: false,
+            }]);
+
+            testSetup.runWebpack(config, (webpackAssert) => {
+                webpackAssert.assertDirectoryContents([
+                    'entrypoints.json',
+                    'runtime.[hash:8].js',
+                    'main.[hash:8].js',
+                    'manifest.json',
+                    'symfony_logo.[hash:8].png',
+                    'symfony_logo_alt.[hash:8].png',
+                ]);
+
+                webpackAssert.assertManifestPath(
+                    'build/symfony_logo.png',
+                    '/build/symfony_logo.91beba37.png',
+                );
+
+                webpackAssert.assertManifestPath(
+                    'build/symfony_logo_alt.png',
+                    '/build/symfony_logo_alt.f880ba14.png',
+                );
+
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
So, the solution for #936 was not complex at all, but creating a failing test was. 

I needed to update the test scripts in the `package.json`, as webpack simply doesn't write it's cache until the mocha  process ends. I did not find an alternative way to trigger the cache files to be written. 

So, I separated the persistent cache tests into a dedicated directory/file, which is ignored during the normal test run. I added commands to run the persistent cache test both with and without previous cache (using the `CLEAR_PERSISTENT_CACHE` environment variable), and updated the original test command to run the normal test once, and the persistent cache tests twice (so the second run is with a valid cache). 

I also needed to update the temp directory generation for the persistent cache, as it need to be deterministic over multiple cache runs. This is done with an extra parameter when creating the webpack configuration. This also makes sure that the webpack persistent cache is not shared over multiple tests (as long as you use unique keys obviously.

Just let me know if something needs to be done different!