### PR TITLE
Upgrade the version of stylus used in dev

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -35,7 +35,6 @@ const features = {
         method: 'enableStylusLoader()',
         packages: [
             { name: 'stylus-loader', enforce_version: true },
-            { name: 'stylus' }
         ],
         description: 'load Stylus files'
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "sass-loader": "^16.0.1",
     "sinon": "^14.0.0",
     "strip-ansi": "^6.0.0",
-    "stylus": "^0.60.0",
+    "stylus": "^0.63.0",
     "stylus-loader": "^7.0.0 || ^8.1.0",
     "svelte": "^3.50.0 || ^4.2.2",
     "svelte-loader": "^3.1.0",
@@ -120,7 +120,6 @@
     "postcss-loader": "^7.0.0 || ^8.1.0",
     "sass": "^1.17.0",
     "sass-loader": "^16.0.1",
-    "stylus": "^0.58.1",
     "stylus-loader": "^7.0.0 || ^8.1.0",
     "ts-loader": "^9.0.0",
     "typescript": "^5.0.0",
@@ -189,9 +188,6 @@
       "optional": true
     },
     "sass-loader": {
-      "optional": true
-    },
-    "stylus": {
       "optional": true
     },
     "stylus-loader": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adobe/css-tools@~4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.2.0.tgz#e1a84fca468f4b337816fcb7f0964beb620ba855"
-  integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
+"@adobe/css-tools@~4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
+  integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
 
 "@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.2.1":
   version "2.3.0"
@@ -6182,10 +6182,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
-sax@~1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+sax@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
+  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
 
 schema-utils@^3.0.0, schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"
@@ -6601,15 +6601,15 @@ stylehacks@^7.0.4:
     fast-glob "^3.3.2"
     normalize-path "^3.0.0"
 
-stylus@^0.60.0:
-  version "0.60.0"
-  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.60.0.tgz#0d75f3772929185d580d164d9394b2dcbed21083"
-  integrity sha512-j2pBgEwzCu05yCuY4cmyp0FtPQQFBBAGB7TY7QaNl7eztiHwkxzwvIp5vjZJND/a1JNOka+ZW9ewVPFZpI3pcA==
+stylus@^0.63.0:
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.63.0.tgz#511e8d56f2005b09010fbc1f62561c7b6f72a490"
+  integrity sha512-OMlgrTCPzE/ibtRMoeLVhOY0RcNuNWh0rhAVqeKnk/QwcuUKQbnqhZ1kg2vzD8VU/6h3FoPTq4RJPHgLBvX6Bw==
   dependencies:
-    "@adobe/css-tools" "~4.2.0"
+    "@adobe/css-tools" "~4.3.3"
     debug "^4.3.2"
     glob "^7.1.6"
-    sax "~1.2.4"
+    sax "~1.3.0"
     source-map "^0.7.3"
 
 supports-color@^5.3.0:


### PR DESCRIPTION
This also removes the optional peerDependency on stylus that was using an outdated range because Encore does not actually use stylus in any way but only stylus-loader. And stylus-loader already declares a required peerDependency on stylus, making package managers ensure its presence when stylus-loader is present.