### PR TITLE
Fix ESLint warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "yarn run test:main && yarn run test:persistent-cache",
     "test:main": "mocha --reporter spec test --recursive --ignore test/persistent-cache/*",
     "test:persistent-cache": "node run-persistent-tests",
-    "lint": "eslint lib test index.js .eslintrc.js --report-unused-disable-directives",
+    "lint": "eslint lib test index.js .eslintrc.js --report-unused-disable-directives --max-warnings=0",
     "travis:lint": "yarn run lint"
   },
   "bin": {

--- a/test/functional.js
+++ b/test/functional.js
@@ -1248,20 +1248,17 @@ module.exports = {
                     );
 
                     // Test that the generated scripts work fine
-                    await new Promise(resolve => {
-                        testSetup.requestTestPage(
-                            browser,
-                            path.join(config.getContext(), 'www'),
-                            [
-                                'build/runtime.js',
-                                `build/${scriptName}`,
-                            ],
-                            async({ page }) => {
-                                expect(await page.evaluate(() => document.body.textContent)).to.contains('[1,2,3,4]');
-                                resolve();
-                            }
-                        );
-                    });
+                    await testSetup.requestTestPage(
+                        browser,
+                        path.join(config.getContext(), 'www'),
+                        [
+                            'build/runtime.js',
+                            `build/${scriptName}`,
+                        ],
+                        async({ page }) => {
+                            expect(await page.evaluate(() => document.body.textContent)).to.contains('[1,2,3,4]');
+                        }
+                    );
                 }
 
                 done();


### PR DESCRIPTION
This configures our CI to enforce fixing ESLint warnings and not just errors.
The only warning that was reported (since #1331) is solved by simplifying the code (removing the function that was keeping a closure on the `browser` mutable variable)