### PR TITLE
Follow-up #1400 (fix URLs generation)

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -604,6 +604,7 @@ class ConfigGenerator {
             headers: { 'Access-Control-Allow-Origin': '*' },
             compress: true,
             historyApiFallback: true,
+            // disabled to let HMR handle updates without full page reloads
             liveReload: false,
             // see https://github.com/symfony/webpack-encore/issues/931#issuecomment-784483725
             host: this.webpackConfig.runtimeConfig.devServerHost,
@@ -612,6 +613,14 @@ class ConfigGenerator {
             // to know the port for sure at Webpack config build time
             port: this.webpackConfig.runtimeConfig.devServerPort,
         };
+
+        // Forward the --server-type CLI flag (e.g. --server-type https) so
+        // that devServerFinalIsHttps can be determined in getWebpackConfig().
+        // configureDevServerOptions() takes precedence if it sets "server".
+        // Use object form { type: ... } so webpack-cli can merge --server-type on top.
+        if (this.webpackConfig.runtimeConfig.devServerServerType) {
+            devServerOptions.server = { type: this.webpackConfig.runtimeConfig.devServerServerType };
+        }
 
         return applyOptionsCallback(
             this.webpackConfig.devServerOptionsConfigurationCallback,

--- a/lib/config/RuntimeConfig.js
+++ b/lib/config/RuntimeConfig.js
@@ -17,6 +17,7 @@ class RuntimeConfig {
         this.environment = process.env.NODE_ENV ? process.env.NODE_ENV : 'dev';
 
         this.useDevServer = false;
+        this.devServerServerType = null;
         // see config-generator - getWebpackConfig()
         this.devServerFinalIsHttps = null;
         this.devServerHost = null;

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -50,6 +50,10 @@ module.exports = function(argv, cwd) {
             runtimeConfig.devServerHost = argv.host ? argv.host : 'localhost';
             runtimeConfig.devServerPort = argv.port ? argv.port : '8080';
 
+            if (argv.serverType) {
+                runtimeConfig.devServerServerType = argv.serverType;
+            }
+
             break;
     }
 

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -276,6 +276,18 @@ module.exports = Encore.getWebpackConfig();
             expect(stderr).to.contain('[webpack-dev-server] Loopback: http://localhost:8080/');
             expect(stderr).to.contain('[webpack-dev-server] Content not from webpack is served from');
 
+            // Verify entrypoints.json contains http:// URLs
+            const entrypoints = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8')
+            );
+            expect(entrypoints.entrypoints.main.js[0]).to.contain('http://localhost:8080/build/');
+
+            // Verify manifest.json contains http:// URLs
+            const manifest = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8')
+            );
+            expect(manifest['build/main.js']).to.contain('http://localhost:8080/build/');
+
             done();
         });
 
@@ -343,6 +355,19 @@ module.exports = Encore.getWebpackConfig();
             expect(stderr).to.contain('[webpack-dev-server] Project is running at:');
             expect(stderr).to.contain('[webpack-dev-server] Loopback: https://localhost:8080/');
             expect(stderr).to.contain('[webpack-dev-server] Content not from webpack is served from');
+
+            // Verify entrypoints.json contains https:// URLs
+            const entrypoints = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8')
+            );
+
+            expect(entrypoints.entrypoints.main.js[0]).to.contain('https://localhost:8080/build/');
+
+            // Verify manifest.json contains https:// URLs
+            const manifest = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8')
+            );
+            expect(manifest['build/main.js']).to.contain('https://localhost:8080/build/');
 
             done();
         });

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -87,6 +87,7 @@ describe('parse-runtime', function() {
         const config = parseArgv(createArgv(['dev-server', '--server-type', 'https', '--host', 'foohost.l', '--port', '9999']), testDir);
 
         expect(config.useDevServer).to.be.true;
+        expect(config.devServerServerType).to.equal('https');
         expect(config.devServerHost).to.equal('foohost.l');
         expect(config.devServerPort).to.equal(9999);
     });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Looks like I went a bit too fast, the URLs generated in `entrypoints.json` and `manifest.json` were always in `http://` even when using flag `--server-type https`. That's now fixed, and tests were improved to prevent regressions.
