### PR TITLE
Remove unmaintained file-loader dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,26 @@
 
 ## 6.0.0
 
-* Drop support for Node.js <22.13.0
-* Update @nuxt/friendly-errors-webpack-plugin to @kocal/friendly-errors-webpack-plugin, an updated fork of the original plugin
-* Update css-minimizer-webpack-plugin to ^8.0.0, see [release notes](https://github.com/webpack/css-minimizer-webpack-plugin/releases/tag/v8.0.0)
+This is a new major version that contains several backwards-compatibility breaks, but for the best!
+
+### BC Breaks
+
+* Remove support of Node.js <22.13.0
+* Remove support of babel-loader@^9.1.3, see possible BC breaks in [10.0.0 release notes](https://github.com/babel/babel-loader/releases/tag/v10.0.0)
+* Remove support of style-loader@^3.3.0, see possible BC breaks in [4.0.0 release notes](https://github.com/webpack/style-loader/releases/tag/v4.0.0)
+* Remove support of less-loader@^11.0.0, see possible BC breaks in [12.0.0 release notes](https://github.com/webpack/less-loader/releases/tag/v12.0.0)
+* Remove support of postcss-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/postcss-loader/releases/tag/v8.0.0)
+* Remove support of stylus-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/stylus-loader/releases/tag/v8.0.0)
+* Remove support of webpack-cli@^5.0.0, see possible BC breaks in [6.0.0 release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0)
+* Remove unmaintained file-loader dependency 
+  The `[N]` placeholder (regex capture groups in filename patterns) is no longer supported. 
+  If you were using patterns like `[1]` or `[2]` in your `Encore.copyFiles()` filename option, you will need to restructure your file organization or use a different naming strategy.
+
+### Features
+
+* Update @nuxt/friendly-errors-webpack-plugin to @kocal/friendly-errors-webpack-plugin, a maintained fork of the original plugin
 * Update webpack from ^5.74.0 to ^5.82.0
-* Remove support for babel-loader ^9.1.3, see [10.0.0 release notes](https://github.com/babel/babel-loader/releases/tag/v10.0.0)
-* Remove support for style-loader ^3.3.0, see [4.0.0 release notes](https://github.com/webpack/style-loader/releases/tag/v4.0.0)
-* Remove support for less-loader ^11.0.0, see [12.0.0 release notes](https://github.com/webpack/less-loader/releases/tag/v12.0.0)
-* Remove support for postcss-loader ^7.0.0, see [8.0.0 release notes](https://github.com/webpack/postcss-loader/releases/tag/v8.0.0)
-* Remove support for stylus-loader ^7.0.0, see [8.0.0 release notes](https://github.com/webpack/stylus-loader/releases/tag/v8.0.0)
-* Remove support for webpack-cli ^5.0.0, see [6.0.0 release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0)
+* Update css-minimizer-webpack-plugin to ^8.0.0, see [release notes](https://github.com/webpack/css-minimizer-webpack-plugin/releases/tag/v8.0.0)
 
 ## 5.3.0
 

--- a/index.js
+++ b/index.js
@@ -584,9 +584,11 @@ class Encore {
      *              A regular expression (or a string containing one) that
      *              the filenames must match in order to be copied
      *      - {string} to (default: [path][name].[ext])
-     *              Where the files must be copied to. You can add all the
-     *              placeholders supported by the file-loader.
-     *              https://github.com/webpack-contrib/file-loader#placeholders
+     *              Where the files must be copied to. Supported placeholders:
+     *                - [name]: filename without extension
+     *                - [ext]: file extension without the leading dot
+     *                - [path]: relative directory path from context
+     *                - [hash:N]: content hash, optionally truncated to N characters
      *      - {boolean} includeSubdirectories (default: true)
      *              Whether or not the copy should include subdirectories.
      *      - {string} context (default: path of the source directory)

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -15,7 +15,6 @@
 
 const cssExtractLoaderUtil = require('./loaders/css-extract');
 const pathUtil = require('./config/path-util');
-const featuresHelper = require('./features');
 // loaders utils
 const cssLoaderUtil = require('./loaders/css');
 const sassLoaderUtil = require('./loaders/sass');
@@ -176,10 +175,6 @@ class ConfigGenerator {
             entry[entryName] = entryChunks;
         }
 
-        if (this.webpackConfig.copyFilesConfigs.length > 0) {
-            featuresHelper.ensurePackagesExistAndAreCorrectVersion('copy_files');
-        }
-
         const copyFilesConfigs = this.webpackConfig.copyFilesConfigs.filter(entry => {
             const copyFrom = path.resolve(
                 this.webpackConfig.getContext(),
@@ -216,11 +211,8 @@ class ConfigGenerator {
 
                     const copyFilesLoaderPath = require.resolve('./webpack/copy-files-loader');
                     const copyFilesLoaderConfig = `${copyFilesLoaderPath}?${JSON.stringify({
-                        // file-loader options
                         context: entry.context ? path.resolve(this.webpackConfig.getContext(), entry.context) : copyFrom,
-                        name: copyTo,
-
-                        // custom copy-files-loader options
+                        filename: copyTo,
                         // the patternSource is base64 encoded in case
                         // it contains characters that don't work with
                         // the "inline loader" syntax

--- a/lib/features.js
+++ b/lib/features.js
@@ -116,13 +116,6 @@ const features = {
         ],
         description: 'use Vue with JSX support'
     },
-    copy_files: {
-        method: 'copyFiles()',
-        packages: [
-            { name: 'file-loader', enforce_version: true },
-        ],
-        description: 'Copy files'
-    },
     notifier: {
         method: 'enableBuildNotifications()',
         packages: [

--- a/lib/webpack/copy-files-loader.js
+++ b/lib/webpack/copy-files-loader.js
@@ -9,39 +9,60 @@
 
 'use strict';
 
-const LoaderDependency = require('webpack/lib/dependencies/LoaderDependency');
 const path = require('path');
 
 module.exports.raw = true; // Needed to avoid corrupted binary files
 
-module.exports.default = function loader(source) {
-    // This is a hack that allows `Encore.copyFiles()` to support
-    // JSON files using the file-loader (which is not something
-    // that is supported in Webpack 4, see https://github.com/symfony/webpack-encore/issues/535)
-    //
-    // Since there is no way to change the module's resource type from a loader
-    // without using private properties yet we have to use "this._module".
-    //
-    // By setting its type to 'javascript/auto' Webpack won't try parsing
-    // the result of the loader as a JSON object.
-    //
-    // For more information:
-    // https://github.com/webpack/webpack/issues/6572#issuecomment-368376326
-    // https://github.com/webpack/webpack/issues/7057
-    const requiredType = 'javascript/auto';
-    if (this._module.type !== requiredType) {
-        // Try to retrieve the factory used by the LoaderDependency type
-        // which should be the NormalModuleFactory.
-        const factory = this._compilation.dependencyFactories.get(LoaderDependency);
-        if (factory === undefined) {
-            throw new Error('Could not retrieve module factory for type LoaderDependency');
-        }
+/**
+ * Interpolates a filename template with the given data.
+ *
+ * Supports the following placeholders (compatible with the legacy file-loader):
+ *   - [name]: filename without extension
+ *   - [ext]: file extension without the leading dot
+ *   - [path]: relative directory path from context, with trailing slash
+ *   - [hash:N] or [contenthash:N]: content hash, optionally truncated to N characters
+ *
+ * @param {string} template - The filename template (e.g., '[path][name].[hash:8].[ext]')
+ * @param {object} data
+ * @param {string} data.resourcePath - Absolute path to the resource
+ * @param {string} data.context - Context directory for computing relative paths
+ * @param {string} data.contentHash - Pre-computed content hash
+ * @returns {string} The interpolated filename
+ */
+function interpolateName(template, { resourcePath, context, contentHash }) {
+    const parsed = path.parse(resourcePath);
+    const ext = parsed.ext.slice(1); // Remove leading dot for file-loader compatibility
+    const name = parsed.name;
 
-        this._module.type = requiredType;
-        this._module.generator = factory.getGenerator(requiredType);
-        this._module.parser = factory.getParser(requiredType);
+    // Compute relative directory path from context
+    let relativeDir = path.relative(context, parsed.dir).replace(/\\/g, '/');
+    if (relativeDir) {
+        relativeDir += '/';
     }
 
+    // Replace parent directory markers (..) with underscores for safety
+    relativeDir = relativeDir.replace(/\.\.(\/)?/g, '_$1');
+
+    return template
+        .replace(/\[name\]/g, name)
+        .replace(/\[ext\]/g, ext)
+        .replace(/\[path\]/g, relativeDir)
+        .replace(/\[(?:content)?hash(?::(\d+))?\]/g, (match, length) => {
+            return length ? contentHash.slice(0, parseInt(length, 10)) : contentHash;
+        });
+}
+
+/**
+ * A webpack loader that copies files to the output directory.
+ *
+ * This loader replaces the deprecated file-loader by using webpack's
+ * native this.emitFile() API. It supports filtering files by pattern
+ * and customizing output paths using template placeholders.
+ *
+ * @param {Buffer} source - The raw file content
+ * @returns {string} A CommonJS module that exports the public URL of the copied file
+ */
+module.exports.default = function loader(source) {
     const options = this.getOptions();
 
     // Retrieve the real path of the resource, relative
@@ -59,7 +80,7 @@ module.exports.default = function loader(source) {
         options.patternFlags
     );
 
-    // If the pattern does not match the ressource's path
+    // If the pattern does not match the resource's path
     // it probably means that the import was resolved using the
     // "resolve.extensions" parameter of Webpack (for instance
     // if "./test.js" was matched by "./test").
@@ -67,25 +88,33 @@ module.exports.default = function loader(source) {
         return 'module.exports = "";';
     }
 
-    // Add the "regExp" option (needed to use the [N] placeholder
-    // see: https://github.com/webpack-contrib/file-loader#n)
-    options.regExp = pattern;
+    // Compute content hash using webpack's built-in hashing utilities
+    // This uses the hash function configured in webpack (e.g., xxhash64)
+    const hash = this.utils.createHash();
+    hash.update(source);
+    const contentHash = hash.digest('hex');
 
-    // Remove copy-files-loader's custom options (in case the
-    // file-loader starts looking for thing it doesn't expect)
-    delete options.patternSource;
-    delete options.patternFlags;
-
-    // Update loader's options.
-    this.loaders.forEach(loader => {
-        if (__filename === loader.path) {
-            loader.options = options;
-            delete loader.query;
-        }
+    // Interpolate the output filename using the template
+    const outputPath = interpolateName(options.filename, {
+        resourcePath,
+        context,
+        contentHash,
     });
 
-    const fileLoader = require('file-loader');
+    // Build asset info for webpack
+    const assetInfo = {
+        sourceFilename: path.relative(this.rootContext, resourcePath).replace(/\\/g, '/'),
+    };
 
-    // If everything is OK, let the file-loader do the copy
-    return fileLoader.bind(this)(source);
+    // Check if filename contains a hash (for immutability hints)
+    if (/\[(?:content)?hash(?::\d+)?\]/i.test(options.filename)) {
+        assetInfo.immutable = true;
+    }
+
+    // Emit the file to the output directory
+    this.emitFile(outputPath, source, null, assetInfo);
+
+    // Return a module that exports the public URL
+    return `module.exports = __webpack_public_path__ + ${JSON.stringify(outputPath)};`;
 };
+

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "eslint-plugin-jsdoc": "^50.8.0",
     "eslint-plugin-mocha": "^11.1.0",
     "eslint-plugin-n": "^17.21.3",
-    "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "fs-extra": "^10.0.0",
     "globals": "^16.3.0",
@@ -114,7 +113,6 @@
     "@vue/babel-plugin-jsx": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.0.0",
     "@vue/compiler-sfc": "^2.6 || ^3.0.2",
-    "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.0",
@@ -164,9 +162,6 @@
       "optional": true
     },
     "@vue/compiler-sfc": {
-      "optional": true
-    },
-    "file-loader": {
       "optional": true
     },
     "fork-ts-checker-webpack-plugin": {

--- a/test/functional.js
+++ b/test/functional.js
@@ -2527,41 +2527,6 @@ module.exports = {
                 });
             });
 
-            it('Can use the "[N]" placeholder', function(done) {
-                const config = createWebpackConfig('www/build', 'production');
-                config.addEntry('main', './js/no_require');
-                config.setPublicPath('/build');
-                config.copyFiles({
-                    from: './images',
-                    pattern: /(symfony)_(logo)\.png/,
-                    to: '[path][2]_[1].[ext]',
-                    includeSubdirectories: false
-                });
-
-                testSetup.runWebpack(config, (webpackAssert) => {
-                    expect(config.outputPath).to.be.a.directory()
-                        .with.files([
-                            'entrypoints.json',
-                            'runtime.js',
-                            'main.js',
-                            'manifest.json',
-                            'logo_symfony.png'
-                        ]);
-
-                    webpackAssert.assertManifestPath(
-                        'build/main.js',
-                        '/build/main.js'
-                    );
-
-                    webpackAssert.assertManifestPath(
-                        'build/symfony_logo.png',
-                        '/build/logo_symfony.png'
-                    );
-
-                    done();
-                });
-            });
-
             it('Does not prevent from setting the map option of the manifest plugin', function(done) {
                 const config = createWebpackConfig('www/build', 'production');
                 config.addEntry('main', './js/no_require');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,14 +4030,6 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-file-loader@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -6854,15 +6846,6 @@ scheduler@^0.23.2:
   dependencies:
     loose-envify "^1.1.0"
 
-schema-utils@^3.0.0, schema-utils@^3.1.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
-  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
-  dependencies:
-    "@types/json-schema" "^7.0.8"
-    ajv "^6.12.5"
-    ajv-keywords "^3.5.2"
-
 "schema-utils@^3.0.0 || ^4.0.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.0.tgz#3b669f04f71ff2dfb5aba7ce2d5a9d79b35622c0"
@@ -6872,6 +6855,15 @@ schema-utils@^3.0.0, schema-utils@^3.1.1:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+schema-utils@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 schema-utils@^4.0.0, schema-utils@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #1396 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


This PR removes the deprecated file-loader dependency in favor of webpack's Asset Modules.
This loader was previously used in `Encore.copyFiles()`.