### PR TITLE
Adds sass-embedded as possible sass-loader backend (see #1093)

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -20,8 +20,7 @@ const features = {
         method: 'enableSassLoader()',
         packages: [
             { name: 'sass-loader', enforce_version: true },
-            // allow node-sass or sass to be installed
-            [{ name: 'sass' }, { name: 'node-sass' }]
+            [{ name: 'sass' }, { name: 'sass-embedded' }, { name: 'node-sass' }]
         ],
         description: 'load Sass files'
     },


### PR DESCRIPTION
Allows sass-embedded as additional sass-loader backend ass discussed in #1093 and https://github.com/symfony/webpack-encore/issues/1011#issuecomment-1040041930