### PR TITLE
Revert removing public option

### DIFF
--- a/bin/encore.js
+++ b/bin/encore.js
@@ -33,6 +33,12 @@ process.argv.splice(2, 1);
 const encoreOnlyArguments = new Set(['--keep-public-path']);
 process.argv = process.argv.filter(arg => !encoreOnlyArguments.has(arg));
 
+// remove argument --public not supported by webpack/dev-server
+const indexPublicArgument = process.argv.indexOf('--public');
+if (indexPublicArgument !== -1) {
+    process.argv.splice(indexPublicArgument, 2);
+}
+
 if (!runtimeConfig.isValidCommand) {
     if (runtimeConfig.command) {
         console.log(chalk.bgRed.white(`Invalid command "${runtimeConfig.command}"`));
@@ -78,6 +84,7 @@ function showUsageInstructions() {
     console.log(`       - ${chalk.yellow('--host')} The hostname/ip address the webpack-dev-server will bind to`);
     console.log(`       - ${chalk.yellow('--port')} The port the webpack-dev-server will bind to`);
     console.log(`       - ${chalk.yellow('--keep-public-path')} Do not change the public path (it is usually prefixed by the dev server URL)`);
+    console.log(`       - ${chalk.yellow('--public')} The public url for entry asset in entrypoints.json`);
     console.log('       - Supports any webpack-dev-server options');
     console.log();
     console.log(`    ${chalk.green('production')} : runs webpack for production`);

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -44,8 +44,8 @@ module.exports = function(argv, cwd) {
             runtimeConfig.devServerHttps = argv.https;
             runtimeConfig.devServerKeepPublicPath = argv.keepPublicPath || false;
 
-            if (typeof argv['client-web-socket-url'] === 'string') {
-                runtimeConfig.devServerPublic = argv['client-web-socket-url'];
+            if (typeof argv.public === 'string') {
+                runtimeConfig.devServerPublic = argv.public;
             }
 
             runtimeConfig.devServerHost = argv.host ? argv.host : 'localhost';

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -93,9 +93,9 @@ describe('parse-runtime', () => {
         expect(config.devServerHttps).to.equal(true);
     });
 
-    it('dev-server command client-web-socket-url', () => {
+    it('dev-server command public', () => {
         const testDir = createTestDirectory();
-        const config = parseArgv(createArgv(['dev-server', '--client-web-socket-url', 'https://my-domain:8080']), testDir);
+        const config = parseArgv(createArgv(['dev-server', '--public', 'https://my-domain:8080']), testDir);
 
         expect(config.devServerPublic).to.equal('https://my-domain:8080');
     });


### PR DESCRIPTION
Add --public option like an encore argument to specify public url that use for entry asset in entrypoints.json. 

I have a problem with this suggestion when I try to build webpack but the result is correct.
Anyone can help me ?

<img width="928" alt="Capture d’écran 2022-02-17 à 20 43 09" src="https://user-images.githubusercontent.com/15611563/154558941-411037fb-9d2a-4532-a158-73870a575708.png">

Fixes #1094 