### PR TITLE
Replace `fast-levenshtein` by `fastest-levenshtein`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ module.exports = {
 
 * #1297 Upgrade GitHub Actions in CI (@Kocal)
 
+* #1304 Replace `fast-levenshtein` by `fastest-levenshtein` (@Kocal)
+
 ## [v4.6.1](https://github.com/symfony/webpack-encore/releases/tag/v4.6.1)
 
 * #1256 Re-adding node 18 support (@weaverryan)

--- a/lib/EncoreProxy.js
+++ b/lib/EncoreProxy.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const levenshtein = require('fast-levenshtein');
+const levenshtein = require('fastest-levenshtein');
 const prettyError = require('./utils/pretty-error');
 
 module.exports = {
@@ -69,7 +69,7 @@ module.exports = {
                             continue;
                         }
 
-                        const distance = levenshtein.get(apiProperty, prop);
+                        const distance = levenshtein.distance(apiProperty, prop);
                         if (distance <= minDistance) {
                             similarProperty = apiProperty;
                             minDistance = distance;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.7.0",
     "css-minimizer-webpack-plugin": "^5.0.0",
-    "fast-levenshtein": "^3.0.0",
+    "fastest-levenshtein": "^1.0.16",
     "mini-css-extract-plugin": "^2.6.0",
     "pkg-up": "^3.1.0",
     "pretty-error": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,14 +3711,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-levenshtein@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz#37b899ae47e1090e40e3fd2318e4d5f0142ca912"
-  integrity sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==
-  dependencies:
-    fastest-levenshtein "^1.0.7"
-
-fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.7:
+fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
   integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==


### PR DESCRIPTION
Package [`fast-levenshtein`](https://www.npmjs.com/package/fast-levenshtein) is a wrapper around [`fastest-levenshtein`](https://www.npmjs.com/package/fastest-levenshtein), but we do not need locale-sensitive string comparaison.

```
Package size report
===================

Package info for "@symfony/webpack-encore@4.6.1": 61 MB
  Released: 2024-01-25 17:18:00.95 +0000 UTC (30w1d ago)
  Downloads last week: 48,107 (32.02%)
  Estimated traffic last week: 2.9 TB
  Subdependencies: 634

Removed dependencies:
  - fast-levenshtein@3.0.0: 30 kB (0.04%)
    Downloads last week: 1,563,771 (N/A% from 3.0.0)
    Downloads last week from "@symfony/webpack-encore@4.6.1": 48,107 (N/A%)
    Traffic last week: N/A
    Traffic from "@symfony/webpack-encore@4.6.1": 2.9 TB (N/A%)
    Subdependencies: 1 (0.15%)

Added dependencies:
  + fastest-levenshtein@1.0.16: 22 kB (0.03%)
    Downloads last week: 9,630,903 (N/A% from 1.0.16)
    Estimated traffic last week: N/A
    Subdependencies: 0 (0%)

Estimated new statistics:
  Package size: 61 MB → 51 MB (83.09%)
  Subdependencies: 634 → 490 (-144)
  Traffic with last week's downloads:
    For current version: 2.9 TB → 2.4 TB (497 GB saved)
    For all versions: 9.2 TB → 7.6 TB (1.6 TB saved)
```