### PR TITLE
Match `@vue/compiler-sfc` requirement with `vue`

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@symfony/stimulus-bridge": "^3.0.0",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.0.0",
-    "@vue/compiler-sfc": "^3.0.2",
+    "@vue/compiler-sfc": "^2.6 || ^3.0.2",
     "eslint": "^8.0.0",
     "eslint-webpack-plugin": "^3.1.0",
     "file-loader": "^6.0.0",

--- a/test_apps/yarn-pnp-with-babel/yarn.lock
+++ b/test_apps/yarn-pnp-with-babel/yarn.lock
@@ -2435,7 +2435,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7

--- a/test_apps/yarn-pnp-with-external-babel-config/yarn.lock
+++ b/test_apps/yarn-pnp-with-external-babel-config/yarn.lock
@@ -2435,7 +2435,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7

--- a/test_apps/yarn-pnp/yarn.lock
+++ b/test_apps/yarn-pnp/yarn.lock
@@ -2412,7 +2412,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7


### PR DESCRIPTION
Fixes https://github.com/symfony/webpack-encore/issues/1165