### PR TITLE
Deprecate Vue 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ## UNRELEASED
 
-* #1259 Update yarn used for test_apps to latest version (@karpilin)
-
-* #1275 Update some dev-dependencies to fix vulnerability issues (@Kocal)
-
-* #1278 Deprecate ESLint integration (@Kocal)
+### Features
 
 * #1284 Improve ESLint and Babel help messages, when enabling ESLint integration (@Kocal)
 
@@ -16,7 +12,7 @@
 
 * #1295 Add JSX support for Vue 3 (@Kocal)
 
-Enabling JSX support for Vue 3 is done with the `Encore.enableVueLoader()`: 
+Enabling JSX support for Vue 3 is done with the `Encore.enableVueLoader()`:
 ```js
 Encore.enableVueLoader(() => {}, { 
     useJsx: true,
@@ -25,7 +21,7 @@ Encore.enableVueLoader(() => {}, {
 ```
 
 If you don't have a custom Babel configuration, then you're all set!
-But if you do, you may need to adjust it 
+But if you do, you may need to adjust it
 to add [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) plugin to your Babel configuration:
 ```js
 // babel.config.js
@@ -35,6 +31,18 @@ module.exports = {
     ]
 };
 ```
+
+### Deprecations
+
+* #1278 Deprecate ESLint integration (@Kocal)
+
+* #1298 Deprecate Vue 2 support (@Kocal)
+
+### Internal
+
+* #1275 Update some dev-dependencies to fix vulnerability issues (@Kocal)
+
+* #1259 Update yarn used for test_apps to latest version (@karpilin)
 
 * #1297 Upgrade GitHub Actions in CI (@Kocal)
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -133,6 +133,9 @@ class ConfigGenerator {
             switch (vueVersion) {
                 case 2:
                 case '2.7':
+                    logger.deprecation('The support for Vue 2 is deprecated and will be removed in the next major version of Encore.' +
+                        ' Please upgrade to Vue 3, and if necessary remove the "version" setting or set it to 3 when calling ".enableVueLoader()".');
+
                     config.resolve.alias['vue$'] = 'vue/dist/vue.esm.js';
                     break;
                 case 3:


### PR DESCRIPTION
Close #1276, Vue 2 has reached its end of life the 31st december 2023.

If I install `vue@2` or if I specify `version: 2` in `.enableVueLoader()`, a deprecation message is now shown:
<img width="1733" alt="image" src="https://github.com/user-attachments/assets/c96f7f79-4a7c-425b-a8ba-22c3cb6b1e43">
