### PR TITLE
Add some types in the internal implementation of Encore

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -82,6 +82,9 @@ class ConfigGenerator {
             this.webpackConfig.runtimeConfig.devServerFinalIsHttps = false;
         }
 
+        /**
+         * @type {import('webpack').Configuration}
+         */
         const config = {
             context: this.webpackConfig.getContext(),
             entry: this.buildEntryConfig(),
@@ -158,6 +161,9 @@ class ConfigGenerator {
     }
 
     buildEntryConfig() {
+        /**
+         * @type {Record<string, string[]>}
+         */
         const entry = {};
 
         for (const [entryName, entryChunks] of this.webpackConfig.entries) {
@@ -544,7 +550,7 @@ class ConfigGenerator {
         }
 
         if (this.webpackConfig.shouldUseSingleRuntimeChunk) {
-            optimization.runtimeChunk = 'single';
+            optimization.runtimeChunk = /** @type {const} */ ('single');
         }
 
         optimization.splitChunks = applyOptionsCallback(
@@ -558,7 +564,7 @@ class ConfigGenerator {
     buildCacheConfig() {
         const cache = {};
 
-        cache.type = 'filesystem';
+        cache.type = /** @type {const} */ ('filesystem');
         cache.buildDependencies = this.webpackConfig.persistentCacheBuildDependencies;
 
         applyOptionsCallback(

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -25,6 +25,9 @@ module.exports = {
     getLoaders(webpackConfig, useCssModules = false) {
         const usePostCssLoader = webpackConfig.usePostCssLoader;
 
+        /**
+         * @type {boolean|object}
+         */
         let modulesConfig = false;
         if (useCssModules) {
             modulesConfig = {


### PR DESCRIPTION
This will allow type-checking the codebase, by fixing cases where the typescript inference is not sufficient without a hint.