### PR TITLE
Added default fallback value for `enableBabelTypeScriptPreset`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1206,7 +1206,7 @@ class Encore {
      * @param {object} options
      * @returns {Encore}
      */
-    enableBabelTypeScriptPreset(options) {
+    enableBabelTypeScriptPreset(options = {}) {
         webpackConfig.enableBabelTypeScriptPreset(options);
 
         return this;


### PR DESCRIPTION
The encore config wrapper does not have an optional/default argument fallback for `enableBabelTypeScriptPreset` and thus creates an invalid number of arguments notice when used without any while it does allow it in https://github.com/symfony/webpack-encore/blob/2e044a958dae6e6820aa99706642039ef8dd27cd/lib/WebpackConfig.js#L729