### PR TITLE
Deprecate ESLint integration

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -771,6 +771,8 @@ class WebpackConfig {
     }
 
     enableEslintPlugin(eslintPluginOptionsOrCallback = () => {}) {
+        logger.deprecation('The ESLint integration is now deprecated and will be removed in the next major release. Please use the standalone ESLint CLI instead, or use the ESLint Webpack plugin directly.');
+
         this.useEslintPlugin = true;
 
         if (typeof eslintPluginOptionsOrCallback === 'function') {


### PR DESCRIPTION
Close #1281 
Let's deprecate it for now, and remove it later in a new major version

<img width="1773" alt="image" src="https://github.com/user-attachments/assets/6e817415-9cc3-4e8c-812c-143e2f16254e">
