### PR TITLE
Drop support for Node.js 19 and 21

### DIFF
--- a/.github/workflows/high-depends.yml
+++ b/.github/workflows/high-depends.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-2019]
-                node-versions: ['18', '20', '21', '22']
+                node-versions: ['18', '20', '22']
 
         steps:
             -   name: Checkout

--- a/.github/workflows/low-depends.yml
+++ b/.github/workflows/low-depends.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-2019]
-                node-versions: ['18', '20', '21', '22']
+                node-versions: ['18', '20', '22']
 
         steps:
             -   name: Checkout

--- a/.github/workflows/stable-tests.yml
+++ b/.github/workflows/stable-tests.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-2019]
-                node-versions: ['18', '20', '21', '22']
+                node-versions: ['18', '20', '22']
 
         steps:
             -   name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a new major version that contains several backwards-compatibility breaks
 
 ### BC Breaks
 
+* #1321 Drop support of Node.js 19 and 21 (@Kocal)
+
 * #1307 Drop `webpack-cli` 4 support, only `webpack-cli` ^5.1.4 is supported (@Kocal)
 
 * #1308 Drop Vue 2 support (End-Of-Life), only Vue 3 is supported (@Kocal)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/symfony/webpack-encore/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.0.0 || ^20.0.0 || >=22.0"
   },
   "homepage": "https://github.com/symfony/webpack-encore",
   "dependencies": {


### PR DESCRIPTION
Due to the `>=18.0.0` version constraint in `engines.node`, it means that we allows Node.js 19 and 21, but, we don't want that.

Odds versions are supported only 6 months, it only helps library maintainers to update their library comptability with a new Node.js LTS-version. You can see on https://nodejs.org/fr/about/previous-releases that Node.js 19 is not present and Node.js 21 support has been stopped around ~may 2024.

Some of our dependencies explicitly does not support explicitly Node.js 19/21, like css-minimizer-webpack-plugin that [I've tried to upgrade to v5](https://github.com/symfony/webpack-encore/actions/runs/10654621974/job/29531168804?pr=1320):
```
yarn install v1.22.22
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error cssnano@7.0.5: The engine "node" is incompatible with this module. Expected version "^18.12.0 || ^20.9.0 || >=22.0". Got "21.7.3"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Since we plan to release a new major version of Encore, it's the good moment.

WDYT?