### PR TITLE
Replace `pkg-up` by an inlined solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ module.exports = {
 
 * #1304 Replace `fast-levenshtein` by `fastest-levenshtein` (@Kocal)
 
+* #1303 Replace `pkg-up` by an inlined solution (@Kocal)
+
 ## [v4.6.1](https://github.com/symfony/webpack-encore/releases/tag/v4.6.1)
 
 * #1256 Re-adding node 18 support (@weaverryan)

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const RuntimeConfig = require('./RuntimeConfig');
-const pkgUp = require('pkg-up');
+const packageUp = require('../utils/package-up');
 const path = require('path');
 const babel = require('@babel/core');
 
@@ -59,7 +59,7 @@ module.exports = function(argv, cwd) {
 
     runtimeConfig.context = argv.context;
     if (typeof runtimeConfig.context === 'undefined') {
-        const packagesPath = pkgUp.sync({ cwd });
+        const packagesPath = packageUp({ cwd });
 
         if (null === packagesPath) {
             throw new Error('Cannot determine webpack context. (Are you executing webpack from a directory outside of your project?). Try passing the --context option.');

--- a/lib/utils/package-up.js
+++ b/lib/utils/package-up.js
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { fileURLToPath } = require('url');
+
+/**
+ * Inlined version of the package "package-up" (ESM only).
+ *
+ * @param {string} cwd The directory to start searching from.
+ * @returns {string|undefined} The path to the nearest package.json file or undefined if not found.
+ */
+module.exports = function({ cwd }) {
+    return findUpSync('package.json', { cwd, type: 'file' });
+};
+
+function toPath(urlOrPath) {
+    return urlOrPath instanceof URL ? fileURLToPath(urlOrPath) : urlOrPath;
+}
+
+/**
+ * Inlined and simplified version of the package "find-up-simple" (ESM only).
+ *
+ * @param {string} name The name of the file to find
+ * @param {Object} options
+ * @param {string} options.cwd The directory to start searching from.
+ * @returns {string|undefined} The path to the file found or undefined if not found.
+ */
+function findUpSync(name, { cwd = process.cwd() } = {}) {
+    let directory = path.resolve(toPath(cwd) || '');
+    const { root } = path.parse(directory);
+
+    while (directory && directory !== root) {
+        const filePath = path.isAbsolute(name) ? name : path.join(directory, name);
+
+        try {
+            const stats = fs.statSync(filePath, { throwIfNoEntry: false });
+            if (stats && stats.isFile()) {
+                return filePath;
+            }
+        } catch (e) {}
+
+        directory = path.dirname(directory);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "css-minimizer-webpack-plugin": "^5.0.0",
     "fastest-levenshtein": "^1.0.16",
     "mini-css-extract-plugin": "^2.6.0",
-    "pkg-up": "^3.1.0",
     "pretty-error": "^4.0.0",
     "resolve-url-loader": "^5.0.0",
     "semver": "^7.3.2",

--- a/test/utils/package-up.js
+++ b/test/utils/package-up.js
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const { resolve: resolvePath } = require('path');
+const expect = require('chai').expect;
+const packageUp = require('../../lib/utils/package-up');
+
+describe('package-up', () => {
+    const test = {
+        'package.json from Encore': {
+            cwd: __dirname,
+            expectedPath: resolvePath(__dirname, '../../package.json'),
+        },
+        'package.json from a subdirectory': {
+            cwd: resolvePath(__dirname, '../../fixtures/stimulus/mock-module'),
+            expectedPath: resolvePath(__dirname, '../../fixtures/stimulus/mock-module/package.json'),
+        },
+        'package.json from Encore when no package.json exists in the current directory': {
+            cwd: resolvePath(__dirname, '../../fixtures'),
+            expectedPath: resolvePath(__dirname, '../../package.json'),
+        },
+        'package.json from Encore when no package.json exists in the current directory (subdirectory)': {
+            cwd: resolvePath(__dirname, '../../fixtures/copy'),
+            expectedPath: resolvePath(__dirname, '../../package.json'),
+        },
+    };
+
+    Object.entries(test).forEach(([description, { cwd, expectedPath }]) => {
+        it(description, () => {
+            expect(expectedPath).to.be.a('string');
+
+            const path = packageUp({ cwd });
+
+            expect(path).to.equal(expectedPath);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,13 +3786,6 @@ find-up@5.0.0, find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
-
 find-up@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -4925,14 +4918,6 @@ locate-character@^3.0.0:
   resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
   integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -5444,7 +5429,7 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -5464,13 +5449,6 @@ p-limit@^4.0.0:
   integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
     yocto-queue "^1.0.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -5542,11 +5520,6 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -5662,13 +5635,6 @@ pkg-dir@^7.0.0:
   integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
   dependencies:
     find-up "^6.3.0"
-
-pkg-up@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
-  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  dependencies:
-    find-up "^3.0.0"
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
[`pkg-up`](https://www.npmjs.com/package/pkg-up) is deprecated, and has been replaced by [`package-up`](https://www.npmjs.com/package/package-up). This one is more lightweight, but is only available as ESM format, which is not compatible with Encore.

So, I've dropped `pkg-up` and inlined `package-up` and its single dependency [`find-up-simple`](https://www.npmjs.com/package/find-up-simple), with some tests. 

Removing `pkg-up` remove a lot of sub-dependencies aswell, which is better in term of security, but also in term of bandwidth and size on disk. 

Here, you can see the impact without `pkg-up` and with `package-up`,  we reduce the bandwidth consumption by ~500 GB (but note that our inlined solution is smaller than `package-up`): 
```
Package size report
===================

Package info for "@symfony/webpack-encore@4.6.1": 61 MB
  Released: 2024-01-25 17:18:00.95 +0000 UTC (30w1d ago)
  Downloads last week: 48,107 (32.02%)
  Estimated traffic last week: 2.9 TB
  Subdependencies: 634

Removed dependencies:
  - pkg-up@3.1.0: 36 kB (0.05%)
    Downloads last week: 6,317,196 (N/A% from 3.1.0)
    Downloads last week from "@symfony/webpack-encore@4.6.1": 48,107 (N/A%)
    Traffic last week: N/A
    Traffic from "@symfony/webpack-encore@4.6.1": 2.9 TB (N/A%)
    Subdependencies: 6 (0.94%)

Added dependencies:
  + package-up@5.0.0: 13 kB (0.02%)
    Downloads last week: 31,071 (N/A% from 5.0.0)
    Estimated traffic last week: N/A
    Subdependencies: 1 (0.15%)

Estimated new statistics:
  Package size: 61 MB → 51 MB (83.07%)
  Subdependencies: 634 → 486 (-148)
  Traffic with last week's downloads:
    For current version: 2.9 TB → 2.4 TB (498 GB saved)
    For all versions: 9.2 TB → 7.6 TB (1.6 TB saved)
```

