### PR TITLE
Fix deprecated public option failure

### DIFF
--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -44,8 +44,8 @@ module.exports = function(argv, cwd) {
             runtimeConfig.devServerHttps = argv.https;
             runtimeConfig.devServerKeepPublicPath = argv.keepPublicPath || false;
 
-            if (typeof argv.public === 'string') {
-                runtimeConfig.devServerPublic = argv.public;
+            if (typeof argv['client-web-socket-url'] === 'string') {
+                runtimeConfig.devServerPublic = argv['client-web-socket-url'];
             }
 
             runtimeConfig.devServerHost = argv.host ? argv.host : 'localhost';

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -93,9 +93,9 @@ describe('parse-runtime', () => {
         expect(config.devServerHttps).to.equal(true);
     });
 
-    it('dev-server command public', () => {
+    it('dev-server command client-web-socket-url', () => {
         const testDir = createTestDirectory();
-        const config = parseArgv(createArgv(['dev-server', '--public', 'https://my-domain:8080']), testDir);
+        const config = parseArgv(createArgv(['dev-server', '--client-web-socket-url', 'https://my-domain:8080']), testDir);
 
         expect(config.devServerPublic).to.equal('https://my-domain:8080');
     });


### PR DESCRIPTION
The --public option used to specify which host to use in the manifest.json.

That options was deprecated in favor of client.webSocketURL

Fixes #1044 