### PR TITLE
Declare svelte and svelte-loader as optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,12 @@
     "stylus-loader": {
       "optional": true
     },
+    "svelte": {
+      "optional": true
+    },
+    "svelte-loader": {
+      "optional": true
+    },
     "ts-loader": {
       "optional": true
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #1386
| License       | MIT

Version 5.3.0 added the peer dependency declaration but forgot to mark it as optional (while the implementation already treats it as optional)
