### PR TITLE
Fix compat with configuring the devserver server as a string

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -68,7 +68,8 @@ class ConfigGenerator {
         if (this.webpackConfig.useDevServer() &&
             (
                 devServerConfig.https
-                || (devServerConfig.server && devServerConfig.server.type === 'https')
+                || devServerConfig.server === 'https'
+                || (typeof devServerConfig.server === 'object' && devServerConfig.server.type === 'https')
                 || this.webpackConfig.runtimeConfig.devServerHttps
             )) {
             this.webpackConfig.runtimeConfig.devServerFinalIsHttps = true;


### PR DESCRIPTION
webpack-dev-server supports providing a string when only the type needs to be configured. Our code checking the type to detect the usage of `https` was not properly handling such configuration.