### PR TITLE
Fix issue between `Encore.enableIntegrityHashes()` and filenames with a query-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 5.0.1
+
+* #1349 Fix issue between `Encore.enableIntegrityHashes()` and filenames with a query-string (@Kocal)
+
 ## 5.0.0
 
 This is a new major version that contains several backwards-compatibility breaks.

--- a/lib/webpack/entry-points-plugin.js
+++ b/lib/webpack/entry-points-plugin.js
@@ -95,9 +95,12 @@ class EntryPointsPlugin {
                 for (const entryName in manifest.entrypoints) {
                     for (const fileType in manifest.entrypoints[entryName]) {
                         for (const asset of manifest.entrypoints[entryName][fileType]) {
+                            if (asset in manifest.integrity) {
+                                continue;
+                            }
+
                             // Drop query string if any
                             const assetNormalized = asset.includes('?') ? asset.split('?')[0] : asset;
-
                             if (assetNormalized in manifest.integrity) {
                                 continue;
                             }
@@ -118,7 +121,7 @@ class EntryPointsPlugin {
                                     fileHashes.push(`${algorithm}-${hash.digest('base64')}`);
                                 }
 
-                                manifest.integrity[assetNormalized] = fileHashes.join(' ');
+                                manifest.integrity[asset] = fileHashes.join(' ');
                             }
                         }
                     }

--- a/test/functional.js
+++ b/test/functional.js
@@ -3138,11 +3138,14 @@ module.exports = {
 
                 testSetup.runWebpack(config, (webpackAssert) => {
                     const integrityData = getIntegrityData(config);
-                    const expectedFilesWithHashes = [
-                        '/build/runtime.js',
-                        '/build/main.js',
-                        '/build/styles.css',
-                    ];
+                    const expectedFilesWithHashes = Object.keys(integrityData).filter(file => {
+                        if (!/\?v=[a-z0-9]{16}$/.test(file)) {
+                            return false;
+                        }
+                        return file.startsWith('/build/runtime.js?v=')
+                            || file.startsWith('/build/main.js?v=')
+                            || file.startsWith('/build/styles.css?v=');
+                    });
 
                     expectedFilesWithHashes.forEach((file) => {
                         expect(integrityData[file]).to.contain('sha384-');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility.
-->

When working on https://github.com/symfony/webpack-encore-bundle/pull/237, I haven't able to see integrity hashes added on `<link>` tags, because my project uses query-string in generated filenames, but the bundle was not able to get those integrity hashes (because the `entrypoints.json` file contained  `"/build/sentry.js": "sha384-hash"` instead of `"/build/sentry.js?v=b86ff72e": "sha384-hash"`) 