### PR TITLE
fix: Babel loader files add .mjs

### DIFF
--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -110,7 +110,7 @@ module.exports = {
      */
     getTest(webpackConfig) {
         const extensions = [
-            'jsx?', // match .js and .jsx
+            'm?jsx?', // match .js and .jsx and .mjs
         ];
 
         if (webpackConfig.useBabelTypeScriptPreset) {

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -670,7 +670,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
 
             // check for the default env preset only
             expect(JSON.stringify(jsRule.use[0].options.presets)).contains('@babel/preset-env');
@@ -1011,7 +1011,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             expect(String(jsRule.exclude)).to.equal(String(/(node_modules|bower_components)/));
 
             const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
@@ -1030,7 +1030,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             expect(String(jsRule.exclude)).to.equal(String(/foo/));
         });
 
@@ -1045,7 +1045,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             expect(jsRule.exclude).to.be.a('Function');
             expect(jsRule.exclude(path.join('test', 'node_modules', 'foo', 'index.js'))).to.be.false;
             expect(jsRule.exclude(path.join('test', 'node_modules', 'bar', 'index.js'))).to.be.true;
@@ -1063,7 +1063,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
             const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === '@babel/preset-env');
             expect(babelEnvPreset[1].useBuiltIns).to.equal('usage');
@@ -1080,7 +1080,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
             const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === '@babel/preset-env');
             expect(babelEnvPreset[1].useBuiltIns).to.equal(false);
@@ -1097,7 +1097,7 @@ describe('The config-generator function', () => {
 
             const actualConfig = configGenerator(config);
 
-            const jsRule = findRule(/\.(jsx?)$/, actualConfig.module.rules);
+            const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
             const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === '@babel/preset-env');
             expect(babelEnvPreset[1].useBuiltIns).to.equal('usage');

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -193,7 +193,7 @@ describe('loaders/babel', () => {
         const config = createConfig();
 
         const actualTest = babelLoader.getTest(config);
-        expect(actualTest.toString()).to.equals(/\.(jsx?)$/.toString());
+        expect(actualTest.toString()).to.equals(/\.(m?jsx?)$/.toString());
     });
 
     it('getTest() with TypeScript', () => {
@@ -201,6 +201,6 @@ describe('loaders/babel', () => {
         config.enableBabelTypeScriptPreset();
 
         const actualTest = babelLoader.getTest(config);
-        expect(actualTest.toString()).to.equals(/\.(jsx?|tsx?)$/.toString());
+        expect(actualTest.toString()).to.equals(/\.(m?jsx?|tsx?)$/.toString());
     });
 });


### PR DESCRIPTION
I just added `.mjs` to babel loader.

Closes: #1081
