### PR TITLE
Add vue 2.7 feature

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -132,6 +132,7 @@ class ConfigGenerator {
             const vueVersion = getVueVersion(this.webpackConfig);
             switch (vueVersion) {
                 case 2:
+                case '2.7':
                     config.resolve.alias['vue$'] = 'vue/dist/vue.esm.js';
                     break;
                 case 3:

--- a/lib/features.js
+++ b/lib/features.js
@@ -97,6 +97,15 @@ const features = {
         ],
         description: 'load Vue files'
     },
+    'vue2.7': {
+        method: 'enableVueLoader()',
+        // vue is needed so the end-user can do things
+        packages: [
+            { name: 'vue', version: '^2.7' },
+            { name: 'vue-loader', version: '^15.10.0' },
+        ],
+        description: 'load Vue files'
+    },
     vue3: {
         method: 'enableVueLoader()',
         // vue is needed so the end-user can do things

--- a/lib/utils/get-vue-version.js
+++ b/lib/utils/get-vue-version.js
@@ -16,7 +16,7 @@ const logger = require('../logger');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {int|null}
+ * @return {int|string|null}
  */
 module.exports = function(webpackConfig) {
     if (webpackConfig.vueOptions.version !== null) {
@@ -28,6 +28,10 @@ module.exports = function(webpackConfig) {
     if (null === vueVersion) {
         // 2 is the current default version to recommend
         return 2;
+    }
+
+    if (semver.satisfies(vueVersion, '^2.7')) {
+        return '2.7';
     }
 
     if (semver.satisfies(vueVersion, '^2')) {


### PR DESCRIPTION

https://blog.vuejs.org/posts/vue-2-7-naruto.html

With `vue 2.7` released, so i try to upgrade my app to `vue 2.7`.

and followed the upgrade guide, after I removed the package `vue-template-compiler`
> Upgrade vue to ^2.7.0. You can also remove vue-template-compiler from the dependencies - it is no longer needed in 2.7.

it shows me the error
```
Error: Install vue-template-compiler to use enableVueLoader(  )
yarn add vue-template-compiler --dev
```

so add a special feature named `vue2.7`
