### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ feel. It aims to solve the most common Webpack use cases.
 
 ## Documentation
 
-[Read the Documentation on symfony.com](https://symfony.com/doc/current/frontend.html).
+[Read the Documentation on symfony.com](https://symfony.com/doc/current/frontend/encore/index.html).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | n/a
| License       | MIT

Documentation link now points to the dedicated Encore documentation instead of the broad "Symfony Front-end Tools" section.
