### PR TITLE
Improve ESLint and Babel help messages, when enabling ESLint integration

### DIFF
--- a/lib/plugins/eslint.js
+++ b/lib/plugins/eslint.js
@@ -40,6 +40,7 @@ If you prefer to create a ${chalk.yellow('.eslintrc.js')} file by yourself, here
 
 ${chalk.yellow(`// .eslintrc.js
 module.exports = {
+    root: true,
     parser: '@babel/eslint-parser',
     extends: ['eslint:recommended'],
 }
@@ -51,13 +52,37 @@ Install ${chalk.yellow('@babel/eslint-parser')} to prevent potential parsing iss
                 const babelConfig = babelLoaderUtil.getLoaders(webpackConfig)[0].options;
                 // cacheDirectory is a custom loader option, not a Babel option
                 delete babelConfig['cacheDirectory'];
+
+                (babelConfig['presets'] || []).forEach(preset => {
+                    if (!Array.isArray(preset)) {
+                        return;
+                    }
+
+                    if (typeof preset[0] === 'string' && preset[0].includes('@babel') && preset[0].includes('preset-env')) {
+                        // The goal is to replace the preset string with a require.resolve() call, executed at runtime.
+                        // Since we output the Babel config as JSON, we need to replace it with a placeholder.
+                        preset[0] = '__PATH_TO_BABEL_PRESET_ENV__';
+
+                        // The option "targets" is not necessary
+                        delete preset[1]['targets'];
+
+                        // If needed, specify the core-js version to use
+                        if (preset[1]['corejs'] === null) {
+                            preset[1]['corejs'] = packageHelper.getPackageVersion('core-js');
+                        }
+                    }
+                });
+
                 message += `
 
 You will also need to specify your Babel config in a separate file. The current
 configuration Encore has been adding for your is:
 
 ${chalk.yellow(`// babel.config.js
-module.exports = ${JSON.stringify(babelConfig, null, 4)}
+module.exports = ${
+    JSON.stringify(babelConfig, null, 4)
+        .replace('"__PATH_TO_BABEL_PRESET_ENV__"', 'require.resolve("@babel/preset-env")')
+}
 `)}`;
 
                 if (webpackConfig.babelConfigurationCallback) {


### PR DESCRIPTION
While working on ESLint deprecation (requiring me to have a valid setup, etc...), those messages are displayed when you try to enable ESLint integration:

```
➜  sf-webpack-encore-lab git:(main) ✗ pnpm dev

> @ dev /Users/kocal/workspace/sf-webpack-encore-lab
> encore dev

Running webpack ...

 DEPRECATION  The ESLint integration is now deprecated and will be removed in the next major release. Please use the standalone ESLint CLI instead, or use the ESLint Webpack plugin directly.
  Error: No ESLint configuration has been found.

   FIX  Run command ./node_modules/.bin/eslint --init or manually create a .eslintrc.js file at   the root of your project.

  If you prefer to create a .eslintrc.js file by yourself, here is an example to get you started:

  // .eslintrc.js
  module.exports = {
      parser: '@babel/eslint-parser',
      extends: ['eslint:recommended'],
  }


  Install @babel/eslint-parser to prevent potential parsing issues: yarn add @babel/eslint-parser --dev


  You will also need to specify your Babel config in a separate file. The current
  configuration Encore has been adding for your is:

  // babel.config.js
  module.exports = {
      "sourceType": "unambiguous",
      "presets": [
          [
              "/Users/kocal/workspace/sf-webpack-encore-lab/node_modules/.pnpm/@babel+preset-env@7.25.3_@babel+core@7.25.2/node_mo  dules/@babel/preset-env/lib/index.js",
              {
                  "modules": false,
                  "targets": {},
                  "useBuiltIns": false,
                  "corejs": null
              }
          ]
      ],
      "plugins": []
  }

  Additionally, remove the .configureBabel() in webpack.config.js: this will no longer be used.
  And remove the .configureBabelPresetEnv() in webpack.config.js: this will no longer be used.
```

There are many errors in those messages:
1. The option `root: true` is missing for ESLint
2. I expect to see `require.resolve("@babel/preset-env")` instead of `"/Users/kocal/workspace/sf-webpack-encore-lab/node_modules/.pnpm/@babel+preset-env@7.25.3_@babel+core@7.25.2/node_mo  dules/@babel/preset-env/lib/index.js"` for Babel.
3. I expect the `corejs` option to be set to the current version of `core-js` (if exists)

With this PR, the output is now:
```
> encore dev

Running webpack ...

 DEPRECATION  The ESLint integration is now deprecated and will be removed in the next major release. Please use the standalone ESLint CLI instead, or use the ESLint Webpack plugin directly.
  Error: No ESLint configuration has been found.

   FIX  Run command ./node_modules/.bin/eslint --init or manually create a .eslintrc.js file at   the root of your project.

  If you prefer to create a .eslintrc.js file by yourself, here is an example to get you started:

  // .eslintrc.js
  module.exports = {
      root: true,
      parser: '@babel/eslint-parser',
      extends: ['eslint:recommended'],
  }


  Install @babel/eslint-parser to prevent potential parsing issues: yarn add @babel/eslint-parser --dev


  You will also need to specify your Babel config in a separate file. The current
  configuration Encore has been adding for your is:

  // babel.config.js
  module.exports = {
      "sourceType": "unambiguous",
      "presets": [
          [
              require.resolve("@babel/preset-env"),
              {
                  "modules": false,
                  "useBuiltIns": false,
                  "corejs": "3.38.1"
              }
          ]
      ],
      "plugins": []
  }
```