### PR TITLE
Allow less-loader v9

### DIFF
--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -19,7 +19,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
+    # needed so that Node 10 downloads a compatible less-loader version
+    - name: Clear lock file
+      run: del yarn.lock
     - name: yarn install
-      run: yarn install
+      run: yarn --ignore-engines
     - name: run tests
       run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,15 @@ matrix:
         - rm yarn.lock
         - yarn
     - os: linux
-      node_js: "10"
+      node_js: "14"
       env: JOB_PART=travis:lint
     - os: linux
       node_js: "10"
       env: JOB_PART=test
+      # needed so that Node 10 downloads a compatible less-loader version
+      install:
+        - rm yarn.lock
+        - yarn --ignore-engines
     - os: linux
       node_js: "12"
       env: JOB_PART=test

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "handlebars-loader": "^1.7.0",
     "http-server": "^0.12.3",
     "less": "^4.0.0",
-    "less-loader": "^7.0.0 || ^8.0.0",
+    "less-loader": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "mocha": "^8.2.1",
     "postcss": "^8.1.0",
     "postcss-loader": "^4.0.0 || ^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,10 +4455,10 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-"less-loader@^7.0.0 || ^8.0.0":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-8.1.1.tgz#ababe912580457ad00a4318146aac5b53e023f42"
-  integrity sha512-K93jJU7fi3n6rxVvzp8Cb88Uy9tcQKfHlkoezHwKILXhlNYiRQl4yowLIkQqmBXOH/5I8yoKiYeIf781HGkW9g==
+"less-loader@^7.0.0 || ^8.0.0 || ^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-9.0.0.tgz#71a0b530174bddf89bb11a5019dd725f54df4791"
+  integrity sha512-bPen1xeGTZuYFFobcdz9kMUVgSSSDZQJtyhawtCtcz1QboQOwhkI7uCwp5UO+IZpO+LJS1W73YwxsufbBT6SBQ==
   dependencies:
     klona "^2.0.4"
 


### PR DESCRIPTION
I'm not sure what the policy on node compatibility is, but the latest major of `less-loader` only seems to drop Node 10 support ([release notes](https://github.com/webpack-contrib/less-loader/blob/master/CHANGELOG.md)).

Webpack Encore still supports Node 10, but that should still be possible if you use one of the other allowed less loaders.