### PR TITLE
Tweak ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,12 +99,19 @@ file that was distributed with this source code.`,
     {
         'files': ['test/**/*'],
         languageOptions: {
+            ecmaVersion: 2025,
             globals: {
                 // For Puppeteer when calling "page.evaluate()"
                 document: 'readonly',
             },
         },
         rules: {
+            'n/no-unsupported-features/node-builtins': ['error', {
+                'ignores': [
+                    'import.meta.dirname',
+                    'import.meta.filename',
+                ]
+            }],
             'vitest/expect-expect': 'off',
             'vitest/valid-expect': 'off',
             'vitest/valid-describe-callback': 'off'

--- a/test/functional.js
+++ b/test/functional.js
@@ -20,7 +20,7 @@ import { createRequire } from 'module';
 import { assertWarning } from './helpers/logger-assert.js';
 import packageJson from '../package.json' with { type: 'json' };
 
-const isLowestDependencies = packageJson.config && packageJson.config["lowest-dependencies"] === true;
+const isLowestDependencies = packageJson.config && packageJson.config['lowest-dependencies'] === true;
 const chunkVueJs = isLowestDependencies
     ? 'vendors-node_modules_pnpm_vue_3_2_14_node_modules_vue_dist_vue_runtime_esm-bundler_js.js'
     : 'vendors-node_modules_pnpm_vue_3_5_32_typescript_5_9_3_node_modules_vue_dist_vue_runtime_esm-b-4f542a.js';
@@ -2003,9 +2003,9 @@ module.exports = {
         config.addEntry('main', './stimulus/assets/app.js');
         config.enableStimulusBridge(import.meta.dirname + '/../fixtures/stimulus/assets/controllers.json');
 
-        const chunkStimulusBridgeMock =             isLowestDependencies
+        const chunkStimulusBridgeMock = isLowestDependencies
             ? 'node_modules_pnpm_symfony_mock-module_file_fixtures_stimulus_mock-module_node_modules_symfony-99479d.js'
-            : 'node_modules_symfony_mock-module_dist_controller_js.js'
+            : 'node_modules_symfony_mock-module_dist_controller_js.js';
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         expect(config.outputPath).to.be.a.directory().with.deep.files([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


Following https://github.com/symfony/webpack-encore/pull/1405#issuecomment-4194735604, it's too early to switch from ESLint to Oxlint (unsupported headers plugin and some other rules too).