### PR TITLE
Use JSDoc imports instead of unused runtime imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const webpack = require('webpack'); // eslint-disable-line no-unused-vars
+/**
+ * @import webpack from 'webpack'
+ */
+
 const EncoreProxy = require('./lib/EncoreProxy');
 const WebpackConfig = require('./lib/WebpackConfig');
 const configGenerator = require('./lib/config-generator');

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -9,10 +9,13 @@
 
 'use strict';
 
+/**
+ * @import RuntimeConfig from './config/RuntimeConfig'
+ */
+
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
-const RuntimeConfig = require('./config/RuntimeConfig'); //eslint-disable-line no-unused-vars
 const logger = require('./logger');
 const regexpEscaper = require('./utils/regexp-escaper');
 const { calculateDevServerUrl } = require('./config/path-util');

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('./WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from './WebpackConfig'
+ */
+
 const cssExtractLoaderUtil = require('./loaders/css-extract');
 const pathUtil = require('./config/path-util');
 const featuresHelper = require('./features');

--- a/lib/config/path-util.js
+++ b/lib/config/path-util.js
@@ -9,9 +9,15 @@
 
 'use strict';
 
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
+/**
+ * @import RuntimeConfig from './RuntimeConfig'
+ */
+
 const path = require('path');
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
-const RuntimeConfig = require('./RuntimeConfig'); //eslint-disable-line no-unused-vars
 const logger = require('../logger');
 
 module.exports = {

--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -9,9 +9,12 @@
 
 'use strict';
 
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const pathUtil = require('./path-util');
 const logger = require('./../logger');
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
 
 class Validator {
     /**

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/loaders/css-extract.js
+++ b/lib/loaders/css-extract.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/loaders/handlebars.js
+++ b/lib/loaders/handlebars.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const cssLoader = require('./css');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const babelLoader = require('./babel');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const loaderFeatures = require('../features');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 const getVueVersion = require('../utils/get-vue-version');

--- a/lib/plugins/asset-output-display.js
+++ b/lib/plugins/asset-output-display.js
@@ -9,8 +9,14 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
-const FriendlyErrorsWebpackPlugin = require('@nuxt/friendly-errors-webpack-plugin'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
+/**
+ * @import FriendlyErrorsWebpackPlugin from '@nuxt/friendly-errors-webpack-plugin'
+ */
+
 const pathUtil = require('../config/path-util');
 const AssetOutputDisplayPlugin = require('../friendly-errors/asset-output-display-plugin');
 const PluginPriorities = require('./plugin-priorities');

--- a/lib/plugins/clean.js
+++ b/lib/plugins/clean.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -9,8 +9,11 @@
 
 'use strict';
 
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const webpack = require('webpack');
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/plugins/delete-unused-entries.js
+++ b/lib/plugins/delete-unused-entries.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const DeleteUnusedEntriesJSPlugin = require('../webpack/delete-unused-entries-js-plugin');
 const PluginPriorities = require('./plugin-priorities');
 const copyEntryTmpName = require('../utils/copyEntryTmpName');

--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const PluginPriorities = require('./plugin-priorities');
 const copyEntryTmpName = require('../utils/copyEntryTmpName');
 const AssetsPlugin = require('assets-webpack-plugin');

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -9,8 +9,11 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin'); // eslint-disable-line
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const FriendlyErrorsWebpackPlugin = require('@nuxt/friendly-errors-webpack-plugin');
 const missingCssFileTransformer = require('../friendly-errors/transformers/missing-css-file');
 const missingCssFileFormatter = require('../friendly-errors/formatters/missing-css-file');

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const { WebpackManifestPlugin } = require('../webpack-manifest-plugin');
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/plugins/mini-css-extract.js
+++ b/lib/plugins/mini-css-extract.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/plugins/notifier.js
+++ b/lib/plugins/notifier.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const pluginFeatures = require('../features');
 const PluginPriorities = require('./plugin-priorities');
 const applyOptionsCallback = require('../utils/apply-options-callback');

--- a/lib/plugins/optimize-css-assets.js
+++ b/lib/plugins/optimize-css-assets.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/plugins/terser.js
+++ b/lib/plugins/terser.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const TerserPlugin = require('terser-webpack-plugin');
 const applyOptionsCallback = require('../utils/apply-options-callback');
 

--- a/lib/plugins/variable-provider.js
+++ b/lib/plugins/variable-provider.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const webpack = require('webpack');
 const PluginPriorities = require('./plugin-priorities');
 

--- a/lib/plugins/vue.js
+++ b/lib/plugins/vue.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const PluginPriorities = require('./plugin-priorities');
 
 /**

--- a/lib/utils/get-vue-version.js
+++ b/lib/utils/get-vue-version.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
+
 const packageHelper = require('../package-helper');
 const semver = require('semver');
 const logger = require('../logger');

--- a/lib/utils/manifest-key-prefix-helper.js
+++ b/lib/utils/manifest-key-prefix-helper.js
@@ -9,7 +9,9 @@
 
 'use strict';
 
-const WebpackConfig = require('../WebpackConfig'); //eslint-disable-line no-unused-vars
+/**
+ * @import WebpackConfig from '../WebpackConfig'
+ */
 
 /**
  * Helper for determining the manifest.json key prefix.


### PR DESCRIPTION
This is better when the import was added only to make the type available in JSDoc types.