### PR TITLE
Update the versions for official actions

### DIFF
--- a/.github/workflows/high-depends.yml
+++ b/.github/workflows/high-depends.yml
@@ -18,10 +18,10 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2.0.0
+                uses: actions/checkout@v3
 
             -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v2
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{matrix.node-versions}}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,10 +8,10 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2.0.0
+                uses: actions/checkout@v3
 
             -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v2
+                uses: actions/setup-node@v3
                 with:
                     node-version: '14'
 

--- a/.github/workflows/low-depends.yml
+++ b/.github/workflows/low-depends.yml
@@ -18,10 +18,10 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2.0.0
+                uses: actions/checkout@v3
 
             -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v2
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{matrix.node-versions}}
 

--- a/.github/workflows/stable-tests.yml
+++ b/.github/workflows/stable-tests.yml
@@ -18,10 +18,10 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2.0.0
+                uses: actions/checkout@v3
 
             -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v2
+                uses: actions/setup-node@v3
                 with:
                     node-version: ${{matrix.node-versions}}
 

--- a/.github/workflows/testing_apps.yml
+++ b/.github/workflows/testing_apps.yml
@@ -87,10 +87,10 @@ jobs:
 
     steps:
       -   name: Checkout
-          uses: actions/checkout@v2.0.0
+          uses: actions/checkout@v3
 
       -   name: Node ${{matrix.node-versions}}
-          uses: actions/setup-node@v2
+          uses: actions/setup-node@v3
           with:
             node-version: '14'
 


### PR DESCRIPTION
This will avoid using deprecated versions