### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -963,7 +963,7 @@ class WebpackConfig {
         const entryNamesOverlapMsg = 'The entry names between addEntry(), addEntries(), and addStyleEntry() must be unique.';
 
         if (this.entries.has(name)) {
-            throw new Error(`Duplicate name "${name}}" already exists as an Entrypoint. ${entryNamesOverlapMsg}`);
+            throw new Error(`Duplicate name "${name}" already exists as an Entrypoint. ${entryNamesOverlapMsg}`);
         }
 
         if (this.styleEntries.has(name)) {


### PR DESCRIPTION
There is a duplicate } sign. So this is printed in the error message.