### PR TITLE
bug: accept use with addPlugin only

### DIFF
--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -43,8 +43,9 @@ class Validator {
         if (this.webpackConfig.entries.size === 0
             && this.webpackConfig.styleEntries.size === 0
             && this.webpackConfig.copyFilesConfigs.length === 0
+            && this.webpackConfig.plugins.length === 0
         ) {
-            throw new Error('No entries found! You must call addEntry() or addEntries() or addStyleEntry() or copyFiles() at least once - otherwise... there is nothing to webpack!');
+            throw new Error('No entries found! You must call addEntry() or addEntries() or addStyleEntry() or copyFiles() or addPlugin() at least once - otherwise... there is nothing to webpack!');
         }
     }
 

--- a/test/config/validator.js
+++ b/test/config/validator.js
@@ -24,6 +24,8 @@ function createConfig() {
 }
 
 describe('The validator function', () => {
+    function CustomPlugin1() {}
+
     it('throws an error if there are no entries', () => {
         const config = createConfig();
         config.publicPath = '/';
@@ -45,6 +47,17 @@ describe('The validator function', () => {
         }).not.throw();
 
         expect(Object.keys(config.copyFilesConfigs).length).to.equal(1);
+    });
+
+    it('should accept use with addPlugin() only', () => {
+        const config = createConfig();
+        config.setOutputPath('/tmp');
+        config.setPublicPath('/tmp');
+        config.addPlugin(new CustomPlugin1());
+
+        expect(() => {
+            validator(config);
+        }).not.throw();
     });
 
     it('throws an error if there is no output path', () => {


### PR DESCRIPTION
i have a multi config setup. In one of my configs i only call `addPlugin()`.

```js
const path = require('node:path');
const fileName = process.env.COPY_FILE_NAME || false;
let copyConfig = {};
if (fileName) {
  copyConfig = {
    from: `${fileName}`,
    to: `${path.dirname(path.relative(path.resolve(__dirname, 'picture'), fileName))}/[name].[contenthash:8][ext]`,
  }
} else {
  copyConfig = {
    from: './picture',
    to: '[path][name].[contenthash:8][ext]'
  }

  Encore.cleanupOutputBeforeBuild()
};

const CopyPlugin = require('copy-webpack-plugin');
Encore
...
  .addPlugin(
      new CopyPlugin({
        patterns: [copyConfig],
      })
    )
...
```

this config only copy files optional only  a specific ;)

Actually only use `addPlugin()` is not supported. I change the code and add test for the scenario.

releated #1140