### PR TITLE
Remove unecessary check on Webpack version 4

### DIFF
--- a/lib/webpack-manifest-plugin/index.js
+++ b/lib/webpack-manifest-plugin/index.js
@@ -8,7 +8,6 @@
  */
 const { relative, resolve } = require('path');
 
-const webpack = require('webpack');
 const NormalModule = require('webpack/lib/NormalModule');
 
 const { beforeRunHook, emitHook, getCompilerHooks, normalModuleLoaderHook } = require('./hooks');
@@ -65,13 +64,9 @@ class WebpackManifestPlugin {
             hook.tap(hookOptions, normalModuleLoader);
         });
 
-        if (webpack.version.startsWith('4')) {
-            compiler.hooks.emit.tap(hookOptions, emit);
-        } else {
-            compiler.hooks.thisCompilation.tap(hookOptions, (compilation) => {
-                compilation.hooks.processAssets.tap(hookOptions, () => emit(compilation));
-            });
-        }
+        compiler.hooks.thisCompilation.tap(hookOptions, (compilation) => {
+            compilation.hooks.processAssets.tap(hookOptions, () => emit(compilation));
+        });
 
         compiler.hooks.run.tap(hookOptions, beforeRun);
         compiler.hooks.watchRun.tap(hookOptions, beforeRun);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility.
-->

We do not support Webpack 4 since a moment now, we can remove this check and import to `webpack`
