### PR TITLE
Accept a symbolic link as target of copyFrom

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -182,7 +182,7 @@ class ConfigGenerator {
                 return false;
             }
 
-            if (!fs.lstatSync(copyFrom).isDirectory()) {
+            if (!fs.statSync(copyFrom).isDirectory()) {
                 logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" seems to be a file. Nothing will be copied for this copyFiles() config object.`);
                 return false;
             }


### PR DESCRIPTION
There's no reason why the `from` option of `copyFrom` cannot be a link to a directory. By using `stat` instead of `lstat`, we are allowing just that.