### PR TITLE
changelog: fix typo in dropped typescript version 8 -> 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 Dependency changes:
 
 * Official support for `ts-loader` 8 was dropped.
-* Official support for `typescript` 8 was dropped and minimum increased to 4.2.2.
+* Official support for `typescript` 3 was dropped and minimum increased to 4.2.2.
 * Official support for `vue` was bumped to 3.2.14 or higher.
 * Official support for `vue-loader` was bumped to 16.7.0 or higher.
 


### PR DESCRIPTION
just a typo fix

1.7.0 release notes should also be updated
https://github.com/symfony/webpack-encore/releases/tag/v1.7.0