### PR TITLE
Read the controllers.json as string rather than Buffer

### DIFF
--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -755,7 +755,7 @@ class WebpackConfig {
         }
 
         // Add configured entrypoints
-        const controllersData = JSON.parse(fs.readFileSync(controllerJsonPath));
+        const controllersData = JSON.parse(fs.readFileSync(controllerJsonPath, 'utf8'));
         const rootDir = path.dirname(path.resolve(controllerJsonPath));
 
         for (let name in controllersData.entrypoints) {


### PR DESCRIPTION
Buffers can implicitly be converted to string (implicitly using `utf8` as encoding) but the type checker does not like this kind of implicit conversion.
When passing an encoding to `fs.readFileSync`, it returns a string by performing an explicit conversion using the provided encoding.