### PR TITLE
Migrate to eslint-plugin-jsdoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,8 @@
 
 module.exports = {
     "root": true,
-    "plugins": ["node", "header"],
-    "extends": ["eslint:recommended", "plugin:node/recommended"],
+    "plugins": ["node", "header", "jsdoc"],
+    "extends": ["eslint:recommended", "plugin:node/recommended", "plugin:jsdoc/recommended"],
     "env": {
         "node": true,
         "es6": true,
@@ -49,7 +49,13 @@ module.exports = {
             "after": true
         }],
         "no-console": "off",
-        "valid-jsdoc": ["error", { "requireParamDescription": false, "requireReturnDescription": false }],
+        "jsdoc/require-jsdoc": "off",
+        "jsdoc/require-param-description": "off",
+        "jsdoc/require-property-description": "off",
+        "jsdoc/require-returns-description": "off",
+        "jsdoc/tag-lines": ["warn", "never", {
+            "startLines": 1
+        }],
         "node/no-unsupported-features": ["error", { version: 8 }],
         "node/no-deprecated-api": "error",
         "node/no-missing-import": "error",
@@ -65,6 +71,11 @@ module.exports = {
         "node/no-unpublished-require": "error",
         "node/process-exit-as-throw": "error",
         "header/header": [2, "block", { "pattern": "This file is part of the Symfony Webpack Encore package" }]
+    },
+    "settings": {
+        "jsdoc": {
+            "mode": "typescript"
+        }
     },
     "overrides": [
         {

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} definePluginOptionsCallback
+     * @param {Function} definePluginOptionsCallback
      * @returns {Encore}
      */
     configureDefinePlugin(definePluginOptionsCallback = () => {}) {
@@ -135,7 +135,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} friendlyErrorsPluginOptionsCallback
+     * @param {Function} friendlyErrorsPluginOptionsCallback
      * @returns {Encore}
      */
     configureFriendlyErrorsPlugin(friendlyErrorsPluginOptionsCallback = () => {}) {
@@ -156,7 +156,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} manifestPluginOptionsCallback
+     * @param {Function} manifestPluginOptionsCallback
      * @returns {Encore}
      */
     configureManifestPlugin(manifestPluginOptionsCallback = () => {}) {
@@ -182,7 +182,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} terserPluginOptionsCallback
+     * @param {Function} terserPluginOptionsCallback
      * @returns {Encore}
      */
     configureTerserPlugin(terserPluginOptionsCallback = () => {}) {
@@ -203,7 +203,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} cssMinimizerPluginOptionsCallback
+     * @param {Function} cssMinimizerPluginOptionsCallback
      * @returns {Encore}
      */
     configureCssMinimizerPlugin(cssMinimizerPluginOptionsCallback = () => {}) {
@@ -249,7 +249,7 @@ class Encore {
      * If the JavaScript files imports/requires CSS/Sass/LESS files,
      * then a CSS file (e.g. main.css) will also be output.
      *
-     * @param {Object.<string, string|array>} entries where the Keys are the
+     * @param {Record<string, string|Array>} entries where the Keys are the
      *                            names (without extension) that will be used
      *                            as the output filename (e.g. app will become app.js)
      *                            in the output directory. The values are the path(s)
@@ -337,7 +337,6 @@ class Encore {
      * Adds a custom loader config
      *
      * @param {object} loader The loader config object
-     *
      * @returns {Encore}
      */
     addLoader(loader) {
@@ -350,7 +349,6 @@ class Encore {
      * Alias to addLoader
      *
      * @param {object} rule
-     *
      * @returns {Encore}
      */
     addRule(rule) {
@@ -374,8 +372,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {object} aliases
-     *
+     * @param {Record<string, string>} aliases
      * @returns {Encore}
      */
     addAliases(aliases) {
@@ -415,7 +412,6 @@ class Encore {
      * ```
      *
      * @param {*} externals
-     *
      * @returns {Encore}
      */
     addExternals(externals) {
@@ -496,7 +492,7 @@ class Encore {
      * You can pass all the options supported by the SplitChunksPlugin
      * but also the following shorthand provided by Encore:
      *
-     * * `node_modules`: An array of `node_modules` packages names
+     * - `node_modules`: An array of `node_modules` packages names
      *
      * For example:
      *
@@ -511,9 +507,9 @@ class Encore {
      *
      * By default, the new cache group will be created with the
      * following options:
-     * * `chunks` set to `"all"`
-     * * `enforce` set to `true`
-     * * `name` set to the value of the "name" parameter
+     * - `chunks` set to `"all"`
+     * - `enforce` set to `true`
+     * - `name` set to the value of the "name" parameter
      *
      * @param {string} name The chunk name (e.g. vendor to create a vendor.js)
      * @param {object} options Cache group option
@@ -567,22 +563,22 @@ class Encore {
      * ```
      *
      * Notes:
-     *      * No transformation is applied to the copied files (for instance
+     *      No transformation is applied to the copied files (for instance
      *        copying a CSS file won't minify it)
      *
      * Supported options:
-     *      * {string} from (mandatory)
+     *      - {string} from (mandatory)
      *              The path of the source directory (mandatory)
-     *      * {RegExp|string} pattern (default: all files)
+     *      - {RegExp|string} pattern (default: all files)
      *              A regular expression (or a string containing one) that
      *              the filenames must match in order to be copied
-     *      * {string} to (default: [path][name].[ext])
+     *      - {string} to (default: [path][name].[ext])
      *              Where the files must be copied to. You can add all the
      *              placeholders supported by the file-loader.
      *              https://github.com/webpack-contrib/file-loader#placeholders
-     *      * {boolean} includeSubdirectories (default: true)
+     *      - {boolean} includeSubdirectories (default: true)
      *              Whether or not the copy should include subdirectories.
-     *      * {string} context (default: path of the source directory)
+     *      - {string} context (default: path of the source directory)
      *              The context to use as a root path when copying files.
      *
      * @param {object|Array} configs
@@ -670,7 +666,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureSplitChunks(callback) {
@@ -692,7 +688,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureWatchOptions(callback) {
@@ -719,7 +715,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureDevServerOptions(callback) {
@@ -747,7 +743,7 @@ class Encore {
      *  This is useful for older packages, that might
      *  expect jQuery (or something else) to be a global variable.
      *
-     * @param {object} variables
+     * @param {Record<string, string|string[]>} variables
      * @returns {Encore}
      */
     autoProvideVariables(variables) {
@@ -795,7 +791,7 @@ class Encore {
      * })
      * ```
      *
-     * @param {function} postCssLoaderOptionsCallback
+     * @param {Function} postCssLoaderOptionsCallback
      * @returns {Encore}
      */
     enablePostCssLoader(postCssLoaderOptionsCallback = () => {}) {
@@ -824,18 +820,18 @@ class Encore {
      * ```
      *
      * Supported options:
-     *      * {boolean} resolveUrlLoader (default=true)
+     *      - {boolean} resolveUrlLoader (default=true)
      *              Whether or not to use the resolve-url-loader.
      *              Setting to false can increase performance in some
      *              cases, especially when using bootstrap_sass. But,
      *              when disabled, all url()'s are resolved relative
      *              to the original entry file... not whatever file
      *              the url() appears in.
-     *      * {object} resolveUrlLoaderOptions (default={})
+     *      - {object} resolveUrlLoaderOptions (default={})
      *              Options parameters for resolve-url-loader
      *              // https://www.npmjs.com/package/resolve-url-loader#options
      *
-     * @param {function} sassLoaderOptionsCallback
+     * @param {Function} sassLoaderOptionsCallback
      * @param {object} encoreOptions
      * @returns {Encore}
      */
@@ -862,7 +858,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} lessLoaderOptionsCallback
+     * @param {Function} lessLoaderOptionsCallback
      * @returns {Encore}
      */
     enableLessLoader(lessLoaderOptionsCallback = () => {}) {
@@ -887,7 +883,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} stylusLoaderOptionsCallback
+     * @param {Function} stylusLoaderOptionsCallback
      * @returns {Encore}
      */
     enableStylusLoader(stylusLoaderOptionsCallback = () => {}) {
@@ -932,7 +928,7 @@ class Encore {
      * ```
      *
      * Supported options:
-     *      * {Condition} exclude (default=/(node_modules|bower_components)/)
+     *      - {Condition} exclude (default=/(node_modules|bower_components)/)
      *              A Webpack Condition passed to the JS/JSX rule that
      *              determines which files and folders should not be
      *              processed by Babel (https://webpack.js.org/configuration/module/#condition).
@@ -943,7 +939,7 @@ class Encore {
      *              they are not excluded anymore.
      *              Cannot be used if the "includeNodeModules" option is
      *              also set.
-     *      * {string[]} includeNodeModules
+     *      - {string[]} includeNodeModules
      *              If set that option will include the given Node modules to
      *              the files that are processed by Babel.
      *              Can be used even if you have an external Babel configuration
@@ -951,7 +947,7 @@ class Encore {
      *              Warning: .babelrc config files don't apply to node_modules. Use
      *              babel.config.json instead to apply the same config to these modules.
      *              Cannot be used if the "exclude" option is also set
-     *      * {'usage'|'entry'|false} useBuiltIns (default=false)
+     *      - {'usage'|'entry'|false} useBuiltIns (default=false)
      *              Set the "useBuiltIns" option of @babel/preset-env that changes
      *              how it handles polyfills (https://babeljs.io/docs/en/babel-preset-env#usebuiltins)
      *              Using it with 'entry' will require you to import core-js
@@ -962,12 +958,12 @@ class Encore {
      *              Cannot be used if you have an external Babel configuration (a .babelrc
      *              file for instance). In this case you can set the option directly into
      *              that configuration file.
-     *      * {number|string|object} corejs (default=not set)
+     *      - {number|string|object} corejs (default=not set)
      *              Set the "corejs" option of @babel/preset-env.
      *              It should contain the version of core-js you added to your project
      *              if useBuiltIns isn't set to false.
      *
-     * @param {function|null} callback
+     * @param {Function|null} callback
      * @param {object} encoreOptions
      * @returns {Encore}
      */
@@ -993,7 +989,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureBabelPresetEnv(callback) {
@@ -1014,7 +1010,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureCssLoader(callback) {
@@ -1047,7 +1043,7 @@ class Encore {
      *     // __filename means that changes to webpack.config.js should invalidate the cache
      *     config: [__filename],
      * });
-     **
+     *
      * // also configure other options the Webpack "cache" key
      * Encore.enableBuildCache({ config: [__filename] }, (cache) => {
      *     cache.version: `${process.env.GIT_REV}`;
@@ -1057,7 +1053,7 @@ class Encore {
      * ```
      *
      * @param {object} buildDependencies
-     * @param {function} cacheCallback
+     * @param {Function} cacheCallback
      * @returns {Encore}
      */
     enableBuildCache(buildDependencies, cacheCallback = (cache) => {}) {
@@ -1084,8 +1080,8 @@ class Encore {
      * );
      * ```
      *
-     * @param {function} loaderOptionsCallback
-     * @param {function} pluginOptionsCallback
+     * @param {Function} loaderOptionsCallback
+     * @param {Function} pluginOptionsCallback
      * @returns {Encore}
      */
     configureMiniCssExtractPlugin(loaderOptionsCallback, pluginOptionsCallback = () => {}) {
@@ -1150,7 +1146,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     enableTypeScriptLoader(callback = () => {}) {
@@ -1165,7 +1161,7 @@ class Encore {
      *
      * This is a build optimization API to reduce build times.
      *
-     * @param {function} forkedTypeScriptTypesCheckOptionsCallback
+     * @param {Function} forkedTypeScriptTypesCheckOptionsCallback
      * @returns {Encore}
      */
     enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {}) {
@@ -1249,11 +1245,11 @@ class Encore {
      * ```
      *
      * Supported options:
-     *      * {boolean} useJsx (default=false)
+     *      - {boolean} useJsx (default=false)
      *              Configure Babel to use the preset "@vue/babel-preset-jsx",
      *              in order to enable JSX usage in Vue components.
      *
-     * @param {function} vueLoaderOptionsCallback
+     * @param {Function} vueLoaderOptionsCallback
      * @param {object} encoreOptions
      * @returns {Encore}
      */
@@ -1280,7 +1276,7 @@ class Encore {
      * ```
      *
      * @param {boolean} enabled
-     * @param {function} notifierPluginOptionsCallback
+     * @param {Function} notifierPluginOptionsCallback
      * @returns {Encore}
      */
     enableBuildNotifications(enabled = true, notifierPluginOptionsCallback = () => {}) {
@@ -1305,7 +1301,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     enableHandlebarsLoader(callback = () => {}) {
@@ -1329,6 +1325,7 @@ class Encore {
      *
      * Internally, this disables the mini-css-extract-plugin
      * and uses the style-loader instead.
+     *
      * @param {boolean} disabled
      * @returns {Encore}
      */
@@ -1351,7 +1348,7 @@ class Encore {
      * });
      * ```
      *
-     * @param {function} callback
+     * @param {Function} callback
      * @returns {Encore}
      */
     configureStyleLoader(callback) {
@@ -1438,7 +1435,7 @@ class Encore {
      * ```
      *
      * @param {object} options
-     * @param {string|object|function} ruleCallback
+     * @param {string|object|Function} ruleCallback
      * @returns {Encore}
      */
     configureImageRule(options = {}, ruleCallback = (rule) => {}) {
@@ -1455,7 +1452,7 @@ class Encore {
      * See configureImageRule() for more details.
      *
      * @param {object} options
-     * @param {string|object|function} ruleCallback
+     * @param {string|object|Function} ruleCallback
      * @returns {Encore}
      */
     configureFontRule(options = {}, ruleCallback = (rule) => {}) {
@@ -1479,8 +1476,8 @@ class Encore {
      * ```
      *
      * @param {string} name
-     * @param {function} callback
-     * @return {Encore}
+     * @param {Function} callback
+     * @returns {Encore}
      */
     configureLoaderRule(name, callback) {
         webpackConfig.configureLoaderRule(name, callback);
@@ -1502,7 +1499,7 @@ class Encore {
      * ```
      *
      * @param {Array} paths Paths that should be cleaned, relative to the "root" option
-     * @param {function} cleanWebpackPluginOptionsCallback
+     * @param {Function} cleanWebpackPluginOptionsCallback
      * @returns {Encore}
      */
     cleanupOutputBeforeBuild(paths = ['**/*'], cleanWebpackPluginOptionsCallback = () => {}) {
@@ -1589,7 +1586,7 @@ class Encore {
      *
      * @param {(function(Encore): boolean) | boolean} condition
      * @param {function(Encore): void} callback
-     * @return {Encore}
+     * @returns {Encore}
      */
     when(condition, callback) {
         if (typeof condition === 'function' && condition(this) || typeof condition === 'boolean' && condition) {
@@ -1712,6 +1709,7 @@ class Encore {
 /**
  * Proxy the API in order to prevent calls to most of its methods
  * if the webpackConfig object hasn't been initialized yet.
+ *
  * @type {Encore}
  */
 module.exports = EncoreProxy.createProxy(new Encore());

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -19,7 +19,7 @@ const { calculateDevServerUrl } = require('./config/path-util');
 
 /**
  * @param {RuntimeConfig|null} runtimeConfig
- * @return {void}
+ * @returns {void}
  */
 function validateRuntimeConfig(runtimeConfig) {
     // if you're using the encore executable, these things should never happen
@@ -316,8 +316,8 @@ class WebpackConfig {
     /**
      * Provide a has of entries at once, as an alternative to calling `addEntry` several times.
      *
-     * @param {Object.<string, string|string[]>} entries
-     * @returns {Void}
+     * @param {Record<string, string|string[]>} entries
+     * @returns {void}
      */
     addEntries(entries = {}) {
         if (typeof entries !== 'object') {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -628,8 +628,7 @@ class ConfigGenerator {
 
 /**
  * @param {WebpackConfig} webpackConfig A configured WebpackConfig object
- *
- * @return {*} The final webpack config object
+ * @returns {*} The final webpack config object
  */
 module.exports = function(webpackConfig) {
     const generator = new ConfigGenerator(webpackConfig);

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -16,7 +16,7 @@ const babel = require('@babel/core');
 
 /**
  * @param {object} argv
- * @param {String} cwd
+ * @param {string} cwd
  * @returns {RuntimeConfig}
  */
 module.exports = function(argv, cwd) {

--- a/lib/config/path-util.js
+++ b/lib/config/path-util.js
@@ -19,7 +19,7 @@ module.exports = {
      * Determines the "contentBase" to use for the devServer.
      *
      * @param {WebpackConfig} webpackConfig
-     * @return {String}
+     * @returns {string}
      */
     getContentBase(webpackConfig) {
         // strip trailing slash (for Unix or Windows)
@@ -59,7 +59,7 @@ module.exports = {
      * Returns the output path, but as a relative string (e.g. web/build)
      *
      * @param {WebpackConfig} webpackConfig
-     * @return {String}
+     * @returns {string}
      */
     getRelativeOutputPath(webpackConfig) {
         return webpackConfig.outputPath.replace(webpackConfig.getContext() + path.sep, '');
@@ -72,7 +72,7 @@ module.exports = {
      * ok to use the publicPath as the manifestKeyPrefix.
      *
      * @param {WebpackConfig} webpackConfig
-     * @return {void}
+     * @returns {void}
      */
     validatePublicPathAndManifestKeyPrefix(webpackConfig) {
         if (webpackConfig.manifestKeyPrefix !== null) {
@@ -120,7 +120,7 @@ module.exports = {
 
     /**
      * @param {RuntimeConfig} runtimeConfig
-     * @return {string|null|Object.public|*}
+     * @returns {string}
      */
     calculateDevServerUrl(runtimeConfig) {
         if (runtimeConfig.devServerFinalIsHttps === null) {

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -16,7 +16,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
-     * @return {Array} of loaders to use for Babel
+     * @returns {Array} of loaders to use for Babel
      */
     getLoaders(webpackConfig) {
         let babelConfig = {
@@ -111,7 +111,7 @@ module.exports = {
 
     /**
      * @param {WebpackConfig} webpackConfig
-     * @return {RegExp} to use for eslint-loader `test` rule
+     * @returns {RegExp} to use for eslint-loader `test` rule
      */
     getTest(webpackConfig) {
         const extensions = [

--- a/lib/loaders/css-extract.js
+++ b/lib/loaders/css-extract.js
@@ -19,7 +19,7 @@ module.exports = {
      *
      * @param {WebpackConfig} webpackConfig
      * @param {Array} loaders An array of some style loaders
-     * @return {Array}
+     * @returns {Array}
      */
     prependLoaders(webpackConfig, loaders) {
         if (!webpackConfig.extractCss) {

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -17,7 +17,7 @@ module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
      * @param {boolean} useCssModules
-     * @return {Array} of loaders to use for CSS files
+     * @returns {Array} of loaders to use for CSS files
      */
     getLoaders(webpackConfig, useCssModules = false) {
         const usePostCssLoader = webpackConfig.usePostCssLoader;

--- a/lib/loaders/handlebars.js
+++ b/lib/loaders/handlebars.js
@@ -16,7 +16,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
-     * @return {Array} of loaders to use for Handlebars
+     * @returns {Array} of loaders to use for Handlebars
      */
     getLoaders(webpackConfig) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('handlebars');

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -18,7 +18,7 @@ module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
      * @param {boolean} useCssModules
-     * @return {Array} of loaders to use for Less files
+     * @returns {Array} of loaders to use for Less files
      */
     getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('less');

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -18,7 +18,7 @@ module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
      * @param {boolean} useCssModules
-     * @return {Array} of loaders to use for Sass files
+     * @returns {Array} of loaders to use for Sass files
      */
     getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('sass');

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -18,7 +18,7 @@ module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
      * @param {boolean} useCssModules
-     * @return {Array} of loaders to use for Stylus files
+     * @returns {Array} of loaders to use for Stylus files
      */
     getLoaders(webpackConfig, useCssModules = false) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stylus');

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -17,7 +17,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
-     * @return {Array} of loaders to use for TypeScript
+     * @returns {Array} of loaders to use for TypeScript
      */
     getLoaders(webpackConfig) {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('typescript');

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -17,7 +17,7 @@ const getVueVersion = require('../utils/get-vue-version');
 module.exports = {
     /**
      * @param {WebpackConfig} webpackConfig
-     * @return {Array} of loaders to use for Vue files
+     * @returns {Array} of loaders to use for Vue files
      */
     getLoaders(webpackConfig) {
         const vueVersion = getVueVersion(webpackConfig);

--- a/lib/plugins/asset-output-display.js
+++ b/lib/plugins/asset-output-display.js
@@ -21,7 +21,7 @@ const PluginPriorities = require('./plugin-priorities');
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @param {FriendlyErrorsWebpackPlugin} friendlyErrorsPlugin
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig, friendlyErrorsPlugin) {
     if (webpackConfig.useDevServer()) {

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -19,7 +19,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
  *
  * @param {Array} plugins to push to
  * @param {WebpackConfig} webpackConfig read only variable
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
 

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -17,7 +17,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     const definePluginOptions = {

--- a/lib/plugins/delete-unused-entries.js
+++ b/lib/plugins/delete-unused-entries.js
@@ -17,7 +17,7 @@ const copyEntryTmpName = require('../utils/copyEntryTmpName');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     const entries = [... webpackConfig.styleEntries.keys()];

--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -84,7 +84,7 @@ function processOutput(webpackConfig) {
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     plugins.push({

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -16,7 +16,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(webpackConfig) {
     const config = {};

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -21,7 +21,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {FriendlyErrorsWebpackPlugin}
+ * @returns {FriendlyErrorsWebpackPlugin}
  */
 module.exports = function(webpackConfig) {
     const friendlyErrorsPluginOptions = {

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -19,7 +19,7 @@ const manifestKeyPrefixHelper = require('../utils/manifest-key-prefix-helper');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     let manifestPluginOptions = {

--- a/lib/plugins/mini-css-extract.js
+++ b/lib/plugins/mini-css-extract.js
@@ -17,7 +17,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     // Don't add the plugin if CSS extraction is disabled

--- a/lib/plugins/notifier.js
+++ b/lib/plugins/notifier.js
@@ -17,7 +17,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     if (!webpackConfig.useWebpackNotifier) {

--- a/lib/plugins/optimize-css-assets.js
+++ b/lib/plugins/optimize-css-assets.js
@@ -15,7 +15,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {object}
+ * @returns {object}
  */
 module.exports = function(webpackConfig) {
     const minimizerPluginOptions = {};

--- a/lib/plugins/terser.js
+++ b/lib/plugins/terser.js
@@ -15,7 +15,7 @@ const applyOptionsCallback = require('../utils/apply-options-callback');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {object}
+ * @returns {object}
  */
 module.exports = function(webpackConfig) {
     const terserPluginOptions = {

--- a/lib/plugins/variable-provider.js
+++ b/lib/plugins/variable-provider.js
@@ -16,7 +16,7 @@ const PluginPriorities = require('./plugin-priorities');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     if (Object.keys(webpackConfig.providedVariables).length > 0) {

--- a/lib/plugins/vue.js
+++ b/lib/plugins/vue.js
@@ -15,7 +15,7 @@ const PluginPriorities = require('./plugin-priorities');
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
- * @return {void}
+ * @returns {void}
  */
 module.exports = function(plugins, webpackConfig) {
     if (!webpackConfig.useVueLoader) {

--- a/lib/utils/get-vue-version.js
+++ b/lib/utils/get-vue-version.js
@@ -16,7 +16,7 @@ const logger = require('../logger');
 
 /**
  * @param {WebpackConfig} webpackConfig
- * @return {int|string|null}
+ * @returns {number|string|null}
  */
 module.exports = function(webpackConfig) {
     if (webpackConfig.vueOptions.version !== null) {

--- a/lib/utils/manifest-key-prefix-helper.js
+++ b/lib/utils/manifest-key-prefix-helper.js
@@ -15,7 +15,7 @@ const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unus
  * Helper for determining the manifest.json key prefix.
  *
  * @param {WebpackConfig} webpackConfig
- * @return {string}
+ * @returns {string}
  */
 module.exports = function(webpackConfig) {
     let manifestPrefix = webpackConfig.manifestKeyPrefix;

--- a/lib/utils/package-up.js
+++ b/lib/utils/package-up.js
@@ -31,7 +31,7 @@ function toPath(urlOrPath) {
  * Inlined and simplified version of the package "find-up-simple" (ESM only).
  *
  * @param {string} name The name of the file to find
- * @param {Object} options
+ * @param {object} options
  * @param {string} options.cwd The directory to start searching from.
  * @returns {string|undefined} The path to the file found or undefined if not found.
  */

--- a/lib/utils/pretty-error.js
+++ b/lib/utils/pretty-error.js
@@ -15,7 +15,7 @@ const PrettyError = require('pretty-error');
  * Render a pretty version of the given error.
  *
  * Supported options:
- *      * {function} skipTrace
+ *      - {function} skipTrace
  *              An optional callback that defines whether
  *              or not each line of the eventual stacktrace
  *              should be kept. First argument is the content
@@ -23,7 +23,6 @@ const PrettyError = require('pretty-error');
  *
  * @param {*} error
  * @param {object} options
- *
  * @returns {void}
  */
 module.exports = function(error, options = {}) {

--- a/lib/utils/regexp-escaper.js
+++ b/lib/utils/regexp-escaper.js
@@ -15,7 +15,7 @@
  * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  *
  * @param {string} str
- * @return {string}
+ * @returns {string}
  */
 module.exports = function regexpEscaper(str) {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/lib/utils/string-escaper.js
+++ b/lib/utils/string-escaper.js
@@ -17,7 +17,7 @@
  * it needs to escape the Window path slashes).
  *
  * @param {string} str
- * @return {string}
+ * @returns {string}
  */
 module.exports = function stringEscaper(str) {
     return str.replace(/\\/g, '\\\\').replace(/\x27/g, '\\\x27');

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-node": "^11.1.0",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -52,7 +52,7 @@ const getMatchedFilename = function(targetDirectory, filenameRegex) {
  * Returns a regex to use to match this filename
  *
  * @param {string} filename Filename with possible [hash:8] wildcard
- * @return {RegExp}
+ * @returns {RegExp}
  */
 const convertFilenameToMatcher = function(filename) {
     const hashMatch = filename.match(/\[hash:(\d+)\]/);
@@ -71,7 +71,7 @@ const convertFilenameToMatcher = function(filename) {
 
 class Assert {
     /**
-     * @param {WebpackConfig} webpackConfig
+     * @param {import('../../lib/WebpackConfig')} webpackConfig
      */
     constructor(webpackConfig) {
         this.webpackConfig = webpackConfig;
@@ -176,11 +176,11 @@ class Assert {
 
     /**
      *
-     * @param {Browser} browser
+     * @param {import('zombie')} browser
      * @param {Array}   expectedResourcePaths Array of expected resources, but just
      *                  their short filenames - e.g. main.css
      *                  (i.e. without the public path)
-     * @return {void}
+     * @returns {void}
      */
     assertResourcesLoadedCorrectly(browser, expectedResourcePaths) {
         const actualResources = [];

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -145,7 +145,7 @@ function stopAllServers() {
  * @param {string} webRootDir Directory path (e.g. /path/to/public) where the web server should be rooted
  * @param {Array} scriptSrcs  Used to create <script src=""> tags.
  * @param {Function} callback Called after the page was requested.
- * @return {void}
+ * @returns {void}
  */
 function requestTestPage(webRootDir, scriptSrcs, callback) {
     var scripts = '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,15 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@es-joy/jsdoccomment@~0.48.0":
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.48.0.tgz#5d9dc1a295cf5d1ed224dffafb4800d5c7206c27"
+  integrity sha512-G6QUWIcC+KvSwXNsJyDTHvqUdNoAVJPPgkc3+Uk4WBKqZvoXhlvazOgm9aL0HwihJLQf0l+tOE2UFzXBqCqgDw==
+  dependencies:
+    comment-parser "1.4.1"
+    esquery "^1.6.0"
+    jsdoc-type-pratt-parser "~4.1.0"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -1239,6 +1248,11 @@
     consola "^3.2.3"
     error-stack-parser "^2.1.4"
     string-width "^4.2.3"
+
+"@pkgr/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
+  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -1974,6 +1988,11 @@ acorn@^8.0.5, acorn@^8.10.0, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
+acorn@^8.12.0:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+
 adjust-sourcemap-loader@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz#fc4a0fd080f7d10471f30a7320f25560ade28c99"
@@ -2057,6 +2076,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -2657,6 +2681,11 @@ commander@^7.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
+comment-parser@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.1.tgz#bdafead37961ac079be11eb7ec65c4d021eaf9cc"
+  integrity sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==
+
 common-path-prefix@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
@@ -2985,6 +3014,13 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
@@ -3312,6 +3348,11 @@ es-module-lexer@^1.2.1:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
   integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
 
+es-module-lexer@^1.5.3:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
+  integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
+
 es-set-tostringtag@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz#11f7cc9f63376930a5f20be4915834f4bc74f9c9"
@@ -3426,6 +3467,23 @@ eslint-plugin-import@^2.26.0:
     semver "^6.3.1"
     tsconfig-paths "^3.15.0"
 
+eslint-plugin-jsdoc@^50.2.2:
+  version "50.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.2.tgz#151e63c8bc245ea8b2357d4229392a5b993827b0"
+  integrity sha512-i0ZMWA199DG7sjxlzXn5AeYZxpRfMJjDPUl7lL9eJJX8TPRoIaxJU4ys/joP5faM5AXE1eqW/dslCj3uj4Nqpg==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.48.0"
+    are-docs-informative "^0.0.2"
+    comment-parser "1.4.1"
+    debug "^4.3.6"
+    escape-string-regexp "^4.0.0"
+    espree "^10.1.0"
+    esquery "^1.6.0"
+    parse-imports "^2.1.1"
+    semver "^7.6.3"
+    spdx-expression-parse "^4.0.0"
+    synckit "^0.9.1"
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
@@ -3476,6 +3534,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz#e3adc021aa038a2a8e0b2f8b0ce8f66b9483b1fb"
+  integrity sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==
+
 eslint@^8.0.0:
   version "8.56.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.56.0.tgz#4957ce8da409dc0809f99ab07a1b94832ab74b15"
@@ -3520,6 +3583,15 @@ eslint@^8.0.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+espree@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-10.1.0.tgz#8788dae611574c0f070691f522e4116c5a11fc56"
+  integrity sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==
+  dependencies:
+    acorn "^8.12.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^4.0.0"
+
 espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
@@ -3538,6 +3610,13 @@ esquery@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
+  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -4683,6 +4762,11 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
+jsdoc-type-pratt-parser@~4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz#ff6b4a3f339c34a6c188cbf50a16087858d22113"
+  integrity sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==
+
 jsdom@11.12.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
@@ -5474,6 +5558,14 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-imports@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/parse-imports/-/parse-imports-2.1.1.tgz#ce52141df24990065d72a446a364bffd595577f4"
+  integrity sha512-TDT4HqzUiTMO1wJRwg/t/hYk8Wdp3iF/ToMIlAoVQfL1Xs/sTxq1dKWSMjMbQmIarfWKymOyly40+zmPHXMqCA==
+  dependencies:
+    es-module-lexer "^1.5.3"
+    slashes "^3.0.12"
 
 parse-json@^5.2.0:
   version "5.2.0"
@@ -6400,6 +6492,11 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -6546,6 +6643,11 @@ sinon@^14.0.0:
     nise "^5.1.2"
     supports-color "^7.2.0"
 
+slashes@^3.0.12:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/slashes/-/slashes-3.0.12.tgz#3d664c877ad542dc1509eaf2c50f38d483a6435a"
+  integrity sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
@@ -6582,6 +6684,24 @@ source-map@^0.7.3, source-map@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+spdx-exceptions@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
+  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
+
+spdx-expression-parse@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz#a23af9f3132115465dac215c099303e4ceac5794"
+  integrity sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz#e44ed19ed318dd1e5888f93325cee800f0f51b89"
+  integrity sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -6838,6 +6958,14 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.1.tgz#febbfbb6649979450131f64735aa3f6c14575c88"
+  integrity sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -6938,6 +7066,11 @@ tslib@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.6.2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
The deprecated valid-jsdoc rule of eslint does not support using typescript syntax for types, while it allows being more precise about types in a much more readable way than using the older jsdoc syntax with separate typedef or callback definitions.
The plugin also implements more rules than what valid-jsdoc does.

This prepares reviving https://github.com/symfony/webpack-encore/pull/818