### PR TITLE
upgrade css-minimizer-webpack-plugin to fix vulnerability YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.7.0",
-    "css-minimizer-webpack-plugin": "^4.0.0",
+    "css-minimizer-webpack-plugin": "^5.0.0",
     "fast-levenshtein": "^3.0.0",
     "mini-css-extract-plugin": "^2.6.0",
     "pkg-up": "^3.1.0",


### PR DESCRIPTION
Bump Vulnerability from dependencies YAML, after 'yarn audit'

┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Uncaught Exception in yaml                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ yaml                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.2.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @symfony/webpack-encore                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @symfony/webpack-encore > css-minimizer-webpack-plugin >     │
│               │ cssnano > yaml                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1091814                     │
└───────────────┴──────────────────────────────────────────────────────────────┘

Upgrade the package version of css-minimizer-webpack-plugin:^5.0.0 seem to fix this warning