### PR TITLE
Allow less-loader 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "handlebars-loader": "^1.7.0",
     "http-server": "^0.12.3",
     "less": "^4.0.0",
-    "less-loader": "^7.0.0 || ^8.0.0 || ^9.0.0",
+    "less-loader": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "mocha": "^8.2.1",
     "postcss": "^8.1.0",
     "postcss-loader": "^4.0.0 || ^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,10 +4465,10 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-"less-loader@^7.0.0 || ^8.0.0 || ^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-9.0.0.tgz#71a0b530174bddf89bb11a5019dd725f54df4791"
-  integrity sha512-bPen1xeGTZuYFFobcdz9kMUVgSSSDZQJtyhawtCtcz1QboQOwhkI7uCwp5UO+IZpO+LJS1W73YwxsufbBT6SBQ==
+"less-loader@^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-10.0.0.tgz#2c21a204a29a46cba7de4e7d3659efa1e303c7d1"
+  integrity sha512-JjioAkw9qyavL0BzMPUOHJa0a20fh+ipq/MNZH4OkU8qERsCMeZIWRE0FDBIx2O+cFguvY01vHh/lmBA9LyWDg==
   dependencies:
     klona "^2.0.4"
 


### PR DESCRIPTION
Looks like the removed a [less context option](https://github.com/webpack-contrib/less-loader/releases/tag/v10.0.0), but I could find any place where it is used in this package.