### PR TITLE
Pin `tmp` dependency version to `^0.2.5` (CVE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "style-loader": "^3.3.0 || ^4.0.0",
     "tapable": "^2.2.1",
     "terser-webpack-plugin": "^5.3.0",
-    "tmp": "^0.2.1",
+    "tmp": "^0.2.5",
     "webpack-manifest-plugin": "^5.0.1",
     "yargs-parser": "^21.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7514,10 +7514,10 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tmp@^0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
-  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+tmp@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Bumps [tmp](https://github.com/raszi/node-tmp) to 0.2.5
