### PR TITLE
[Stimulus Bridge] Entrypoint: Allow to import aliases

### DIFF
--- a/fixtures/stimulus/assets/controllers.json
+++ b/fixtures/stimulus/assets/controllers.json
@@ -10,5 +10,7 @@
             }
         }
     },
-    "entrypoints": []
+    "entrypoints": {
+        "@symfony/mock-module/entrypoint": "@symfony/mock-module/dist/entrypoint.js"
+    }
 }

--- a/fixtures/stimulus/mock-module/dist/entrypoint.js
+++ b/fixtures/stimulus/mock-module/dist/entrypoint.js
@@ -1,0 +1,1 @@
+console.log('Hello from the mock module entrypoint!');

--- a/fixtures/stimulus/mock-module/package.json
+++ b/fixtures/stimulus/mock-module/package.json
@@ -12,6 +12,9 @@
                     "@symfony/mock-module/dist/style.css": true
                 }
             }
+        },
+        "entrypoints": {
+            "@symfony/mock-module/entrypoint": "@symfony/mock-module/dist/entrypoint.js"
         }
     }
 }

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -764,6 +764,12 @@ class WebpackConfig {
         const rootDir = path.dirname(path.resolve(controllerJsonPath));
 
         for (let name in controllersData.entrypoints) {
+            // Imported entrypoint (e.g. from node_modules) should be used as-is
+            if (controllersData.entrypoints[name].startsWith('@')) {
+                this.addEntry(name, controllersData.entrypoints[name]);
+                continue;
+            }
+
             this.addEntry(name, rootDir + '/' + controllersData.entrypoints[name]);
         }
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -2024,7 +2024,7 @@ module.exports = {
             const appDir = testSetup.createTestAppDir();
 
             const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
-            if (!semver.satisfies(version, '^3.0.0')) {
+            if (!semver.satisfies(version, '>3.0.0')) {
                 // we support the old version, but it's not tested
                 this.skip();
 
@@ -2045,12 +2045,14 @@ module.exports = {
                     'node_modules_symfony_mock-module_dist_controller_js.js',
                     'entrypoints.json',
                     'runtime.js',
+                    '@symfony/mock-module/entrypoint.js'
                 ]);
 
                 // test controllers and style are shipped
                 webpackAssert.assertOutputFileContains('main.js', 'app-controller');
                 webpackAssert.assertOutputFileContains('node_modules_symfony_mock-module_dist_controller_js.js', 'mock-module-controller');
                 webpackAssert.assertOutputFileContains('main.css', 'body {}');
+                webpackAssert.assertOutputFileContains('entrypoints.json', '@symfony/mock-module/entrypoint');
 
                 done();
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


I was re-working on the doc pr to expose entrypoint inside a UX bundle.

https://github.com/symfony/symfony-docs/pull/21292

I didn't really like the fact that, to expose an entrypoint in webpack encore, user must add it relative to node_modules folder : 

```json
    {
        "name": "@acme/feature",
        "symfony": {
            "entrypoints": {
                "@acme/feature/entrypoint": "../node_modules/@acme/feature/entrypoint.js"
            }
        }
    }
```

With that change in enableStimulusBridge, we allow to import entrypoint from a bundle like that 

```json
// acme-feature-bundle/assets/package.json

    {
        "name": "@acme/feature",
        "symfony": {
            "entrypoints": {
                "@acme/feature/entrypoint": "@acme/feature/entrypoint.js"
            }
        }
    }
```
