### PR TITLE
Leverage code formatting from ESLint to Oxfmt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-| Q             | A
-| ------------- | ---
-| Bug fix?      | yes/no
-| New feature?  | yes/no <!-- please update CHANGELOG.md file -->
-| Deprecations? | yes/no <!-- please update CHANGELOG.md file -->
-| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
-| License       | MIT
+| Q             | A                                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Bug fix?      | yes/no                                                                                                                    |
+| New feature?  | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
+| Deprecations? | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
+| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
+| License       | MIT                                                                                                                       |
 
 <!--
 Replace this notice by a description of your feature/bugfix.

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,9 +1,9 @@
-name: ESLint
+name: Oxfmt
 on: [push, pull_request]
 
 jobs:
-    eslint:
-        name: ESLint
+    oxfmt:
+        name: Oxfmt
         runs-on: ubuntu-latest
         env:
             # We don't want Puppeteer to automatically download a browser when dependencies are being installed
@@ -25,5 +25,5 @@ jobs:
             - name: Install pnpm Dependencies
               run: pnpm install
 
-            - name: Run ESLint
-              run: pnpm lint
+            - name: Run Oxfmt
+              run: pnpm fmt:check

--- a/.github/workflows/high-depends.yml
+++ b/.github/workflows/high-depends.yml
@@ -22,26 +22,26 @@ jobs:
                       os: windows-latest
 
         steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
+            - name: Checkout
+              uses: actions/checkout@v4
 
-            -   name: Install pnpm
-                uses: pnpm/action-setup@v5
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
 
-            -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v4
-                with:
-                    node-version: ${{matrix.node-versions}}
-                    cache: pnpm
+            - name: Node ${{matrix.node-versions}}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{matrix.node-versions}}
+                  cache: pnpm
 
-            -   name: Remove Lock File
-                run: rm pnpm-lock.yaml
+            - name: Remove Lock File
+              run: rm pnpm-lock.yaml
 
-            -   name: Install Node.js Dependencies
-                run: pnpm install
+            - name: Install Node.js Dependencies
+              run: pnpm install
 
-            -   name: Show Installed Versions
-                run: pnpm list --depth=0
+            - name: Show Installed Versions
+              run: pnpm list --depth=0
 
-            -   name: Run Tests
-                run: pnpm test
+            - name: Run Tests
+              run: pnpm test

--- a/.github/workflows/low-depends.yml
+++ b/.github/workflows/low-depends.yml
@@ -22,37 +22,37 @@ jobs:
                       os: windows-latest
 
         steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
+            - name: Checkout
+              uses: actions/checkout@v4
 
-            -   name: Install pnpm
-                uses: pnpm/action-setup@v5
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
 
-            -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v4
-                with:
-                    node-version: ${{matrix.node-versions}}
-                    cache: pnpm
+            - name: Node ${{matrix.node-versions}}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{matrix.node-versions}}
+                  cache: pnpm
 
-            -   name: Remove Lock File
-                run: rm pnpm-lock.yaml
+            - name: Remove Lock File
+              run: rm pnpm-lock.yaml
 
-            -   name: Force Lowest Dependencies
-                run: node ./scripts/force-lowest-dependencies
+            - name: Force Lowest Dependencies
+              run: node ./scripts/force-lowest-dependencies
 
             # We have some tests that need to "git checkout" package.json file.
             # Commit them prevent the tests from re-using the locked dependencies.
-            -   name: Commit Changes, to preserve a clean working directory
-                run: |
-                    git config --global user.email ""
-                    git config --global user.name "Symfony"
-                    git commit -am "Force Lowest Dependencies"
+            - name: Commit Changes, to preserve a clean working directory
+              run: |
+                  git config --global user.email ""
+                  git config --global user.name "Symfony"
+                  git commit -am "Force Lowest Dependencies"
 
-            -   name: Install Node.js Dependencies
-                run: pnpm install
+            - name: Install Node.js Dependencies
+              run: pnpm install
 
-            -   name: Show Installed Versions
-                run: pnpm list --depth=0
+            - name: Show Installed Versions
+              run: pnpm list --depth=0
 
-            -   name: Run Tests
-                run: pnpm test
+            - name: Run Tests
+              run: pnpm test

--- a/.github/workflows/stable-tests.yml
+++ b/.github/workflows/stable-tests.yml
@@ -22,23 +22,23 @@ jobs:
                       os: windows-latest
 
         steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
+            - name: Checkout
+              uses: actions/checkout@v4
 
-            -   name: Install pnpm
-                uses: pnpm/action-setup@v5
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
 
-            -   name: Node ${{matrix.node-versions}}
-                uses: actions/setup-node@v4
-                with:
-                    node-version: ${{matrix.node-versions}}
-                    cache: pnpm
+            - name: Node ${{matrix.node-versions}}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{matrix.node-versions}}
+                  cache: pnpm
 
-            -   name: Install Node.js Dependencies
-                run: pnpm install
+            - name: Install Node.js Dependencies
+              run: pnpm install
 
-            -   name: Show Installed Versions
-                run: pnpm list --depth=0
+            - name: Show Installed Versions
+              run: pnpm list --depth=0
 
-            -   name: Run Tests
-                run: pnpm test
+            - name: Run Tests
+              run: pnpm test

--- a/.github/workflows/testing_apps.yml
+++ b/.github/workflows/testing_apps.yml
@@ -2,149 +2,149 @@ name: Testing in real apps
 on: [push, pull_request]
 
 jobs:
-  testing_app:
-    strategy:
-      fail-fast: false
-      matrix:
-        app:
-          - name: npm
-            pkg_manager: npm
-            working_directory: test_apps/npm
-            script: |
-              npm install --ci
-              npm add --save-dev ../../webpack-encore.tgz
-              npm run encore dev
-              npm run encore production
+    testing_app:
+        strategy:
+            fail-fast: false
+            matrix:
+                app:
+                    - name: npm
+                      pkg_manager: npm
+                      working_directory: test_apps/npm
+                      script: |
+                          npm install --ci
+                          npm add --save-dev ../../webpack-encore.tgz
+                          npm run encore dev
+                          npm run encore production
 
-          - name: npm (with .mjs config)
-            pkg_manager: npm
-            working_directory: test_apps/npm-mjs
-            script: |
-              npm install --ci
-              npm add --save-dev ../../webpack-encore.tgz
-              npm run encore dev
-              npm run encore production
+                    - name: npm (with .mjs config)
+                      pkg_manager: npm
+                      working_directory: test_apps/npm-mjs
+                      script: |
+                          npm install --ci
+                          npm add --save-dev ../../webpack-encore.tgz
+                          npm run encore dev
+                          npm run encore production
 
-          - name: npm (with Babel)
-            pkg_manager: npm
-            working_directory: test_apps/npm-with-babel
-            script: |
-              npm install --ci
-              npm add --save-dev ../../webpack-encore.tgz
-              npm run encore dev
-              npm run encore production
+                    - name: npm (with Babel)
+                      pkg_manager: npm
+                      working_directory: test_apps/npm-with-babel
+                      script: |
+                          npm install --ci
+                          npm add --save-dev ../../webpack-encore.tgz
+                          npm run encore dev
+                          npm run encore production
 
-          - name: npm (with external Babel configuration file)
-            pkg_manager: npm
-            working_directory: test_apps/npm-with-external-babel-config
-            script: |
-              npm install --ci
-              npm add --save-dev ../../webpack-encore.tgz
-              npm run encore dev
-              npm run encore production
+                    - name: npm (with external Babel configuration file)
+                      pkg_manager: npm
+                      working_directory: test_apps/npm-with-external-babel-config
+                      script: |
+                          npm install --ci
+                          npm add --save-dev ../../webpack-encore.tgz
+                          npm run encore dev
+                          npm run encore production
 
-          - name: pnpm
-            pkg_manager: pnpm
-            working_directory: test_apps/pnpm
-            script: |
-              pnpm install --frozen-lockfile
-              pnpm add --save-dev ../../webpack-encore.tgz
-              pnpm run encore dev
-              pnpm run encore production
+                    - name: pnpm
+                      pkg_manager: pnpm
+                      working_directory: test_apps/pnpm
+                      script: |
+                          pnpm install --frozen-lockfile
+                          pnpm add --save-dev ../../webpack-encore.tgz
+                          pnpm run encore dev
+                          pnpm run encore production
 
-          - name: pnpm (with .mjs config)
-            pkg_manager: pnpm
-            working_directory: test_apps/pnpm-mjs
-            script: |
-              pnpm install --frozen-lockfile
-              pnpm add --save-dev ../../webpack-encore.tgz
-              pnpm run encore dev
-              pnpm run encore production
+                    - name: pnpm (with .mjs config)
+                      pkg_manager: pnpm
+                      working_directory: test_apps/pnpm-mjs
+                      script: |
+                          pnpm install --frozen-lockfile
+                          pnpm add --save-dev ../../webpack-encore.tgz
+                          pnpm run encore dev
+                          pnpm run encore production
 
-          - name: pnpm (with Babel)
-            pkg_manager: pnpm
-            working_directory: test_apps/pnpm-with-babel
-            script: |
-              pnpm install --frozen-lockfile
-              pnpm add --save-dev ../../webpack-encore.tgz
-              pnpm run encore dev
-              pnpm run encore production
+                    - name: pnpm (with Babel)
+                      pkg_manager: pnpm
+                      working_directory: test_apps/pnpm-with-babel
+                      script: |
+                          pnpm install --frozen-lockfile
+                          pnpm add --save-dev ../../webpack-encore.tgz
+                          pnpm run encore dev
+                          pnpm run encore production
 
-          - name: pnpm (with external Babel configuration file)
-            pkg_manager: pnpm
-            working_directory: test_apps/pnpm-with-external-babel-config
-            script: |
-              pnpm install --frozen-lockfile
-              pnpm add --save-dev ../../webpack-encore.tgz
-              pnpm run encore dev
-              pnpm run encore production
+                    - name: pnpm (with external Babel configuration file)
+                      pkg_manager: pnpm
+                      working_directory: test_apps/pnpm-with-external-babel-config
+                      script: |
+                          pnpm install --frozen-lockfile
+                          pnpm add --save-dev ../../webpack-encore.tgz
+                          pnpm run encore dev
+                          pnpm run encore production
 
-          - name: Yarn Plug'n'Play
-            pkg_manager: yarn
-            working_directory: test_apps/yarn-pnp
-            script: |
-              yarn set version 4.3.0
-              yarn install --immutable
-              yarn add --dev ../../webpack-encore.tgz
-              yarn run encore dev
-              yarn run encore production
+                    - name: Yarn Plug'n'Play
+                      pkg_manager: yarn
+                      working_directory: test_apps/yarn-pnp
+                      script: |
+                          yarn set version 4.3.0
+                          yarn install --immutable
+                          yarn add --dev ../../webpack-encore.tgz
+                          yarn run encore dev
+                          yarn run encore production
 
-          - name: Yarn Plug'n'Play (with .mjs config)
-            pkg_manager: yarn
-            working_directory: test_apps/yarn-pnp-mjs
-            script: |
-              yarn set version 4.3.0
-              yarn install --immutable
-              yarn add --dev ../../webpack-encore.tgz
-              yarn run encore dev
-              yarn run encore production
+                    - name: Yarn Plug'n'Play (with .mjs config)
+                      pkg_manager: yarn
+                      working_directory: test_apps/yarn-pnp-mjs
+                      script: |
+                          yarn set version 4.3.0
+                          yarn install --immutable
+                          yarn add --dev ../../webpack-encore.tgz
+                          yarn run encore dev
+                          yarn run encore production
 
-          - name: Yarn Plug'n'Play (with Babel)
-            pkg_manager: yarn
-            working_directory: test_apps/yarn-pnp-with-babel
-            script: |
-              yarn set version 4.3.0
-              yarn install --immutable
-              yarn add --dev ../../webpack-encore.tgz
-              yarn run encore dev
-              yarn run encore production
+                    - name: Yarn Plug'n'Play (with Babel)
+                      pkg_manager: yarn
+                      working_directory: test_apps/yarn-pnp-with-babel
+                      script: |
+                          yarn set version 4.3.0
+                          yarn install --immutable
+                          yarn add --dev ../../webpack-encore.tgz
+                          yarn run encore dev
+                          yarn run encore production
 
-          - name: Yarn Plug'n'Play (with external Babel configuration file)
-            pkg_manager: yarn
-            working_directory: test_apps/yarn-pnp-with-external-babel-config
-            script: |
-              yarn set version 4.3.0
-              yarn install --immutable
-              yarn add --dev ../../webpack-encore.tgz
-              yarn run encore dev
-              yarn run encore production
+                    - name: Yarn Plug'n'Play (with external Babel configuration file)
+                      pkg_manager: yarn
+                      working_directory: test_apps/yarn-pnp-with-external-babel-config
+                      script: |
+                          yarn set version 4.3.0
+                          yarn install --immutable
+                          yarn add --dev ../../webpack-encore.tgz
+                          yarn run encore dev
+                          yarn run encore production
 
-    name: ${{ matrix.app.name }}
-    runs-on: ubuntu-latest
-    env:
-      # We don't want Puppeteer to automatically download a browser when dependencies are being installed
-      PUPPETEER_SKIP_DOWNLOAD: 'true'
+        name: ${{ matrix.app.name }}
+        runs-on: ubuntu-latest
+        env:
+            # We don't want Puppeteer to automatically download a browser when dependencies are being installed
+            PUPPETEER_SKIP_DOWNLOAD: 'true'
 
-    steps:
-      -   name: Checkout
-          uses: actions/checkout@v4
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      -   name: Install pnpm
-          uses: pnpm/action-setup@v5
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
 
-      -   name: Compute testing app's lockfile
-          run: echo "LOCKFILE=${{ matrix.app.pkg_manager == 'yarn' && 'yarn.lock' || matrix.app.pkg_manager == 'pnpm' && 'pnpm-lock.yaml' || matrix.app.pkg_manager == 'npm' && 'package-lock.json' }}" >> $GITHUB_ENV
+            - name: Compute testing app's lockfile
+              run: echo "LOCKFILE=${{ matrix.app.pkg_manager == 'yarn' && 'yarn.lock' || matrix.app.pkg_manager == 'pnpm' && 'pnpm-lock.yaml' || matrix.app.pkg_manager == 'npm' && 'package-lock.json' }}" >> $GITHUB_ENV
 
-      -   name: Node ${{matrix.node-versions}}
-          uses: actions/setup-node@v4
-          with:
-            node-version: '22.13.0'
-            cache: ${{ matrix.app.pkg_manager }}
-            cache-dependency-path: ${{ matrix.app.working_directory }}/${{ env.LOCKFILE }}
+            - name: Node ${{matrix.node-versions}}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22.13.0'
+                  cache: ${{ matrix.app.pkg_manager }}
+                  cache-dependency-path: ${{ matrix.app.working_directory }}/${{ env.LOCKFILE }}
 
-      -   name: Packing Encore
-          run: pnpm pack --out webpack-encore.tgz
+            - name: Packing Encore
+              run: pnpm pack --out webpack-encore.tgz
 
-      -   name: Running script
-          working-directory: ${{ matrix.app.working_directory }}
-          run: ${{ matrix.app.script }}
+            - name: Running script
+              working-directory: ${{ matrix.app.working_directory }}
+              run: ${{ matrix.app.script }}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "ignorePatterns": ["fixtures/**", "test_apps/**"],
+    "singleQuote": true,
+    "semi": true,
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "bracketSpacing": true,
+    "sortImports": true,
+    "sortPackageJson": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,18 @@ pnpm install
 
 ```bash
 pnpm lint
-pnpm lint --fix
 ```
 
-Runs ESLint on all source files (`lib/`, `test/`, `index.js`).
+Runs ESLint on whole codebase. Use `pnpm lint --fix` to automatically fix issues where possible.
+
+### Formatting
+
+```bash
+pnpm fmt:check
+pnpm fmt
+```
+
+Runs Oxfmt on whole codebase. Use `pnpm fmt` to automatically format code.
 
 ### Testing
 
@@ -125,13 +133,13 @@ Use JSDoc `@import` for type information:
 
 ### Naming Conventions
 
-| Type | Convention | Examples |
-|------|------------|----------|
-| Files (general) | kebab-case | `config-generator.js`, `path-util.js` |
-| Files (classes) | PascalCase | `WebpackConfig.js`, `RuntimeConfig.js` |
-| Variables/Functions | camelCase | `webpackConfig`, `getLoaders()` |
-| Classes | PascalCase | `WebpackConfig`, `RuntimeConfig` |
-| Constants | UPPER_SNAKE_CASE | (rarely used) |
+| Type                | Convention       | Examples                               |
+| ------------------- | ---------------- | -------------------------------------- |
+| Files (general)     | kebab-case       | `config-generator.js`, `path-util.js`  |
+| Files (classes)     | PascalCase       | `WebpackConfig.js`, `RuntimeConfig.js` |
+| Variables/Functions | camelCase        | `webpackConfig`, `getLoaders()`        |
+| Classes             | PascalCase       | `WebpackConfig`, `RuntimeConfig`       |
+| Constants           | UPPER_SNAKE_CASE | (rarely used)                          |
 
 ### Method Naming Patterns
 
@@ -141,7 +149,7 @@ Use JSDoc `@import` for type information:
 - **Configurers**: `configureBabel()`, `configureDefinePlugin()`
 - **Validators**: `validateRuntimeConfig()`, `validateNameIsNewEntry()`
 - **Booleans**: Prefix with `use`, `is`, `should`, `has`:
-  - `useVersioning`, `useSourceMaps`, `isProduction()`, `shouldUseSingleRuntimeChunk`
+    - `useVersioning`, `useSourceMaps`, `isProduction()`, `shouldUseSingleRuntimeChunk`
 
 ### Error Handling
 
@@ -153,7 +161,9 @@ if (typeof callback !== 'function') {
 }
 
 // Include valid options in error messages
-throw new Error(`Invalid option "${optionKey}" passed to method(). Valid keys are ${Object.keys(validOptions).join(', ')}`);
+throw new Error(
+    `Invalid option "${optionKey}" passed to method(). Valid keys are ${Object.keys(validOptions).join(', ')}`
+);
 ```
 
 Use the logger for warnings, recommendations, and deprecations:
@@ -174,9 +184,9 @@ Tests use Vitest with native expect assertions:
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import WebpackConfig from '../lib/WebpackConfig.js';
 
-describe('WebpackConfig object', function() {
-    describe('setOutputPath', function() {
-        it('use absolute, existent path', function() {
+describe('WebpackConfig object', function () {
+    describe('setOutputPath', function () {
+        it('use absolute, existent path', function () {
             const config = createConfig();
             config.setOutputPath(__dirname);
             expect(config.outputPath).toBe(__dirname);
@@ -186,6 +196,7 @@ describe('WebpackConfig object', function() {
 ```
 
 Test helpers are in `test/helpers/`:
+
 - `setup.js`: `createWebpackConfig()`, `runWebpack()`, `createTestAppDir()`
 - `assert.js`: Custom assertions for webpack output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,98 +23,104 @@ can adopt modern async APIs from the ecosystem without hacks**.
 
 ### BC Breaks and upgrade steps
 
-* Migrate from CommonJS to ESM — the package now requires `"type": "module"` in your project or
+- Migrate from CommonJS to ESM — the package now requires `"type": "module"` in your project or
   the use of `.mjs` file extensions. Update your `webpack.config.js`:
-  ```js
-  // Before (CJS)
-  const Encore = require('@symfony/webpack-encore');
-  // ...
-  module.exports = Encore.getWebpackConfig();
 
-  // After (ESM)
-  import Encore from '@symfony/webpack-encore';
-  // ...
-  export default await Encore.getWebpackConfig();
-  ```
-  Note: `Encore.getWebpackConfig()` is now **async** and returns a `Promise`. Use `await` at the
-  top level of your webpack config (webpack supports async config files natively).
+    ```js
+    // Before (CJS)
+    const Encore = require('@symfony/webpack-encore');
+    // ...
+    module.exports = Encore.getWebpackConfig();
 
-* If you prefer not to add `"type": "module"` to your project, you can rename your webpack config
+    // After (ESM)
+    import Encore from '@symfony/webpack-encore';
+    // ...
+    export default await Encore.getWebpackConfig();
+    ```
+
+    Note: `Encore.getWebpackConfig()` is now **async** and returns a `Promise`. Use `await` at the
+    top level of your webpack config (webpack supports async config files natively).
+
+- If you prefer not to add `"type": "module"` to your project, you can rename your webpack config
   file to `webpack.config.mjs` instead. Webpack detects the `.mjs` extension and treats it as ESM
   automatically.
 
-* Replace `__dirname` and `__filename` with their ESM equivalents in your webpack config:
-  ```js
-  // Before (CJS)
-  path.resolve(__dirname, 'src/utilities/')
-  config: [__filename]
+- Replace `__dirname` and `__filename` with their ESM equivalents in your webpack config:
 
-  // After (ESM)
-  path.resolve(import.meta.dirname, 'src/utilities/')
-  config: [import.meta.filename]
-  ```
+    ```js
+    // Before (CJS)
+    path.resolve(__dirname, 'src/utilities/');
+    config: [__filename];
 
-* Replace `require()` calls in your webpack config with `import` statements:
-  ```js
-  // Before (CJS)
-  const path = require('path');
+    // After (ESM)
+    path.resolve(import.meta.dirname, 'src/utilities/');
+    config: [import.meta.filename];
+    ```
 
-  // After (ESM)
-  import path from 'path';
-  ```
-  Similarly, `require.resolve()` becomes `import.meta.resolve()`:
-  ```js
-  // Before (CJS)
-  options.implementation = require.resolve('sass-embedded');
+- Replace `require()` calls in your webpack config with `import` statements:
 
-  // After (ESM)
-  import { fileURLToPath } from 'url';
+    ```js
+    // Before (CJS)
+    const path = require('path');
 
-  options.implementation = fileURLToPath(import.meta.resolve('sass-embedded'));
-  ```
+    // After (ESM)
+    import path from 'path';
+    ```
 
-  If you need to require a CJS-only package, use `createRequire`:
-  ```js
-  import { createRequire } from 'module';
-  const require = createRequire(import.meta.url);
-  const somePackage = require('cjs-only-package');
-  ```
+    Similarly, `require.resolve()` becomes `import.meta.resolve()`:
 
-* Config files that use CJS syntax (`module.exports`, `require()`) must be renamed to `.cjs` if
+    ```js
+    // Before (CJS)
+    options.implementation = require.resolve('sass-embedded');
+
+    // After (ESM)
+    import { fileURLToPath } from 'url';
+
+    options.implementation = fileURLToPath(import.meta.resolve('sass-embedded'));
+    ```
+
+    If you need to require a CJS-only package, use `createRequire`:
+
+    ```js
+    import { createRequire } from 'module';
+    const require = createRequire(import.meta.url);
+    const somePackage = require('cjs-only-package');
+    ```
+
+- Config files that use CJS syntax (`module.exports`, `require()`) must be renamed to `.cjs` if
   your project has `"type": "module"` in its `package.json`. This affects files such as:
-  - `postcss.config.js` → `postcss.config.cjs`
-  - `babel.config.js` → `babel.config.cjs`
+    - `postcss.config.js` → `postcss.config.cjs`
+    - `babel.config.js` → `babel.config.cjs`
 
-  Alternatively, and preferably, rewrite them as ESM:
-  ```js
-  // postcss.config.js (ESM)
-  import autoprefixer from 'autoprefixer';
+    Alternatively, and preferably, rewrite them as ESM:
 
-  export default {
-      plugins: [
-          autoprefixer(),
-      ],
-  };
-  ```
+    ```js
+    // postcss.config.js (ESM)
+    import autoprefixer from 'autoprefixer';
 
-* With `"type": "module"`, webpack enables
+    export default {
+        plugins: [autoprefixer()],
+    };
+    ```
+
+- With `"type": "module"`, webpack enables
   [`resolve.fullySpecified`](https://webpack.js.org/configuration/module/#resolvefullyspecified)
   by default. This means **file extensions are now required** in some imports that previously
   worked without them:
-  - **Relative imports**: `import('./my-dependency')` → `import('./my-dependency.js')`
-  - **Deep package imports** from packages that do not have an `"exports"` field in their
-    `package.json`, for example:
-    - `import delegate from 'licia/delegate'` → `import delegate from 'licia/delegate.js'`
-    - `import 'jquery-ui/ui/widgets/progressbar'` → `import 'jquery-ui/ui/widgets/progressbar.js'`
+    - **Relative imports**: `import('./my-dependency')` → `import('./my-dependency.js')`
+    - **Deep package imports** from packages that do not have an `"exports"` field in their
+      `package.json`, for example:
+        - `import delegate from 'licia/delegate'` → `import delegate from 'licia/delegate.js'`
+        - `import 'jquery-ui/ui/widgets/progressbar'` → `import 'jquery-ui/ui/widgets/progressbar.js'`
 
-* The package `"exports"` field is now restrictive: only `"@symfony/webpack-encore"` and
+- The package `"exports"` field is now restrictive: only `"@symfony/webpack-encore"` and
   `"@symfony/webpack-encore/lib/plugins/plugin-priorities.js"` are exposed as public entry points.
   If you were importing other internal modules directly, those imports will no longer work.
 
 ### Features
 
-* Update postcss-loader support from 8.1.0 to 8.1.1 for ESM compatibility
-* Add support for [webpack-cli@7.0.0](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%407.0.0)
+- Update postcss-loader support from 8.1.0 to 8.1.1 for ESM compatibility
+- Add support for [webpack-cli@7.0.0](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%407.0.0)
 
 ## 6.0.0
 
@@ -122,51 +128,51 @@ This is a new major version that contains several backwards-compatibility breaks
 
 ### BC Breaks
 
-* Remove support of Node.js <22.13.0
-* Remove support of babel-loader@^9.1.3, see possible BC breaks in [10.0.0 release notes](https://github.com/babel/babel-loader/releases/tag/v10.0.0)
-* Remove support of style-loader@^3.3.0, see possible BC breaks in [4.0.0 release notes](https://github.com/webpack/style-loader/releases/tag/v4.0.0)
-* Remove support of less-loader@^11.0.0, see possible BC breaks in [12.0.0 release notes](https://github.com/webpack/less-loader/releases/tag/v12.0.0)
-* Remove support of postcss-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/postcss-loader/releases/tag/v8.0.0)
-* Remove support of stylus-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/stylus-loader/releases/tag/v8.0.0)
-* Remove support of webpack-cli@^5.0.0, see possible BC breaks in [6.0.0 release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0)
-* Remove unmaintained file-loader dependency
+- Remove support of Node.js <22.13.0
+- Remove support of babel-loader@^9.1.3, see possible BC breaks in [10.0.0 release notes](https://github.com/babel/babel-loader/releases/tag/v10.0.0)
+- Remove support of style-loader@^3.3.0, see possible BC breaks in [4.0.0 release notes](https://github.com/webpack/style-loader/releases/tag/v4.0.0)
+- Remove support of less-loader@^11.0.0, see possible BC breaks in [12.0.0 release notes](https://github.com/webpack/less-loader/releases/tag/v12.0.0)
+- Remove support of postcss-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/postcss-loader/releases/tag/v8.0.0)
+- Remove support of stylus-loader@^7.0.0, see possible BC breaks in [8.0.0 release notes](https://github.com/webpack/stylus-loader/releases/tag/v8.0.0)
+- Remove support of webpack-cli@^5.0.0, see possible BC breaks in [6.0.0 release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0)
+- Remove unmaintained file-loader dependency
   The `[N]` placeholder (regex capture groups in filename patterns) is no longer supported.
   If you were using patterns like `[1]` or `[2]` in your `Encore.copyFiles()` filename option, you will need to restructure your file organization or use a different naming strategy.
-* Remove deprecated `--https` flag and `devServerConfig.https` option for webpack-dev-server, use `--server-type https` or `configureDevServerOptions()` with `server: 'https'` instead
+- Remove deprecated `--https` flag and `devServerConfig.https` option for webpack-dev-server, use `--server-type https` or `configureDevServerOptions()` with `server: 'https'` instead
 
 ### Features
 
-* Update @nuxt/friendly-errors-webpack-plugin to @kocal/friendly-errors-webpack-plugin, a maintained fork of the original plugin
-* Update webpack from ^5.74.0 to ^5.82.0
-* Update css-minimizer-webpack-plugin to ^8.0.0, see [release notes](https://github.com/webpack/css-minimizer-webpack-plugin/releases/tag/v8.0.0)
-* Finish removing Vue 2 support leftovers (JSX code path, `vue-jsx` feature, `version: 2` option, Vue 2 peer dependencies), which was forgotten during v5.0.0
+- Update @nuxt/friendly-errors-webpack-plugin to @kocal/friendly-errors-webpack-plugin, a maintained fork of the original plugin
+- Update webpack from ^5.74.0 to ^5.82.0
+- Update css-minimizer-webpack-plugin to ^8.0.0, see [release notes](https://github.com/webpack/css-minimizer-webpack-plugin/releases/tag/v8.0.0)
+- Finish removing Vue 2 support leftovers (JSX code path, `vue-jsx` feature, `version: 2` option, Vue 2 peer dependencies), which was forgotten during v5.0.0
 
 ## 5.3.0
 
-* Add support for Svelte 5
+- Add support for Svelte 5
 
 ## 5.2.0
 
-* Add support for Webpack CLI ^6.0.0
+- Add support for Webpack CLI ^6.0.0
 
-* Add support for babel-loader ^10.0.0
+- Add support for babel-loader ^10.0.0
 
-* Add support for style-loader ^4.0.0
+- Add support for style-loader ^4.0.0
 
 If you manually specified the option `insert`, now it can only be a selector or the path to the module.
 Follow the [style-loader migration guide](https://github.com/webpack-contrib/style-loader/releases/tag/v4.0.0) to upgrade!
 
-* Re-add `webpack-manifest-plugin` dependency, which was previously embedded in https://github.com/symfony/webpack-encore/pull/921
+- Re-add `webpack-manifest-plugin` dependency, which was previously embedded in https://github.com/symfony/webpack-encore/pull/921
 
 ## 5.1.0
 
 ### Features
 
-* Add support for @symfony/stimulus-bridge@^4.0.0 by @Kocal in https://github.com/symfony/webpack-encore/pull/1361
+- Add support for @symfony/stimulus-bridge@^4.0.0 by @Kocal in https://github.com/symfony/webpack-encore/pull/1361
 
 ## 5.0.1
 
-* #1349 Fix issue between `Encore.enableIntegrityHashes()` and filenames with a query-string (@Kocal)
+- #1349 Fix issue between `Encore.enableIntegrityHashes()` and filenames with a query-string (@Kocal)
 
 ## 5.0.0
 
@@ -174,50 +180,51 @@ This is a new major version that contains several backwards-compatibility breaks
 
 ### Features
 
-* #1344 Add options configuration callback to `Encore.enableReactPreset()` (@Kocal)
+- #1344 Add options configuration callback to `Encore.enableReactPreset()` (@Kocal)
 
-* #1345 Add support for integrity hashes when asset names contain a query string (@Kocal)
+- #1345 Add support for integrity hashes when asset names contain a query string (@Kocal)
 
 ### BC Breaks
 
-* #1321 Drop support of Node.js 19 and 21 (@Kocal)
+- #1321 Drop support of Node.js 19 and 21 (@Kocal)
 
-* #1307 Drop `webpack-cli` 4 support, only `webpack-cli` ^5.1.4 is supported (@Kocal)
+- #1307 Drop `webpack-cli` 4 support, only `webpack-cli` ^5.1.4 is supported (@Kocal)
 
-* #1318 Drop webpack-dev-server 4 support, only webpack-dev-server 5 is supported (@Kocal)
+- #1318 Drop webpack-dev-server 4 support, only webpack-dev-server 5 is supported (@Kocal)
 
 The dev-server options have changed between versions 4 and 5, see [the official migration guide to v5](https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md).
 For example:
+
 ```js
 // With webpack-dev-server 4:
 Encore.configureDevServerOptions((options) => {
-   options.https = {
-     ca: "./path/to/server.pem",
-     pfx: "./path/to/server.pfx",
-     key: "./path/to/server.key",
-     cert: "./path/to/server.crt",
-     passphrase: "webpack-dev-server",
-     requestCert: true,
-   };
+    options.https = {
+        ca: './path/to/server.pem',
+        pfx: './path/to/server.pfx',
+        key: './path/to/server.key',
+        cert: './path/to/server.crt',
+        passphrase: 'webpack-dev-server',
+        requestCert: true,
+    };
 });
 
 // With webpack-dev-server 5 (now):
 Encore.configureDevServerOptions((options) => {
-   options.server = {
-      type: 'https',
-      options: {
-         ca: "./path/to/server.pem",
-         pfx: "./path/to/server.pfx",
-         key: "./path/to/server.key",
-         cert: "./path/to/server.crt",
-         passphrase: "webpack-dev-server",
-         requestCert: true,
-      }
-   };
+    options.server = {
+        type: 'https',
+        options: {
+            ca: './path/to/server.pem',
+            pfx: './path/to/server.pfx',
+            key: './path/to/server.key',
+            cert: './path/to/server.crt',
+            passphrase: 'webpack-dev-server',
+            requestCert: true,
+        },
+    };
 });
 ```
 
-* #1336 Make `webpack-dev-server` dependency optional (@Kocal)
+- #1336 Make `webpack-dev-server` dependency optional (@Kocal)
 
 The `webpack-dev-server` package is now an optional peer dependency.
 It has been removed because some projects may not use it, and it was installing a bunch of unnecessary dependencies.
@@ -226,6 +233,7 @@ Removing the `webpack-dev-server` dependency from Encore reduces the number of d
 it helps to reduce the size of the `node_modules` directory and the number of possible vulnerabilities.
 
 To use the `webpack-dev-server` again, you need to install it manually:
+
 ```shell
 npm install webpack-dev-server --save-dev
 # or
@@ -234,61 +242,70 @@ yarn add webpack-dev-server --dev
 pnpm install webpack-dev-server --save-dev
 ```
 
-* #1308 Drop Vue 2 support (End-Of-Life), only Vue 3 is supported (@Kocal)
+- #1308 Drop Vue 2 support (End-Of-Life), only Vue 3 is supported (@Kocal)
 
-* #1309 Drop ESLint integration (@Kocal)
+- #1309 Drop ESLint integration (@Kocal)
 
-* #1313 Drop `clean-webpack-plugin` in favor of webpack's `output.clean` configuration. The
+- #1313 Drop `clean-webpack-plugin` in favor of webpack's `output.clean` configuration. The
   configuration settings supported by `Encore.cleanupOutputBeforeBuild` have changed (@stof)
 
-* #1324 Drop `css-minimizer-webpack-plugin` 5 support, only `css-minimizer-webpack-plugin` 7 is supported (@Kocal)
+- #1324 Drop `css-minimizer-webpack-plugin` 5 support, only `css-minimizer-webpack-plugin` 7 is supported (@Kocal)
 
-* #1342 Replace [`assets-webpack-plugin`](https://github.com/ztoben/assets-webpack-plugin) dependency by an internal plugin, to generate `entrypoints.json` file (@Kocal)
+- #1342 Replace [`assets-webpack-plugin`](https://github.com/ztoben/assets-webpack-plugin) dependency by an internal plugin, to generate `entrypoints.json` file (@Kocal)
 
-* #1317 Drop support of sass-loader ^13 and ^14, add support for sass-loader ^16 (@Kocal)
+- #1317 Drop support of sass-loader ^13 and ^14, add support for sass-loader ^16 (@Kocal)
 
 The sass-loader's options have changed, [the `modern` options](https://sass-lang.com/documentation/js-api/interfaces/options) are now used by default.
 Though not recommended,
 you must specify the option `api: 'legacy'`
 if you want to keep [the `legacy` options](https://sass-lang.com/documentation/js-api/interfaces/legacystringoptions/).
 For example:
+
 ```js
 // With the legacy API:
 Encore.enableSassLoader((options) => {
     options.api = 'legacy';
-    options.includePaths = [/*...*/];
+    options.includePaths = [
+        /*...*/
+    ];
 });
 
 // With the modern API (default):
 Encore.enableSassLoader((options) => {
-   options.loadPaths = [/*...*/];
+    options.loadPaths = [
+        /*...*/
+    ];
 });
 ```
 
-* #1319 Drop support of css-loader ^6, add support for css-loader ^7.1 (@Kocal)
+- #1319 Drop support of css-loader ^6, add support for css-loader ^7.1 (@Kocal)
 
 Since [`css-loader` 7.0.0](https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04),
 styles imports became named by default.
 It means you should update your code from:
+
 ```js
-import style from "./style.css";
+import style from './style.css';
 
 console.log(style.myClass);
 ```
+
 to:
+
 ```js
-import * as style from "./style.css";
+import * as style from './style.css';
 
 console.log(style.myClass);
 ```
 
 There is also a possibility to keep the previous behavior by configuring the `css-loader`'s `modules` option:
+
 ```js
-config.configureCssLoader(options => {
-   if (options.modules) {
-       options.modules.namedExport = false;
-       options.modules.exportLocalsConvention = 'as-is';
-   }
+config.configureCssLoader((options) => {
+    if (options.modules) {
+        options.modules.namedExport = false;
+        options.modules.exportLocalsConvention = 'as-is';
+    }
 });
 ```
 
@@ -297,51 +314,52 @@ config.configureCssLoader(options => {
 > until https://github.com/vuejs/vue-loader/pull/1909 is merged and released, you will need to restore the previous
 > behavior by configuring Encore with the code above.
 
-* #1333 Replace `chalk` by `picocolors` (@Kocal)
+- #1333 Replace `chalk` by `picocolors` (@Kocal)
 
 ### Internal
 
-* #1325 Remove no-op argument (@stof)
+- #1325 Remove no-op argument (@stof)
 
-* #1327 Fix compat with configuring the devserver server as a string (@stof)
+- #1327 Fix compat with configuring the devserver server as a string (@stof)
 
-* #1328 Remove non-existent option in our package-up utility (@stof)
+- #1328 Remove non-existent option in our package-up utility (@stof)
 
-* #1329 Read the controllers.json as string rather than Buffer (@stof)
+- #1329 Read the controllers.json as string rather than Buffer (@stof)
 
-* #1330 Add some types in the internal implementation of Encore (@stof)
+- #1330 Add some types in the internal implementation of Encore (@stof)
 
-* #1331 test(deps): replace Zombie by Puppeteer (@Kocal)
+- #1331 test(deps): replace Zombie by Puppeteer (@Kocal)
 
-* #1332 Upgrade locked dependencies (@stof)
+- #1332 Upgrade locked dependencies (@stof)
 
-* #1334 Upgrade the version of stylus used in dev (@stof)
+- #1334 Upgrade the version of stylus used in dev (@stof)
 
-* #1335 Fix ESLint warning (@stof)
+- #1335 Fix ESLint warning (@stof)
 
-* #1339 Add PR template (@Kocal)
+- #1339 Add PR template (@Kocal)
 
-* #1343 Add tests for CSS Modules with React and Preact (@Kocal)
+- #1343 Add tests for CSS Modules with React and Preact (@Kocal)
 
 ## 4.7.0
 
 ### Features
 
-* #1284 Improve ESLint and Babel help messages, when enabling ESLint integration (@Kocal)
+- #1284 Improve ESLint and Babel help messages, when enabling ESLint integration (@Kocal)
 
-* #1285 Add support for PNPM for installation commands (@Kocal)
+- #1285 Add support for PNPM for installation commands (@Kocal)
 
-* #1286 Add support for Node.js 22 (@Kocal)
+- #1286 Add support for Node.js 22 (@Kocal)
 
-* #1299 Add support for less-loader 12 (@Kocal)
+- #1299 Add support for less-loader 12 (@Kocal)
 
-* #1301 Add support for postcss-loader 8 (@Kocal)
+- #1301 Add support for postcss-loader 8 (@Kocal)
 
-* #1302 Add support for stylus-loader 8 (@Kocal)
+- #1302 Add support for stylus-loader 8 (@Kocal)
 
-* #1295 Add JSX support for Vue 3 (@Kocal)
+- #1295 Add JSX support for Vue 3 (@Kocal)
 
 Enabling JSX support for Vue 3 is done with the `Encore.enableVueLoader()`:
+
 ```js
 Encore.enableVueLoader(() => {}, {
     useJsx: true,
@@ -352,91 +370,90 @@ Encore.enableVueLoader(() => {}, {
 If you don't have a custom Babel configuration, then you're all set!
 But if you do, you may need to adjust it
 to add [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) plugin to your Babel configuration:
+
 ```js
 // babel.config.js
 module.exports = {
-    plugins: [
-        '@vue/babel-plugin-jsx'
-    ]
+    plugins: ['@vue/babel-plugin-jsx'],
 };
 ```
 
 ### Deprecations
 
-* #1278 Deprecate ESLint integration (@Kocal)
+- #1278 Deprecate ESLint integration (@Kocal)
 
-* #1298 Deprecate Vue 2 support (@Kocal)
+- #1298 Deprecate Vue 2 support (@Kocal)
 
 ### Internal
 
-* #1275 Update some dev-dependencies to fix vulnerability issues (@Kocal)
+- #1275 Update some dev-dependencies to fix vulnerability issues (@Kocal)
 
-* #1259 Update yarn used for test_apps to latest version (@karpilin)
+- #1259 Update yarn used for test_apps to latest version (@karpilin)
 
-* #1297 Upgrade GitHub Actions in CI (@Kocal)
+- #1297 Upgrade GitHub Actions in CI (@Kocal)
 
-* #1304 Replace `fast-levenshtein` by `fastest-levenshtein` (@Kocal)
+- #1304 Replace `fast-levenshtein` by `fastest-levenshtein` (@Kocal)
 
-* #1303 Replace `pkg-up` by an inlined solution (@Kocal)
+- #1303 Replace `pkg-up` by an inlined solution (@Kocal)
 
 ## [v4.6.1](https://github.com/symfony/webpack-encore/releases/tag/v4.6.1)
 
-* #1256 Re-adding node 18 support (@weaverryan)
+- #1256 Re-adding node 18 support (@weaverryan)
 
 ## [v4.6.0](https://github.com/symfony/webpack-encore/releases/tag/v4.6.0)
 
-* #1254 Increased minimum Node version to 20 (@weaverryan)
+- #1254 Increased minimum Node version to 20 (@weaverryan)
 
-* #1253 Allow sass-loader 14 (@cedric-anne)
+- #1253 Allow sass-loader 14 (@cedric-anne)
 
-* #1247 Allow only configuring a plugin (@gimler)
+- #1247 Allow only configuring a plugin (@gimler)
 
 ## [v4.5.0](https://github.com/symfony/webpack-encore/releases/tag/v4.5.0)
 
 ### Features
 
-* #1235 Dropping support for Node 14 (16 is new min) and allowing `svelte` 4 (@weaverryan)
+- #1235 Dropping support for Node 14 (16 is new min) and allowing `svelte` 4 (@weaverryan)
 
-* #1185 Bump `babel-loader` from 8.2.5 to 9.1.2 (@dppanteon) - the
+- #1185 Bump `babel-loader` from 8.2.5 to 9.1.2 (@dppanteon) - the
   [CHANGELOG for babel 9](https://github.com/babel/babel-loader/releases/tag/v9.0.0)
   does not list any breaking changes besides increasing the minimum Node version.
 
-* #1224 Allow fork-ts-checker-webpack-plugin ^8.0 and ^9.0 (@buffcode)
+- #1224 Allow fork-ts-checker-webpack-plugin ^8.0 and ^9.0 (@buffcode)
 
 ## [v4.4.0](https://github.com/symfony/webpack-encore/releases/tag/v4.4.0)
 
 ### Features
 
-* #1203 upgrade css-minimizer-webpack-plugin from 4 to 5
+- #1203 upgrade css-minimizer-webpack-plugin from 4 to 5
 
 ## [v4.3.0](https://github.com/symfony/webpack-encore/releases/tag/v4.3.0)
 
 ### Features
 
-* #1200 Allow TypeScript 5 (@jmsche)
-* #1190 Allow eslint-webpack-plugin ^4.0 (@evertharmeling)
+- #1200 Allow TypeScript 5 (@jmsche)
+- #1190 Allow eslint-webpack-plugin ^4.0 (@evertharmeling)
 
 ### Bugs
 
-* #1175 Delay force sync until needed (@wesoledi, @weaverryan)
+- #1175 Delay force sync until needed (@wesoledi, @weaverryan)
 
 ## [v4.2.0](https://github.com/symfony/webpack-encore/releases/tag/v4.2.0)
 
 ### Features
 
-* Allow webpack-cli version 5 to be used in your package.json file
+- Allow webpack-cli version 5 to be used in your package.json file
 
 ## [v4.1.0](https://github.com/symfony/webpack-encore/releases/tag/v4.1.0)
 
-*October 17th, 2022*
+_October 17th, 2022_
 
 ### Features
 
-* Add support for Svelte - #781 thanks to @zairigimad
+- Add support for Svelte - #781 thanks to @zairigimad
 
 ### Bug Fixes
 
-* Support for Vue 2 was accidentally dropped in 4.0.0, and was re-added - #1157 thanks to @Kocal.
+- Support for Vue 2 was accidentally dropped in 4.0.0, and was re-added - #1157 thanks to @Kocal.
 
 ## [v4.0.0](https://github.com/symfony/webpack-encore/releases/tag/v4.0.0)
 
@@ -444,7 +461,8 @@ This major release makes Encore compatible with [Yarn Plug'n'Play](https://yarnp
 
 ### BC Breaks
 
-* The following dependencies **must be added** in your `package.json`: `webpack webpack-cli @babel/core @babel/preset-env` (#1142 and #1150):
+- The following dependencies **must be added** in your `package.json`: `webpack webpack-cli @babel/core @babel/preset-env` (#1142 and #1150):
+
 ```shell
 npm install webpack webpack-cli @babel/core @babel/preset-env --save-dev
 
@@ -452,8 +470,9 @@ npm install webpack webpack-cli @babel/core @babel/preset-env --save-dev
 yarn add webpack webpack-cli @babel/core @babel/preset-env --dev
 ```
 
-* The following dependencies **must be removed** from your `package.json` and Babel configuration: `@babel/plugin-syntax-dynamic-import @babel/plugin-proposal-class-properties`,
-since they are already included in `@babel/preset-env` (#1150):
+- The following dependencies **must be removed** from your `package.json` and Babel configuration: `@babel/plugin-syntax-dynamic-import @babel/plugin-proposal-class-properties`,
+  since they are already included in `@babel/preset-env` (#1150):
+
 ```shell
 npm remove @babel/plugin-syntax-dynamic-import @babel/plugin-proposal-class-properties
 
@@ -462,6 +481,7 @@ yarn remove @babel/plugin-syntax-dynamic-import @babel/plugin-proposal-class-pro
 ```
 
 and remove it from your Encore configuration:
+
 ```diff
 Encore.configureBabel((options) => {
 -    config.plugins.push('@babel/plugin-proposal-class-properties');
@@ -471,29 +491,28 @@ Encore.configureBabel((options) => {
 
 ## [v3.1.0](https://github.com/symfony/webpack-encore/releases/tag/v3.1.0)
 
-*August 24th, 2022*
+_August 24th, 2022_
 
-* Add vue 2.7 feature to allow dropping `vue-template-compiler` - #1134 thanks to @billyct
+- Add vue 2.7 feature to allow dropping `vue-template-compiler` - #1134 thanks to @billyct
 
 ## [v3.0.0](https://github.com/symfony/webpack-encore/releases/tag/v3.0.0)
 
-*July 8th, 2022*
+_July 8th, 2022_
 
 This major release drops support for Node 12 (minimum is now Node 14) and
 also bumps some dependencies up a new major version.
 
 ### BC Breaks
 
-* In #1122 support for Node 12 was dropped.
+- In #1122 support for Node 12 was dropped.
 
-* In #1133, the following dependencies were bumped a major version:
-
-  * `css-minimizer-webpack-plugin` 3.4 -> 4.0 (4.0 just drops Node 12 support)
-  * `less-loader` 10 -> 11
-  * `postcss-loader` 6 -> 7
-  * `sass-loader` 12 -> 13
-  * `stylus` 0.57 -> 0.58
-  * `stylus-loader` 6 -> 7
+- In #1133, the following dependencies were bumped a major version:
+    - `css-minimizer-webpack-plugin` 3.4 -> 4.0 (4.0 just drops Node 12 support)
+    - `less-loader` 10 -> 11
+    - `postcss-loader` 6 -> 7
+    - `sass-loader` 12 -> 13
+    - `stylus` 0.57 -> 0.58
+    - `stylus-loader` 6 -> 7
 
 If you're using any of these (all are optional except for `css-minimizer-webpack-plugin`
 and are extended them with custom configuration, check the CHANGELOG of each for
@@ -501,22 +520,22 @@ any possible BC breaks).
 
 ### Feature
 
-- [#1133](https://github.com/symfony/webpack-encore/pull/1133) - Increasing dependencies - *@weaverryan*
-- [#1125](https://github.com/symfony/webpack-encore/pull/1125) - Changing to support the "server" options object for webpack-dev-server - *@weaverryan*
-- [#1122](https://github.com/symfony/webpack-encore/pull/1122) - Allow sass-loader:^13.0.0, require node >= 14 - *@jmsche*
-- [#1118](https://github.com/symfony/webpack-encore/pull/1118) - Use cli param server-type to define devServer https mode - *@thegillou*
+- [#1133](https://github.com/symfony/webpack-encore/pull/1133) - Increasing dependencies - _@weaverryan_
+- [#1125](https://github.com/symfony/webpack-encore/pull/1125) - Changing to support the "server" options object for webpack-dev-server - _@weaverryan_
+- [#1122](https://github.com/symfony/webpack-encore/pull/1122) - Allow sass-loader:^13.0.0, require node >= 14 - _@jmsche_
+- [#1118](https://github.com/symfony/webpack-encore/pull/1118) - Use cli param server-type to define devServer https mode - _@thegillou_
 
 ## [v2.1.0](https://github.com/symfony/webpack-encore/releases/tag/v2.1.0)
 
-*May 5th, 2022*
+_May 5th, 2022_
 
 ### Feature
 
-- [#1093](https://github.com/symfony/webpack-encore/pull/1093) - Allow sass-embedded - *@IonBazan*
+- [#1093](https://github.com/symfony/webpack-encore/pull/1093) - Allow sass-embedded - _@IonBazan_
 
 ## [v2.0.0](https://github.com/symfony/webpack-encore/releases/tag/v2.0.0)
 
-*May 3rd, 2022*
+_May 3rd, 2022_
 
 This is a new major version that contains several backwards-compatibility breaks.
 
@@ -526,38 +545,38 @@ The following dependencies were upgraded a major version. It's unlikely
 these will cause problems, unless you were further configuring this part
 of Encore:
 
-* `clean-webpack-plugin` Version `3` to `4`: dropped old Node & Webpack version support
-* `css-loader` Version `5` to `6`: dropped old Node version support & [CHANGELOG](https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#-breaking-changes)
-* `css-minimizer-webpack-plugin` Version `2` to `3`: dropped old Node version support
-* `loader-utils` REMOVED
-* `mini-css-extract-plugin` Version `1.5` to `2.2.1`: dropped old Node & Webpack version support & [CHANGELOG](https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/CHANGELOG.md#-breaking-changes)
-* `pretty-error` Version `3.0` to `4.0`: dropped old Node version support
-* `resolve-url-loader` Version `3.0` to `5.0`: dropped old Node version support, requires postcss `^8.0`, remove `rework` engine & [CHANGELOG](https://github.com/bholloway/resolve-url-loader/blob/v4-maintenance/packages/resolve-url-loader/CHANGELOG.md)
-* `style-loader` Version `2` to `3`: dropped old Node and Webpack version support & [CHANGELOG](https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#-breaking-changes)
-* `yargs-parser` Version `20.2` to `21`: dropped old Node version support
+- `clean-webpack-plugin` Version `3` to `4`: dropped old Node & Webpack version support
+- `css-loader` Version `5` to `6`: dropped old Node version support & [CHANGELOG](https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#-breaking-changes)
+- `css-minimizer-webpack-plugin` Version `2` to `3`: dropped old Node version support
+- `loader-utils` REMOVED
+- `mini-css-extract-plugin` Version `1.5` to `2.2.1`: dropped old Node & Webpack version support & [CHANGELOG](https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/CHANGELOG.md#-breaking-changes)
+- `pretty-error` Version `3.0` to `4.0`: dropped old Node version support
+- `resolve-url-loader` Version `3.0` to `5.0`: dropped old Node version support, requires postcss `^8.0`, remove `rework` engine & [CHANGELOG](https://github.com/bholloway/resolve-url-loader/blob/v4-maintenance/packages/resolve-url-loader/CHANGELOG.md)
+- `style-loader` Version `2` to `3`: dropped old Node and Webpack version support & [CHANGELOG](https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#-breaking-changes)
+- `yargs-parser` Version `20.2` to `21`: dropped old Node version support
 
 Additionally, Encore changed the supported versions of the following packages,
 which you may have installed to enable extra features:
 
-* `eslint` Minimum version increased from `7` to `8`
-* `eslint-webpack-plugin` Minimum version increased from `2.5` to `3`
-* `fork-ts-checker-webpack-plugin` Minimum version increased from `5` to `6` [CHANGELOG](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/releases/tag/v6.0.0)
-* `less-loader` Minimum version increased from `7` to `10`
-* `postcss-loader` Minimum version increased from `4` to `6`
-* `preact` Minimum version increased from `8` to `10` [CHANGELOG](https://github.com/preactjs/preact/releases/tag/10.0.0)
-* `sass-loader` Minimum version increased from `9` to `12`
-* `stylus` Minimum version increased from `0.54` to `0.56`
-* `stylus-loader` Minimum version increased from `3` to `6` [CHANGELOG](https://github.com/webpack-contrib/stylus-loader/blob/master/CHANGELOG.md#400-2020-09-29)
-* `vue-loader` Minimum version increased from `16` to `17` [CHANGELOG](https://github.com/vuejs/vue-loader/blob/next/CHANGELOG.md#1700-2021-12-12)
+- `eslint` Minimum version increased from `7` to `8`
+- `eslint-webpack-plugin` Minimum version increased from `2.5` to `3`
+- `fork-ts-checker-webpack-plugin` Minimum version increased from `5` to `6` [CHANGELOG](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/releases/tag/v6.0.0)
+- `less-loader` Minimum version increased from `7` to `10`
+- `postcss-loader` Minimum version increased from `4` to `6`
+- `preact` Minimum version increased from `8` to `10` [CHANGELOG](https://github.com/preactjs/preact/releases/tag/10.0.0)
+- `sass-loader` Minimum version increased from `9` to `12`
+- `stylus` Minimum version increased from `0.54` to `0.56`
+- `stylus-loader` Minimum version increased from `3` to `6` [CHANGELOG](https://github.com/webpack-contrib/stylus-loader/blob/master/CHANGELOG.md#400-2020-09-29)
+- `vue-loader` Minimum version increased from `16` to `17` [CHANGELOG](https://github.com/vuejs/vue-loader/blob/next/CHANGELOG.md#1700-2021-12-12)
 
-* Removed `Encore.enableEslintLoader()`: use `Encore.enableEslintPlugin()`.
+- Removed `Encore.enableEslintLoader()`: use `Encore.enableEslintPlugin()`.
 
-* If using `enableEslintPlugin()` with the `@babel/eslint-parser` parser,
+- If using `enableEslintPlugin()` with the `@babel/eslint-parser` parser,
   you may now need to create an external Babel configuration file. To see
   an example, temporarily delete your `.eslintrc.js` file and run Encore.
   The error will show you a Babel configuration file you can use.
 
-* With `configureDefinePlugin()`, the `options['process.env']` key format
+- With `configureDefinePlugin()`, the `options['process.env']` key format
   passed to the callback has changed (see #960). If you are using `configureDefinePlugin()`
   to add more items to `process.env`, your code will need to change:
 
@@ -566,487 +585,486 @@ Encore.configureDefinePlugin((options) => {
 -    options['process.env']['SOME_VAR'] = JSON.stringify('the value');
 +    options['process.env.SOME_VAR'] = JSON.stringify('the value');
 })
-````
+```
 
 ## [v1.8.2](https://github.com/symfony/webpack-encore/releases/tag/v1.8.2)
 
-*Mar 17th, 2022*
+_Mar 17th, 2022_
 
 ### Bug Fix
 
-- [#1095](https://github.com/symfony/webpack-encore/pull/1095) - bug #1095 Revert removing public option from dev-server - *@louismariegaborit*
+- [#1095](https://github.com/symfony/webpack-encore/pull/1095) - bug #1095 Revert removing public option from dev-server - _@louismariegaborit_
 
 ## [v1.8.1](https://github.com/symfony/webpack-encore/releases/tag/v1.8.1)
 
-*Jan 21st, 2022*
+_Jan 21st, 2022_
 
 ### Bug Fix
 
-- [#1076](https://github.com/symfony/webpack-encore/pull/1076) - fix: lazy-load ESLint plugin dependency, fix #1075 - *@Kocal*
+- [#1076](https://github.com/symfony/webpack-encore/pull/1076) - fix: lazy-load ESLint plugin dependency, fix #1075 - _@Kocal_
 
 ## [v1.8.0](https://github.com/symfony/webpack-encore/releases/tag/v1.8.0)
 
-*Jan 20th, 2022*
+_Jan 20th, 2022_
 
 ### Feature
 
-- [#985](https://github.com/symfony/webpack-encore/pull/985) - Move from eslint-loader to eslint-webpack-plugin - *@Kocal*
-- [#1070](https://github.com/symfony/webpack-encore/pull/1070) - New Encore method for adding multiple entries at once - *@shmolf*
-- [#1074](https://github.com/symfony/webpack-encore/pull/1074) - Support AVIF images - *@benbankes*
+- [#985](https://github.com/symfony/webpack-encore/pull/985) - Move from eslint-loader to eslint-webpack-plugin - _@Kocal_
+- [#1070](https://github.com/symfony/webpack-encore/pull/1070) - New Encore method for adding multiple entries at once - _@shmolf_
+- [#1074](https://github.com/symfony/webpack-encore/pull/1074) - Support AVIF images - _@benbankes_
 
 ## [v1.7.1](https://github.com/symfony/webpack-encore/releases/tag/v1.7.1)
 
-*Jan 20th, 2022*
+_Jan 20th, 2022_
 
 ### Bug Fix
 
-- [#1069](https://github.com/symfony/webpack-encore/pull/1069) - Increased webpack-cli version constraint to v.4.9.1 - *@nspyke*
+- [#1069](https://github.com/symfony/webpack-encore/pull/1069) - Increased webpack-cli version constraint to v.4.9.1 - _@nspyke_
 
 ## [v1.7.0](https://github.com/symfony/webpack-encore/releases/tag/v1.7.0)
 
-*Dec 2nd, 2021*
+_Dec 2nd, 2021_
 
 Dependency changes:
 
-* Official support for `ts-loader` 8 was dropped.
-* Official support for `typescript` 3 was dropped and minimum increased to 4.2.2.
-* Official support for `vue` was bumped to 3.2.14 or higher.
-* Official support for `vue-loader` was bumped to 16.7.0 or higher.
+- Official support for `ts-loader` 8 was dropped.
+- Official support for `typescript` 3 was dropped and minimum increased to 4.2.2.
+- Official support for `vue` was bumped to 3.2.14 or higher.
+- Official support for `vue-loader` was bumped to 16.7.0 or higher.
 
 ### Feature
 
-- [#1062](https://github.com/symfony/webpack-encore/pull/1062) - Allowing @hotwired/stimulus, allowing @symfony/stimulus-bridge 3, dropping v1. - *@weaverryan*
+- [#1062](https://github.com/symfony/webpack-encore/pull/1062) - Allowing @hotwired/stimulus, allowing @symfony/stimulus-bridge 3, dropping v1. - _@weaverryan_
 
 ### Bug Fix
 
-- [#1058](https://github.com/symfony/webpack-encore/pull/1058) - Fix deprecated public option failure for webpack-dev-server - *@atesca09*
+- [#1058](https://github.com/symfony/webpack-encore/pull/1058) - Fix deprecated public option failure for webpack-dev-server - _@atesca09_
 
 ## [v1.6.1](https://github.com/symfony/webpack-encore/releases/tag/v1.6.1)
 
-*Sep 3rd, 2021*
+_Sep 3rd, 2021_
 
 ### Bug Fix
 
-- [#1031](https://github.com/symfony/webpack-encore/pull/1031) - changing position of host option for webpack-dev-server - *@weaverryan*
+- [#1031](https://github.com/symfony/webpack-encore/pull/1031) - changing position of host option for webpack-dev-server - _@weaverryan_
 
 ## [v1.6.0](https://github.com/symfony/webpack-encore/releases/tag/v1.6.0)
 
-*Aug 31st, 2021*
+_Aug 31st, 2021_
 
 ### Feature
 
-- [#1008](https://github.com/symfony/webpack-encore/pull/1008) - Allow postcss-loader 6  - *@bobvandevijver*
-- [#1009](https://github.com/symfony/webpack-encore/pull/1009) - Allow less-loader 10 - *@bobvandevijver*
+- [#1008](https://github.com/symfony/webpack-encore/pull/1008) - Allow postcss-loader 6 - _@bobvandevijver_
+- [#1009](https://github.com/symfony/webpack-encore/pull/1009) - Allow less-loader 10 - _@bobvandevijver_
 
 ## [v1.5.0](https://github.com/symfony/webpack-encore/releases/tag/v1.5.0)
 
-*June 18th, 2021*
+_June 18th, 2021_
 
 ### Feature
 
-- [#1000](https://github.com/symfony/webpack-encore/pull/1000) - Allow ts-loader ^9.0.0, close #993 - *@Kocal*
-- [#999](https://github.com/symfony/webpack-encore/pull/999) - Allow sass-loader ^12.0.0, close #996 - *@Kocal*
+- [#1000](https://github.com/symfony/webpack-encore/pull/1000) - Allow ts-loader ^9.0.0, close #993 - _@Kocal_
+- [#999](https://github.com/symfony/webpack-encore/pull/999) - Allow sass-loader ^12.0.0, close #996 - _@Kocal_
 
 ## [v1.4.0](https://github.com/symfony/webpack-encore/releases/tag/v1.4.0)
 
-*May 31st, 2021*
+_May 31st, 2021_
 
 ### Feature
 
-- [#983](https://github.com/symfony/webpack-encore/pull/983) - Allow less-loader v9 - *@bobvandevijver*
+- [#983](https://github.com/symfony/webpack-encore/pull/983) - Allow less-loader v9 - _@bobvandevijver_
 
 ### Bug Fix
 
-- [#979](https://github.com/symfony/webpack-encore/pull/979) - #936: Fix manifest key problem when using copy files - *@bobvandevijver*
+- [#979](https://github.com/symfony/webpack-encore/pull/979) - #936: Fix manifest key problem when using copy files - _@bobvandevijver_
 
 ## [v1.3.0](https://github.com/symfony/webpack-encore/releases/tag/v1.3.0)
 
-*May 11th, 2021*
+_May 11th, 2021_
 
 ### Feature
 
-- [#976](https://github.com/symfony/webpack-encore/pull/976) - Change friendly-errors-webpack-plugin to `@nuxt`/friendly-errors-webpack-plugin - *@hailwood*
+- [#976](https://github.com/symfony/webpack-encore/pull/976) - Change friendly-errors-webpack-plugin to `@nuxt`/friendly-errors-webpack-plugin - _@hailwood_
 
 ### Bug Fix
 
-- [#975](https://github.com/symfony/webpack-encore/pull/975) - Resolve security issue CVE-2021-23369 - *@elghailani*
+- [#975](https://github.com/symfony/webpack-encore/pull/975) - Resolve security issue CVE-2021-23369 - _@elghailani_
 
 ## [v1.2.0](https://github.com/symfony/webpack-encore/releases/tag/v1.2.0)
 
-*May 3rd, 2021*
+_May 3rd, 2021_
 
 ### Feature
 
-- [#968](https://github.com/symfony/webpack-encore/pull/968) - Locking assets-webpack-plugin to less than 7.1.0 - *@weaverryan*
-- [#966](https://github.com/symfony/webpack-encore/pull/966) - Upgrade to css-minimize-webpack-plugin 2.0 - *@stof*
-- [#963](https://github.com/symfony/webpack-encore/pull/963) - feat: add Encore.when() - *@Kocal*
+- [#968](https://github.com/symfony/webpack-encore/pull/968) - Locking assets-webpack-plugin to less than 7.1.0 - _@weaverryan_
+- [#966](https://github.com/symfony/webpack-encore/pull/966) - Upgrade to css-minimize-webpack-plugin 2.0 - _@stof_
+- [#963](https://github.com/symfony/webpack-encore/pull/963) - feat: add Encore.when() - _@Kocal_
 
 ### Bug Fix
 
-- [#943](https://github.com/symfony/webpack-encore/pull/943) - Do not allow webpack-dev-server to find an open port - *@weaverryan*
+- [#943](https://github.com/symfony/webpack-encore/pull/943) - Do not allow webpack-dev-server to find an open port - _@weaverryan_
 
 ## [v1.1.2](https://github.com/symfony/webpack-encore/releases/tag/v1.1.2)
 
-*March 1st, 2021*
+_March 1st, 2021_
 
 ### Bug Fix
 
-- [#939](https://github.com/symfony/webpack-encore/pull/939) - fixing 2 issues related to webpack-dev-server and HMR - *@weaverryan*
-- [#938](https://github.com/symfony/webpack-encore/pull/938) - Require vue-loader 15.9.5 to work with Encore 1.0 - *@weaverryan*
+- [#939](https://github.com/symfony/webpack-encore/pull/939) - fixing 2 issues related to webpack-dev-server and HMR - _@weaverryan_
+- [#938](https://github.com/symfony/webpack-encore/pull/938) - Require vue-loader 15.9.5 to work with Encore 1.0 - _@weaverryan_
 
 ## [v1.1.1](https://github.com/symfony/webpack-encore/releases/tag/v1.1.1)
 
-*February 19th, 2021*
+_February 19th, 2021_
 
 ### Bug Fix
 
-- [#930](https://github.com/symfony/webpack-encore/pull/930) - Fix Encore.copyFiles() when copying images/fonts - *@Lyrkan*
+- [#930](https://github.com/symfony/webpack-encore/pull/930) - Fix Encore.copyFiles() when copying images/fonts - _@Lyrkan_
 
 ## [v1.1.0](https://github.com/symfony/webpack-encore/releases/tag/v1.1.0)
 
-*February 12th, 2021*
+_February 12th, 2021_
 
 ### Feature
 
-- [#929](https://github.com/symfony/webpack-encore/pull/929) - Allowing stylus-loader 5 - *@weaverryan*
-- [#928](https://github.com/symfony/webpack-encore/pull/928) - allowing sass-loader 11 - *@weaverryan*
-- [#918](https://github.com/symfony/webpack-encore/pull/918) - Allowing new postcss-loader and less-loader - *@weaverryan*
+- [#929](https://github.com/symfony/webpack-encore/pull/929) - Allowing stylus-loader 5 - _@weaverryan_
+- [#928](https://github.com/symfony/webpack-encore/pull/928) - allowing sass-loader 11 - _@weaverryan_
+- [#918](https://github.com/symfony/webpack-encore/pull/918) - Allowing new postcss-loader and less-loader - _@weaverryan_
 
 ## [v1.0.6](https://github.com/symfony/webpack-encore/releases/tag/v1.0.6)
 
-*February 12th, 2021*
+_February 12th, 2021_
 
 ### Bug Fix
 
-- [#921](https://github.com/symfony/webpack-encore/pull/921) - Fixing manifest paths (by temporarily embedding webpack-manifest-plugin fix) - *@weaverryan*
+- [#921](https://github.com/symfony/webpack-encore/pull/921) - Fixing manifest paths (by temporarily embedding webpack-manifest-plugin fix) - _@weaverryan_
 
 ## [v1.0.5](https://github.com/symfony/webpack-encore/releases/tag/v1.0.5)
 
-*February 6th, 2021*
+_February 6th, 2021_
 
 ### Bug Fix
 
-- [#917](https://github.com/symfony/webpack-encore/pull/917) - Re-working dev-server and https detection - *@weaverryan*
+- [#917](https://github.com/symfony/webpack-encore/pull/917) - Re-working dev-server and https detection - _@weaverryan_
 
 ## [v1.0.4](https://github.com/symfony/webpack-encore/releases/tag/v1.0.4)
 
-*February 2nd, 2021*
+_February 2nd, 2021_
 
 ### Bug Fix
 
-- [#910](https://github.com/symfony/webpack-encore/pull/910) - Fix stimulus version bug - *@weaverryan*
+- [#910](https://github.com/symfony/webpack-encore/pull/910) - Fix stimulus version bug - _@weaverryan_
 
 ## [v1.0.3](https://github.com/symfony/webpack-encore/releases/tag/v1.0.3)
 
-*January 31st, 2021*
+_January 31st, 2021_
 
 ### Bug Fix
 
-- [#905](https://github.com/symfony/webpack-encore/pull/905) - Omit cache key entirely when build cache is disabled - *@weaverryan*
+- [#905](https://github.com/symfony/webpack-encore/pull/905) - Omit cache key entirely when build cache is disabled - _@weaverryan_
 
 ## [v1.0.2](https://github.com/symfony/webpack-encore/releases/tag/v1.0.2)
 
-*January 29th, 2021*
+_January 29th, 2021_
 
 ### Bug Fix
 
-- [#902](https://github.com/symfony/webpack-encore/pull/902) - next stimulus-bridge will actually be 2.0 - *@weaverryan*
-- [#901](https://github.com/symfony/webpack-encore/pull/901) - Working around missing manifest.json bug - *@weaverryan*
+- [#902](https://github.com/symfony/webpack-encore/pull/902) - next stimulus-bridge will actually be 2.0 - _@weaverryan_
+- [#901](https://github.com/symfony/webpack-encore/pull/901) - Working around missing manifest.json bug - _@weaverryan_
 
 ## [v1.0.1](https://github.com/symfony/webpack-encore/releases/tag/v1.0.1)
 
-*January 29th, 2021*
+_January 29th, 2021_
 
 ### Bug Fix
 
-- [#899](https://github.com/symfony/webpack-encore/pull/899) - Fixing support for webpack-dev-server v4 - *@weaverryan*
+- [#899](https://github.com/symfony/webpack-encore/pull/899) - Fixing support for webpack-dev-server v4 - _@weaverryan_
 
 ## [v1.0.0](https://github.com/symfony/webpack-encore/releases/tag/v1.0.0)
 
-*January 27th, 2021*
+_January 27th, 2021_
 
 ### Feature
 
-- [#892](https://github.com/symfony/webpack-encore/pull/892) - Prep for 1.0: upgrading all outdated dependencies - *@weaverryan*
-- [#889](https://github.com/symfony/webpack-encore/pull/889) - bumping preset-env to version that depends on @babel/plugin-proposal-class-properties - *@weaverryan*
-- [#888](https://github.com/symfony/webpack-encore/pull/888) - updating stimulus-bridge plugin to work with proposed new loader - *@weaverryan*
-- [#887](https://github.com/symfony/webpack-encore/pull/887) - Bump less 4 and less loader 7 - *@VincentLanglet*
-- [#884](https://github.com/symfony/webpack-encore/pull/884) - [Webpack 5] Adding new enableBuildCache() method for Webpack 5 persistent caching - *@weaverryan*
-- [#883](https://github.com/symfony/webpack-encore/pull/883) - Updating images and fonts to use Webpack 5 Asset modules - *@weaverryan*
-- [#878](https://github.com/symfony/webpack-encore/pull/878) - [Webpack5] Using old watchOptions regexp & removing Node 13 support - *@weaverryan*
-- [#645](https://github.com/symfony/webpack-encore/pull/645) - Update Webpack to v5 (+ other dependencies) - *@Lyrkan*
+- [#892](https://github.com/symfony/webpack-encore/pull/892) - Prep for 1.0: upgrading all outdated dependencies - _@weaverryan_
+- [#889](https://github.com/symfony/webpack-encore/pull/889) - bumping preset-env to version that depends on @babel/plugin-proposal-class-properties - _@weaverryan_
+- [#888](https://github.com/symfony/webpack-encore/pull/888) - updating stimulus-bridge plugin to work with proposed new loader - _@weaverryan_
+- [#887](https://github.com/symfony/webpack-encore/pull/887) - Bump less 4 and less loader 7 - _@VincentLanglet_
+- [#884](https://github.com/symfony/webpack-encore/pull/884) - [Webpack 5] Adding new enableBuildCache() method for Webpack 5 persistent caching - _@weaverryan_
+- [#883](https://github.com/symfony/webpack-encore/pull/883) - Updating images and fonts to use Webpack 5 Asset modules - _@weaverryan_
+- [#878](https://github.com/symfony/webpack-encore/pull/878) - [Webpack5] Using old watchOptions regexp & removing Node 13 support - _@weaverryan_
+- [#645](https://github.com/symfony/webpack-encore/pull/645) - Update Webpack to v5 (+ other dependencies) - _@Lyrkan_
 
 ## [v0.33.0](https://github.com/symfony/webpack-encore/releases/tag/v0.33.0)
 
-*December 3rd, 2020*
+_December 3rd, 2020_
 
 ### Feature
 
-- [#870](https://github.com/symfony/webpack-encore/pull/870) - Prefer sass over node-sass - *@weaverryan*
-- [#869](https://github.com/symfony/webpack-encore/pull/869) - Upgrade Vue3 deps beyond beta - *@weaverryan*
-- [#865](https://github.com/symfony/webpack-encore/pull/865) - Bump sass-loader to ^10.0.0  - *@weaverryan*
-- [#854](https://github.com/symfony/webpack-encore/pull/854) - Updates postcss loader to v4 - *@railto*
-- [#831](https://github.com/symfony/webpack-encore/pull/831) - Validator should allow copyFiles() without other entries. - *@pszalko*
-- [#800](https://github.com/symfony/webpack-encore/pull/800) - ⬆️ Upgraded ts-loader to ^8.0.1 - *@skmedix*
-- [#774](https://github.com/symfony/webpack-encore/pull/774) - feat: add support for ESLint 7, drop support ESLint 5 - *@Kocal*
-- [#756](https://github.com/symfony/webpack-encore/pull/756) - Add a boolean parameter to Encore.disableCssExtraction() - *@football2801*
+- [#870](https://github.com/symfony/webpack-encore/pull/870) - Prefer sass over node-sass - _@weaverryan_
+- [#869](https://github.com/symfony/webpack-encore/pull/869) - Upgrade Vue3 deps beyond beta - _@weaverryan_
+- [#865](https://github.com/symfony/webpack-encore/pull/865) - Bump sass-loader to ^10.0.0 - _@weaverryan_
+- [#854](https://github.com/symfony/webpack-encore/pull/854) - Updates postcss loader to v4 - _@railto_
+- [#831](https://github.com/symfony/webpack-encore/pull/831) - Validator should allow copyFiles() without other entries. - _@pszalko_
+- [#800](https://github.com/symfony/webpack-encore/pull/800) - ⬆️ Upgraded ts-loader to ^8.0.1 - _@skmedix_
+- [#774](https://github.com/symfony/webpack-encore/pull/774) - feat: add support for ESLint 7, drop support ESLint 5 - _@Kocal_
+- [#756](https://github.com/symfony/webpack-encore/pull/756) - Add a boolean parameter to Encore.disableCssExtraction() - _@football2801_
 
 ## [v0.32.1](https://github.com/symfony/webpack-encore/releases/tag/v0.32.1)
 
-*December 3rd, 2020*
+_December 3rd, 2020_
 
 ### Bug Fix
 
-- [#863](https://github.com/symfony/webpack-encore/pull/863) - fix(stimulus): don't require an optional dependency if it's not used - *@Kocal*
+- [#863](https://github.com/symfony/webpack-encore/pull/863) - fix(stimulus): don't require an optional dependency if it's not used - _@Kocal_
 
 ## [v0.32.0](https://github.com/symfony/webpack-encore/releases/tag/v0.32.0)
 
-*December 3rd, 2020*
+_December 3rd, 2020_
 
 ### Feature
 
-- [#859](https://github.com/symfony/webpack-encore/pull/859) - Implement Stimulus bridge configurator - *@tgalopin*
+- [#859](https://github.com/symfony/webpack-encore/pull/859) - Implement Stimulus bridge configurator - _@tgalopin_
 
 ## [v0.31.1](https://github.com/symfony/webpack-encore/releases/tag/v0.31.1)
 
-*December 3rd, 2020*
+_December 3rd, 2020_
 
 ### Bug Fix
 
-- [#848](https://github.com/symfony/webpack-encore/pull/848) - Update resolve-url-loader to fix prototype pollution - *@Khartir*
+- [#848](https://github.com/symfony/webpack-encore/pull/848) - Update resolve-url-loader to fix prototype pollution - _@Khartir_
 
 ## [v0.31.0](https://github.com/symfony/webpack-encore/releases/tag/v0.31.0)
 
-*September 10th, 2020*
+_September 10th, 2020_
 
 ### Bug Fix
 
-- [#832](https://github.com/symfony/webpack-encore/pull/832) - Update assets-webpack-plugin to ^5.1.1 - *@cilefen*
+- [#832](https://github.com/symfony/webpack-encore/pull/832) - Update assets-webpack-plugin to ^5.1.1 - _@cilefen_
 
 ## [v0.30.2](https://github.com/symfony/webpack-encore/releases/tag/v0.30.2)
 
-*May 14th, 2020*
+_May 14th, 2020_
 
 ### Bug Fix
 
-- [#772](https://github.com/symfony/webpack-encore/pull/772) - Setting CleanWebpackPlugin's cleanStaleWebpackAssets: false - *@weaverryan*
+- [#772](https://github.com/symfony/webpack-encore/pull/772) - Setting CleanWebpackPlugin's cleanStaleWebpackAssets: false - _@weaverryan_
 
 ## [v0.30.1](https://github.com/symfony/webpack-encore/releases/tag/v0.30.1)
 
-*May 13th, 2020*
+_May 13th, 2020_
 
 ### Bug Fix
 
-- [#769](https://github.com/symfony/webpack-encore/pull/769) - Reverting change to only package vue runtime loader - *@weaverryan*
+- [#769](https://github.com/symfony/webpack-encore/pull/769) - Reverting change to only package vue runtime loader - _@weaverryan_
 
 ## [v0.30.0](https://github.com/symfony/webpack-encore/releases/tag/v0.30.0)
 
-*May 11th, 2020*
+_May 11th, 2020_
 
 ### Feature
 
-- [#763](https://github.com/symfony/webpack-encore/pull/763) - Removing vue2 alias to use the full build - *@weaverryan*
-- [#760](https://github.com/symfony/webpack-encore/pull/760) - upgrading to clean-webpack-plugin 3.0 - *@weaverryan*
-- [#759](https://github.com/symfony/webpack-encore/pull/759) - upgrading fork-ts-checker-webpack-plugin to test 4.0 - *@weaverryan*
-- [#758](https://github.com/symfony/webpack-encore/pull/758) - Feat/sass loader 8 - *@weaverryan*
-- [#746](https://github.com/symfony/webpack-encore/pull/746) - Added Vue3 support - *@weaverryan*
+- [#763](https://github.com/symfony/webpack-encore/pull/763) - Removing vue2 alias to use the full build - _@weaverryan_
+- [#760](https://github.com/symfony/webpack-encore/pull/760) - upgrading to clean-webpack-plugin 3.0 - _@weaverryan_
+- [#759](https://github.com/symfony/webpack-encore/pull/759) - upgrading fork-ts-checker-webpack-plugin to test 4.0 - _@weaverryan_
+- [#758](https://github.com/symfony/webpack-encore/pull/758) - Feat/sass loader 8 - _@weaverryan_
+- [#746](https://github.com/symfony/webpack-encore/pull/746) - Added Vue3 support - _@weaverryan_
 
 ### Bug Fix
 
-- [#765](https://github.com/symfony/webpack-encore/pull/765) - Fixing babel.config.js filename in message - *@weaverryan*
-- [#752](https://github.com/symfony/webpack-encore/pull/752) - Upgrade yargs-parser - *@stof*
-- [#739](https://github.com/symfony/webpack-encore/pull/739) - Resolve loaders directly from Encore instead of using their names - *@Lyrkan*
-- [#738](https://github.com/symfony/webpack-encore/pull/738) - Fix babel config file detection - *@jdreesen*
+- [#765](https://github.com/symfony/webpack-encore/pull/765) - Fixing babel.config.js filename in message - _@weaverryan_
+- [#752](https://github.com/symfony/webpack-encore/pull/752) - Upgrade yargs-parser - _@stof_
+- [#739](https://github.com/symfony/webpack-encore/pull/739) - Resolve loaders directly from Encore instead of using their names - _@Lyrkan_
+- [#738](https://github.com/symfony/webpack-encore/pull/738) - Fix babel config file detection - _@jdreesen_
 
 ## [v0.29.1](https://github.com/symfony/webpack-encore/releases/tag/v0.29.1)
 
-*April 18th, 2020*
+_April 18th, 2020_
 
 ### Bug Fix
 
-- [#732](https://github.com/symfony/webpack-encore/pull/732) - feat: add ESLint 6 support - *@Kocal*
+- [#732](https://github.com/symfony/webpack-encore/pull/732) - feat: add ESLint 6 support - _@Kocal_
 
 ## [v0.29.0](https://github.com/symfony/webpack-encore/releases/tag/v0.29.0)
 
-*April 17th, 2020*
+_April 17th, 2020_
 
 ### Feature
 
-- [#731](https://github.com/symfony/webpack-encore/pull/731) - Upgrade file-loader and allowed version for url-loader, drop Node 8 support - *@weaverryan*
-- [#729](https://github.com/symfony/webpack-encore/pull/729) - bumping to css-loader v3 - *@weaverryan*
-- [#718](https://github.com/symfony/webpack-encore/pull/718) - Include the .pcss extension for PostCSS files - *@opdavies*
-- [#715](https://github.com/symfony/webpack-encore/pull/715) - Added the possibility to configure the StyleLoader via the method Enc… - *@tooltonix*
-- [#710](https://github.com/symfony/webpack-encore/pull/710) - bump: style-loader version 1.X - *@Grafikart*
-- [#694](https://github.com/symfony/webpack-encore/pull/694) - Add Encore.enableBabelTypeScriptPreset() to "compile" TypeScript with Babel - *@Kocal*
-- [#693](https://github.com/symfony/webpack-encore/pull/693) - Add a way to configure devServer options - *@Kocal*
-- [#687](https://github.com/symfony/webpack-encore/pull/687) - Remove ESLint user-related config - *@Kocal*
-- [#680](https://github.com/symfony/webpack-encore/pull/680) - Add Encore.addCacheGroup() method and depreciate Encore.createSharedEntry() - *@Lyrkan*
-- [#574](https://github.com/symfony/webpack-encore/pull/574) - Proposal to replace #504 (ESLint/Vue) - *@Kocal*
+- [#731](https://github.com/symfony/webpack-encore/pull/731) - Upgrade file-loader and allowed version for url-loader, drop Node 8 support - _@weaverryan_
+- [#729](https://github.com/symfony/webpack-encore/pull/729) - bumping to css-loader v3 - _@weaverryan_
+- [#718](https://github.com/symfony/webpack-encore/pull/718) - Include the .pcss extension for PostCSS files - _@opdavies_
+- [#715](https://github.com/symfony/webpack-encore/pull/715) - Added the possibility to configure the StyleLoader via the method Enc… - _@tooltonix_
+- [#710](https://github.com/symfony/webpack-encore/pull/710) - bump: style-loader version 1.X - _@Grafikart_
+- [#694](https://github.com/symfony/webpack-encore/pull/694) - Add Encore.enableBabelTypeScriptPreset() to "compile" TypeScript with Babel - _@Kocal_
+- [#693](https://github.com/symfony/webpack-encore/pull/693) - Add a way to configure devServer options - _@Kocal_
+- [#687](https://github.com/symfony/webpack-encore/pull/687) - Remove ESLint user-related config - _@Kocal_
+- [#680](https://github.com/symfony/webpack-encore/pull/680) - Add Encore.addCacheGroup() method and depreciate Encore.createSharedEntry() - _@Lyrkan_
+- [#574](https://github.com/symfony/webpack-encore/pull/574) - Proposal to replace #504 (ESLint/Vue) - _@Kocal_
 
 ### Bug Fix
 
-- [#649](https://github.com/symfony/webpack-encore/pull/649) - Allow to use the [N] placeholder in copyFiles() - *@Lyrkan*
+- [#649](https://github.com/symfony/webpack-encore/pull/649) - Allow to use the [N] placeholder in copyFiles() - _@Lyrkan_
 
 ## [v0.28.3](https://github.com/symfony/webpack-encore/releases/tag/v0.28.3)
 
-*February 24th, 2020*
+_February 24th, 2020_
 
 ### Bug Fix
 
-- [#697](https://github.com/symfony/webpack-encore/pull/697) - Fix source maps being generated by default in dev - *@Lyrkan*
-
+- [#697](https://github.com/symfony/webpack-encore/pull/697) - Fix source maps being generated by default in dev - _@Lyrkan_
 
 ## 0.28.0
 
- * Don't make `@babel/preset-env` use `forceAllTransforms` option
-   in production - this will reduce build size in production
-   for environments that only need to support more modern
-   browsers - #612 thanks to @Lyrkan.
+- Don't make `@babel/preset-env` use `forceAllTransforms` option
+  in production - this will reduce build size in production
+  for environments that only need to support more modern
+  browsers - #612 thanks to @Lyrkan.
 
- * Added support with `enablePostCssLoader()` to process files
-   ending in `.postcss` or using `lang="postcss"` in Vue - #594
-   thanks to @Lyrkan.
+- Added support with `enablePostCssLoader()` to process files
+  ending in `.postcss` or using `lang="postcss"` in Vue - #594
+  thanks to @Lyrkan.
 
- * Allow `resolve-url-loader` to be configured via `enableSassLoader()` -
-   #603 thanks to @diegocardoso93.
+- Allow `resolve-url-loader` to be configured via `enableSassLoader()` -
+  #603 thanks to @diegocardoso93.
 
- * Support was removed from Node 9 (a no-longer-supported version
-   of Node) - #585 thanks to @weaverryan
+- Support was removed from Node 9 (a no-longer-supported version
+  of Node) - #585 thanks to @weaverryan
 
- * [BC Break] Removed the ability to use `[chunkhash]` in
-   `configureFilenames()`, which was already deprecated and
-   no longer reliable - #608 thanks to @Lyrkan.
+- [BC Break] Removed the ability to use `[chunkhash]` in
+  `configureFilenames()`, which was already deprecated and
+  no longer reliable - #608 thanks to @Lyrkan.
 
 ## 0.27.0
 
- * [Behavior Change] The Babel configuration `sourceType` default was
-   changed from not being specified (so, the default `module` was used)
-   to `unambiguous`. This is to help Babel's `useBuiltIns` functionality
-   properly determine if a `require` or `import` should be automatically
-   added to your files, based on that file's style - #555 thanks to @Lyrkan.
+- [Behavior Change] The Babel configuration `sourceType` default was
+  changed from not being specified (so, the default `module` was used)
+  to `unambiguous`. This is to help Babel's `useBuiltIns` functionality
+  properly determine if a `require` or `import` should be automatically
+  added to your files, based on that file's style - #555 thanks to @Lyrkan.
 
- * Added JSX support to Vue! #553 thanks to @Kocal.
+- Added JSX support to Vue! #553 thanks to @Kocal.
 
- * Cleaned up the jsdoc in `index.js` to add better docs and better
-   IDE auto-completion - #550 thank sto @Lyrkan.
+- Cleaned up the jsdoc in `index.js` to add better docs and better
+  IDE auto-completion - #550 thank sto @Lyrkan.
 
 ## 0.26.0
 
- * [Behavior change] The Babel `useBuiltIns` option default value changed
-   from `entry` to `false`, which means that polyfills may no longer be
-   provided in the same way. This is due to a change in Babel and core-js.
-   To get the same functionality back, run `yarn add core-js --dev`, then use:
+- [Behavior change] The Babel `useBuiltIns` option default value changed
+  from `entry` to `false`, which means that polyfills may no longer be
+  provided in the same way. This is due to a change in Babel and core-js.
+  To get the same functionality back, run `yarn add core-js --dev`, then use:
 
-   ```js
-   Encore.configureBabel(() => {}, {
-       useBuiltIns: 'entry', // or try "usage"
-       corejs: 3
-   })
-   ```
+    ```js
+    Encore.configureBabel(() => {}, {
+        useBuiltIns: 'entry', // or try "usage"
+        corejs: 3,
+    });
+    ```
 
-   This comes from #545 thanks to @Lyrkan.
+    This comes from #545 thanks to @Lyrkan.
 
- * Added the ability to "resolve" CSS and Sass files without specifying
-   the file extension and by taking advantage of the `sass` or `style`
-   attribute in an npm package. For example, you can now import the main
-   Bootstrap SASS file from within a SASS file by saying `@import ~bootstrap`.
-   This will use the `sass` attribute from the bootstrap `package.json`
-   file to find which file to load. #474 thanks to @deAtog.
+- Added the ability to "resolve" CSS and Sass files without specifying
+  the file extension and by taking advantage of the `sass` or `style`
+  attribute in an npm package. For example, you can now import the main
+  Bootstrap SASS file from within a SASS file by saying `@import ~bootstrap`.
+  This will use the `sass` attribute from the bootstrap `package.json`
+  file to find which file to load. #474 thanks to @deAtog.
 
- * Added a new `Encore.enableIntegrityHashes()`, which will cause a new
-   `integrity` key to be added to `entrypoints.json` with integrity values
-   that can be included in the `script` or `link` tag for that asset - #522
-   thanks to @Lyrkan.
+- Added a new `Encore.enableIntegrityHashes()`, which will cause a new
+  `integrity` key to be added to `entrypoints.json` with integrity values
+  that can be included in the `script` or `link` tag for that asset - #522
+  thanks to @Lyrkan.
 
- * Allow some parts of `configureBabel()` to be used, even if there is
-   an external `.babelrc` configuration file - #544 thanks to @Lyrkan.
+- Allow some parts of `configureBabel()` to be used, even if there is
+  an external `.babelrc` configuration file - #544 thanks to @Lyrkan.
 
 ## 0.25.0
 
- * [BC BREAK] Various dependency versions were updated, including
-   `css-loader` updated from `^1.0.0` to `^2.1.1` and `resolve-url-loader`
-   updated from `^2.3.0` to `^3.0.1`. The minimum Node version was
-   also bumped from 6 to 8. See #540 for more details.
+- [BC BREAK] Various dependency versions were updated, including
+  `css-loader` updated from `^1.0.0` to `^2.1.1` and `resolve-url-loader`
+  updated from `^2.3.0` to `^3.0.1`. The minimum Node version was
+  also bumped from 6 to 8. See #540 for more details.
 
- * Added `Encore.disableCssExtraction()` if you prefer your CSS to
-   be output via the `style-loader` - #539 thank to @Lyrkan.
+- Added `Encore.disableCssExtraction()` if you prefer your CSS to
+  be output via the `style-loader` - #539 thank to @Lyrkan.
 
- * Added `Encore.configureLoaderRule()` as a way to configure the
-   loader config that Encore normally handles - #509 thanks to @Kocal.
+- Added `Encore.configureLoaderRule()` as a way to configure the
+  loader config that Encore normally handles - #509 thanks to @Kocal.
 
- * Babel cache is no longer used for production builds to avoid a
-   bug where the cache prevents browserslist from being used - #516
-   thanks to @Lyrkan.
+- Babel cache is no longer used for production builds to avoid a
+  bug where the cache prevents browserslist from being used - #516
+  thanks to @Lyrkan.
 
 ## 0.24.0
 
- * Add CSS modules support in Vue.js for Sass/Less/Stylus - #511
-   thanks to @Lyrkan
+- Add CSS modules support in Vue.js for Sass/Less/Stylus - #511
+  thanks to @Lyrkan
 
- * Allow to use Dart Sass instead of Node Sass - #517 thanks to
-   @Lyrkan
+- Allow to use Dart Sass instead of Node Sass - #517 thanks to
+  @Lyrkan
 
- * Allow to set a custom context in copyFiles - #518 thanks to
-   @Lyrkan
+- Allow to set a custom context in copyFiles - #518 thanks to
+  @Lyrkan
 
- * Improve 'Install x to use y' and 'Unrecognized method' error
-   messages - #520 thanks to @Lyrkan
+- Improve 'Install x to use y' and 'Unrecognized method' error
+  messages - #520 thanks to @Lyrkan
 
- * Allow to set @babel/preset-env's useBuiltIns option - #521
-   thanks to @Lyrkan
+- Allow to set @babel/preset-env's useBuiltIns option - #521
+  thanks to @Lyrkan
 
- * Allow setOutputPath to create nested directories - #525 thanks
-   to @Lyrkan
+- Allow setOutputPath to create nested directories - #525 thanks
+  to @Lyrkan
 
 ## 0.23.0
 
- * Add support for CSS modules in Vue - #508 thanks to @Lyrkan
+- Add support for CSS modules in Vue - #508 thanks to @Lyrkan
 
- * Store externals in an array - #495 thanks to @deAtog
+- Store externals in an array - #495 thanks to @deAtog
 
- * Add `Encore.isRuntimeEnvironmentConfigured()` - #500 thanks
-   to @stof.
+- Add `Encore.isRuntimeEnvironmentConfigured()` - #500 thanks
+  to @stof.
 
- * Add the ability to configure watch options - #486 thanks
-   to @Kocal
+- Add the ability to configure watch options - #486 thanks
+  to @Kocal
 
- * Enabled cache and parallelism for terser for faster builds -
-   #497 thanks to @Kocal
+- Enabled cache and parallelism for terser for faster builds -
+  #497 thanks to @Kocal
 
 ## 0.22.0
 
- * [BC BREAK] The values/paths in entrypoints.json were previously
-   stripped of their opening slash. That behavior has been changed:
-   the opening slash is now included: Before: `build/foo.js`, After: `/build/foo.js`.
+- [BC BREAK] The values/paths in entrypoints.json were previously
+  stripped of their opening slash. That behavior has been changed:
+  the opening slash is now included: Before: `build/foo.js`, After: `/build/foo.js`.
 
 ## 0.21.0
 
- * [BC BREAK] Webpack was upgraded to version 4. This includes a number of major
-   and minor changes. The changes are listed below under the
-   `Webpack 4 Upgrade` section.
+- [BC BREAK] Webpack was upgraded to version 4. This includes a number of major
+  and minor changes. The changes are listed below under the
+  `Webpack 4 Upgrade` section.
 
- * [BC BREAK] The `createSharedEntry()` no longer can be passed an array of files.
-   Instead, set this to just one file, and require the other files from inside that
-   file.
+- [BC BREAK] The `createSharedEntry()` no longer can be passed an array of files.
+  Instead, set this to just one file, and require the other files from inside that
+  file.
 
- * [DEPRECATION] You must now call either `Encore.enableSingleRuntimeChunk()`
-   or `Encore.disableSingleRuntimeChunk()`: not calling either method is
-   deprecated. The recommended setting is `Encore.enableSingleRuntimeChunk()`.
-   This will cause a new `runtime.js` file to be created, which must be included
-   on your page with a script tag (before any other script tags for Encore
-   JavaScript files). See the documentation above `enableSingleRuntimeChunk()` in
-   `index.js` for more details.
+- [DEPRECATION] You must now call either `Encore.enableSingleRuntimeChunk()`
+  or `Encore.disableSingleRuntimeChunk()`: not calling either method is
+  deprecated. The recommended setting is `Encore.enableSingleRuntimeChunk()`.
+  This will cause a new `runtime.js` file to be created, which must be included
+  on your page with a script tag (before any other script tags for Encore
+  JavaScript files). See the documentation above `enableSingleRuntimeChunk()` in
+  `index.js` for more details.
 
- * [BEHAVIOR CHANGE] Previously, without any config, Babel was
-   configured to "transpile" (i.e. re-write) your JavaScript so
-   that it was compatible with all browsers that currently have
-   more than 1% of the market share. The new default behavior
-   is a bit more aggressive, and may rewrite even more code to
-   be compatible with even older browsers. The *recommendation*
-   is to add a new `browserslist` key to your `package.json` file
-   that specifies exactly what browsers you need to support. For
-   example, to get the old configuration, add the following to
-   `package.json`:
+- [BEHAVIOR CHANGE] Previously, without any config, Babel was
+  configured to "transpile" (i.e. re-write) your JavaScript so
+  that it was compatible with all browsers that currently have
+  more than 1% of the market share. The new default behavior
+  is a bit more aggressive, and may rewrite even more code to
+  be compatible with even older browsers. The _recommendation_
+  is to add a new `browserslist` key to your `package.json` file
+  that specifies exactly what browsers you need to support. For
+  example, to get the old configuration, add the following to
+  `package.json`:
 
 ```json
 {
@@ -1057,249 +1075,249 @@ Dependency changes:
 See the [browserslist](https://github.com/browserslist/browserslist) library
 for a full description of all of the valid browser descriptions.
 
- * Added a new `copyFiles()` method that is able to copy static files
-   into your build directory and allows them to be versioned. #409
-   thanks to @Lyrkan
+- Added a new `copyFiles()` method that is able to copy static files
+  into your build directory and allows them to be versioned. #409
+  thanks to @Lyrkan
 
- * Introduced a new `configureSplitChunks()` method that can be
-   used to further configure the `optimizations.splitChunks` configuration.
+- Introduced a new `configureSplitChunks()` method that can be
+  used to further configure the `optimizations.splitChunks` configuration.
 
- * A new `entrypoints.json` file is now always output. For expert
-   use-cases, the `optimizations.splitChunks.chunks` configuration
-   can be set via `configureSplitChunks()` to `all`. Then, you
-   can write some custom server-side code to parse the `entrypoints.js`
-   so that you know which `script` and `link` tags are needed for
-   each entry.
+- A new `entrypoints.json` file is now always output. For expert
+  use-cases, the `optimizations.splitChunks.chunks` configuration
+  can be set via `configureSplitChunks()` to `all`. Then, you
+  can write some custom server-side code to parse the `entrypoints.js`
+  so that you know which `script` and `link` tags are needed for
+  each entry.
 
- * The "dynamic import" syntax is now supported out of the box
-   because the `@babel/plugin-syntax-dynamic-import` babel plugin
-   is always enabled. This allows you to do "Dynamic Imports"
-   as described here: https://webpack.js.org/guides/code-splitting/#dynamic-imports
+- The "dynamic import" syntax is now supported out of the box
+  because the `@babel/plugin-syntax-dynamic-import` babel plugin
+  is always enabled. This allows you to do "Dynamic Imports"
+  as described here: https://webpack.js.org/guides/code-splitting/#dynamic-imports
 
- * A new "version check" system was added for optional dependencies.
-   Now, when you install optional plugins to support a feature, if
-   you are using an unsupported version, you will see a warning.
-   "Package recommendation" errors (i.e. when you enable a feature
-   but you are missing some packages) will also contain the version
-   in the install string when necessary (e.g. `yarn add foo@^2.0`).
+- A new "version check" system was added for optional dependencies.
+  Now, when you install optional plugins to support a feature, if
+  you are using an unsupported version, you will see a warning.
+  "Package recommendation" errors (i.e. when you enable a feature
+  but you are missing some packages) will also contain the version
+  in the install string when necessary (e.g. `yarn add foo@^2.0`).
 
- * Support was added `handlebars-loader` by calling `enableHandlebarsLoader()`.
-   #301 thanks to @ogiammetta
+- Support was added `handlebars-loader` by calling `enableHandlebarsLoader()`.
+  #301 thanks to @ogiammetta
 
- * Support was added for `eslint-loader` by calling `enableEslintLoader()`.
-   #243 thanks to @pinoniq
+- Support was added for `eslint-loader` by calling `enableEslintLoader()`.
+  #243 thanks to @pinoniq
 
- * The `css-loader` can now be configured by calling `configureCssLoader()`.
-   #335 thanks to @XWB
+- The `css-loader` can now be configured by calling `configureCssLoader()`.
+  #335 thanks to @XWB
 
- * It's now possible to control the `exclude` for Babel so that you can
-   process certain node_modules packages  through Babel - use
-   the new second argument to `configureBabel()` - #401 thanks to
-   @Lyrkan.
+- It's now possible to control the `exclude` for Babel so that you can
+  process certain node_modules packages through Babel - use
+  the new second argument to `configureBabel()` - #401 thanks to
+  @Lyrkan.
 
 ## Webpack 4 Upgrade Details
 
- * Node 7 is no longer supported. This is because the new
-   `mini-css-extract-plugin` does not support it (and neither)
-   does Yarn.
+- Node 7 is no longer supported. This is because the new
+  `mini-css-extract-plugin` does not support it (and neither)
+  does Yarn.
 
- * For Preact, the necessary plugin the user needs to install
-   changed from `babel-plugin-transform-react-jsx` to `@babel/plugin-transform-react-jsx`.
+- For Preact, the necessary plugin the user needs to install
+  changed from `babel-plugin-transform-react-jsx` to `@babel/plugin-transform-react-jsx`.
 
- * The NamedModulesPlugin was removed.
+- The NamedModulesPlugin was removed.
 
- * The `babel-preset-env` package (which was at version ^1.2.2) was
-   removed in favor of `@babel/preset-env`.
+- The `babel-preset-env` package (which was at version ^1.2.2) was
+  removed in favor of `@babel/preset-env`.
 
- * ExtractTextPlugin was removed and replaced with
-   mini-css-extract-plugin. Accordingly, `extractTextPluginOptionsCallback()`
-   was removed.
+- ExtractTextPlugin was removed and replaced with
+  mini-css-extract-plugin. Accordingly, `extractTextPluginOptionsCallback()`
+  was removed.
 
- * Support for CoffeeScript was entirely removed.
+- Support for CoffeeScript was entirely removed.
 
- * Actual lang="sass" no longer works for Vue. However, lang="scss"
-   continues to work fine.
+- Actual lang="sass" no longer works for Vue. However, lang="scss"
+  continues to work fine.
 
- * uglifyjs-webpack-plugin was replaced by terser-webpack-plugin.
-   If you're using `configureUglifyJsPlugin()`, please switch to
-   `configureTerserPlugin()` instead.
+- uglifyjs-webpack-plugin was replaced by terser-webpack-plugin.
+  If you're using `configureUglifyJsPlugin()`, please switch to
+  `configureTerserPlugin()` instead.
 
 ## 0.20.1
 
- * Upgraded webpack-manifest-plugin from 2.0.0 RC1 to ^2.0.0.
-   The original RC version was not meant to be used in a release.
-   #306 via @weaverryan
+- Upgraded webpack-manifest-plugin from 2.0.0 RC1 to ^2.0.0.
+  The original RC version was not meant to be used in a release.
+  #306 via @weaverryan
 
 ## 0.20.0
 
- * Added `Encore.configureUrlLoader()` method that allows you
-   to inline smaller images/file assets for better performance
-   #296 via @Lyrkan
+- Added `Encore.configureUrlLoader()` method that allows you
+  to inline smaller images/file assets for better performance
+  #296 via @Lyrkan
 
- * Improved error messages that recommend using yarn vs npm
-   #291 via @Lyrkan
+- Improved error messages that recommend using yarn vs npm
+  #291 via @Lyrkan
 
- * Fixed bug with using --stats option #299 via @Lyrkan
+- Fixed bug with using --stats option #299 via @Lyrkan
 
- * Allow configuration callbacks to return their value
-   #300 via @Lyrkan
+- Allow configuration callbacks to return their value
+  #300 via @Lyrkan
 
- * Updated to use the new v2 of webpack-manifest-plugin
-   #164 via @weaverryan
+- Updated to use the new v2 of webpack-manifest-plugin
+  #164 via @weaverryan
 
 ## 0.19.0
 
- * Updated how Encore is exported to support better IDE auto-completion
-   #263 via @florentdestremau
+- Updated how Encore is exported to support better IDE auto-completion
+  #263 via @florentdestremau
 
 ## 0.18.0
 
- * Added `Encore.addAliases()` and `Encore.addExternal()` shortcut methods
-   #217 via @Lyrkan
+- Added `Encore.addAliases()` and `Encore.addExternal()` shortcut methods
+  #217 via @Lyrkan
 
- * Fixed hash lengths - normalized all to 8 - #216 via @Lyrkan
+- Fixed hash lengths - normalized all to 8 - #216 via @Lyrkan
 
- * Added CoffeeScript loader - #201 via @harentius
+- Added CoffeeScript loader - #201 via @harentius
 
 ## 0.17.0
 
- * Added build notifications by calling `Encore.enableBuildNotifications()` -
-   #190 via @Lyrkan
+- Added build notifications by calling `Encore.enableBuildNotifications()` -
+  #190 via @Lyrkan
 
- * Added Stylus support via `Encore.enableStylusLoader()` - #195
-   via @mneuhaus
+- Added Stylus support via `Encore.enableStylusLoader()` - #195
+  via @mneuhaus
 
 ## 0.16.0
 
- * Added a priority argument to the `addPlugin()` method so that we
-    can (mostly in the future) allow plugins to be ordered, if/when
-    that becomes necessary - #177 via @Lyrkan
+- Added a priority argument to the `addPlugin()` method so that we
+  can (mostly in the future) allow plugins to be ordered, if/when
+  that becomes necessary - #177 via @Lyrkan
 
- * Fixed several minor bugs related to extra `.map` files (#170),
-    always having a DefinePlugin enabled (#172), fixing extra
-    instances of the ts-loader (#181) and upgrading a dependency
-    to avoid a deprecation warning (#182) - all via @Lyrkan
+- Fixed several minor bugs related to extra `.map` files (#170),
+  always having a DefinePlugin enabled (#172), fixing extra
+  instances of the ts-loader (#181) and upgrading a dependency
+  to avoid a deprecation warning (#182) - all via @Lyrkan
 
 ## 0.15.1
 
- * Fixed bug with using `?` in your versioning strategy with
-   `addStyleEntry` - #161 via @Lyrkan
+- Fixed bug with using `?` in your versioning strategy with
+  `addStyleEntry` - #161 via @Lyrkan
 
- * Fixed bug when using `webpack.config.babel.js` with ES6
-   imports - #167 via @Lyrkan
+- Fixed bug when using `webpack.config.babel.js` with ES6
+  imports - #167 via @Lyrkan
 
 ## 0.15.0
 
- * Add support for [Preact](https://preactjs.com/) - #144 via @Lyrkan
+- Add support for [Preact](https://preactjs.com/) - #144 via @Lyrkan
 
- * Added `Encore.configureManifestPlugin()` method - #142 via @Seikyo
+- Added `Encore.configureManifestPlugin()` method - #142 via @Seikyo
 
- * Added 5 new methods to configure plugins! #152 via @Lyrkan
-   * `Encore.configureDefinePlugin()`
-   * `Encore.configureExtractTextPlugin()`
-   * `Encore.configureFriendlyErrorsPlugin()`
-   * `Encore.configureLoaderOptionsPlugin()`
-   * `Encore.configureUglifyJsPlugin()`
+- Added 5 new methods to configure plugins! #152 via @Lyrkan
+    - `Encore.configureDefinePlugin()`
+    - `Encore.configureExtractTextPlugin()`
+    - `Encore.configureFriendlyErrorsPlugin()`
+    - `Encore.configureLoaderOptionsPlugin()`
+    - `Encore.configureUglifyJsPlugin()`
 
 ## 0.14.0
 
- * Added `Encore.configureFilenames()` so that you can fully control
-   the filename patterns for all types of files - #137 via @Lyrkan
+- Added `Encore.configureFilenames()` so that you can fully control
+  the filename patterns for all types of files - #137 via @Lyrkan
 
- * Added `Encore.configureRuntimeEnvironment()`, which is useful
-   if you need to require `webpack.config.js` from some non-Encore
-   process (e.g. Karma) - #115 via @Lyrkan
+- Added `Encore.configureRuntimeEnvironment()`, which is useful
+  if you need to require `webpack.config.js` from some non-Encore
+  process (e.g. Karma) - #115 via @Lyrkan
 
 ## 0.13.0
 
- * [BEHAVIOR CHANGE] Image and font files now *always* include
-   a hash in their filename, and the hash is shorter - #110 via @Lyrkan
+- [BEHAVIOR CHANGE] Image and font files now _always_ include
+  a hash in their filename, and the hash is shorter - #110 via @Lyrkan
 
- * Fixed a bug that caused extra comments to be in the final production
-   compiled JavaScript - #132 via @weaverryan
+- Fixed a bug that caused extra comments to be in the final production
+  compiled JavaScript - #132 via @weaverryan
 
- * `Encore.enablePostCssLoader()` now accepts an options callback -
-   #130 via @Lyrkan
+- `Encore.enablePostCssLoader()` now accepts an options callback -
+  #130 via @Lyrkan
 
- * `Encore.enableLessLoader()` now accepts an options callback -
-   #134 via @Lyrkan
+- `Encore.enableLessLoader()` now accepts an options callback -
+  #134 via @Lyrkan
 
- * Added `Encore.enableForkedTypeScriptTypesChecking()` to enable
-   [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin)
-   for faster typescript type checking - #101 via @davidmpaz
+- Added `Encore.enableForkedTypeScriptTypesChecking()` to enable
+  [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin)
+  for faster typescript type checking - #101 via @davidmpaz
 
- * Added `Encore.disableImagesLoader()` and `Encore.disableFontsLoader()`
-   to totally disable the `file-loader` rules for images and fonts -
-   #103 via @Lyrkan
+- Added `Encore.disableImagesLoader()` and `Encore.disableFontsLoader()`
+  to totally disable the `file-loader` rules for images and fonts -
+  #103 via @Lyrkan
 
 ## 0.12.0
 
- * Fixed a bug with webpack 3.4.0 ("Can't resolve dev") - #114.
+- Fixed a bug with webpack 3.4.0 ("Can't resolve dev") - #114.
 
- * Added `--keep-public-path` option to `dev-server` that allows
-   you to specify that you do *not* want your `publicPath` to
-   automatically point at the dev-server URL. Also relaxed the
-   requirements when using `dev-server` so that you *can* now
-   specify a custom, fully-qualified `publicPath` URL - #96
+- Added `--keep-public-path` option to `dev-server` that allows
+  you to specify that you do _not_ want your `publicPath` to
+  automatically point at the dev-server URL. Also relaxed the
+  requirements when using `dev-server` so that you _can_ now
+  specify a custom, fully-qualified `publicPath` URL - #96
 
- * Fixed bug where `@import` CSS wouldn't use postcss - #108
+- Fixed bug where `@import` CSS wouldn't use postcss - #108
 
 ## 0.11.0
 
- * The `webpack` package was upgraded from version 2.2 to 3.1 #53. The
-    `extract-text-webpack-plugin` package was also upgraded from
-    2.1 to 3.0.
+- The `webpack` package was upgraded from version 2.2 to 3.1 #53. The
+  `extract-text-webpack-plugin` package was also upgraded from
+  2.1 to 3.0.
 
 ## 0.10.0
 
- * [BC BREAK] If you're using `enableSassLoader()` AND passing an options
-   array, the options now need to be moved to the second argument:
+- [BC BREAK] If you're using `enableSassLoader()` AND passing an options
+  array, the options now need to be moved to the second argument:
 
-   ```js
-   // before
-   .enableSassLoader({ resolve_url_loader: true });
+    ```js
+    // before
+    .enableSassLoader({ resolve_url_loader: true });
 
-   // after
-   enableSassLoader(function(sassOptions) {}, {
-       resolve_url_loader: true
-   })
-   ```
+    // after
+    enableSassLoader(function(sassOptions) {}, {
+        resolve_url_loader: true
+    })
+    ```
 
- * Allowing typescript options callback to be optional - #75
+- Allowing typescript options callback to be optional - #75
 
- * Allow the Encore singleton to be reset - #83
+- Allow the Encore singleton to be reset - #83
 
- * Fixing bug with vue-loader and sass - #89
+- Fixing bug with vue-loader and sass - #89
 
 ## 0.9.1
 
- * Syntax error fix - #64
+- Syntax error fix - #64
 
 ## 0.9.0
 
- * [BEHAVIOR CHANGE] When using `autoProvidejQuery()`, `window.jQuery` is now also
-   included (and so will be re-written in the compiled files). If you're also exposing
-   `jQuery` as a global variable, you'll need to update your code:
+- [BEHAVIOR CHANGE] When using `autoProvidejQuery()`, `window.jQuery` is now also
+  included (and so will be re-written in the compiled files). If you're also exposing
+  `jQuery` as a global variable, you'll need to update your code:
 
-   ```js
-   // Before: if you had this
-   window.jQuery = require('jquery');
+    ```js
+    // Before: if you had this
+    window.jQuery = require('jquery');
 
-   // After: change to this
-   global.jQuery = require('jquery');
-   ```
+    // After: change to this
+    global.jQuery = require('jquery');
+    ```
 
-  * Vue.js support! See #49
+- Vue.js support! See #49
 
-  * Typescript support! See #50
+- Typescript support! See #50
 
 ## 0.8.0
 
- * Windows support fixed #28
+- Windows support fixed #28
 
- * Added `Encore.addPlugin()` #19
+- Added `Encore.addPlugin()` #19
 
- * Added `Encore.addLoader()` #11
+- Added `Encore.addLoader()` #11
 
- * `Encore.cleanupOutputBeforeBuild()` now empties the directory
-   instead or removing it.
+- `Encore.cleanupOutputBeforeBuild()` now empties the directory
+  instead or removing it.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ![Node](https://img.shields.io/node/v/@symfony/webpack-encore.svg)
 
 Webpack Encore is a simpler way to integrate [Webpack](https://webpack.js.org/) into your
-application. It *wraps* Webpack, giving you a clean & powerful API
+application. It _wraps_ Webpack, giving you a clean & powerful API
 for bundling JavaScript modules, pre-processing CSS & JS and compiling
 and minifying assets. Encore gives you a professional asset system
-that's a *delight* to use.
+that's a _delight_ to use.
 
 > [!TIP]
 > Symfony released an [AssetMapper](https://symfony.com/doc/current/frontend/asset_mapper.html) component, a production-ready simpler alternative to Webpack Encore
@@ -19,7 +19,7 @@ Encore is inspired by [Webpacker](https://github.com/rails/webpacker) and
 Webpack: using its features, concepts and naming conventions for a familiar
 feel. It aims to solve the most common Webpack use cases.
 
-> Encore is made by Symfony and works *beautifully* in Symfony applications.
+> Encore is made by Symfony and works _beautifully_ in Symfony applications.
 > But it can easily be used in any application... in any language!
 
 ## Documentation

--- a/bin/encore.js
+++ b/bin/encore.js
@@ -8,17 +8,15 @@
  * file that was distributed with this source code.
  */
 
-import parseRuntime from '../lib/config/parse-runtime.js';
-import context from '../lib/context.js';
 import pc from 'picocolors';
-import logger from '../lib/logger.js';
-import featuresHelper from '../lib/features.js';
 import yargsParser from 'yargs-parser';
 
-const runtimeConfig = parseRuntime(
-    yargsParser(process.argv.slice(2)),
-    process.cwd()
-);
+import parseRuntime from '../lib/config/parse-runtime.js';
+import context from '../lib/context.js';
+import featuresHelper from '../lib/features.js';
+import logger from '../lib/logger.js';
+
+const runtimeConfig = parseRuntime(yargsParser(process.argv.slice(2)), process.cwd());
 context.runtimeConfig = runtimeConfig;
 
 // prevent logs from being dumped
@@ -31,7 +29,7 @@ process.argv.splice(2, 1);
 
 // remove arguments not supported by webpack/-dev-server
 const encoreOnlyArguments = new Set(['--keep-public-path']);
-process.argv = process.argv.filter(arg => !encoreOnlyArguments.has(arg));
+process.argv = process.argv.filter((arg) => !encoreOnlyArguments.has(arg));
 
 // remove argument --public not supported by webpack/dev-server
 const indexPublicArgument = process.argv.indexOf('--public');
@@ -57,7 +55,10 @@ if (runtimeConfig.helpRequested) {
 
 if (runtimeConfig.useDevServer) {
     try {
-        featuresHelper.ensurePackagesExistAndAreCorrectVersion('webpack-dev-server', 'the webpack Development Server');
+        featuresHelper.ensurePackagesExistAndAreCorrectVersion(
+            'webpack-dev-server',
+            'the webpack Development Server'
+        );
     } catch (e) {
         console.log(e);
         process.exit(1);
@@ -79,7 +80,9 @@ if (runtimeConfig.useDevServer) {
 function showUsageInstructions() {
     const validCommands = ['dev', 'prod', 'production', 'dev-server'];
 
-    console.log(`usage ${pc.green('encore')} [${ validCommands.map(command => pc.green(command)).join('|') }]`);
+    console.log(
+        `usage ${pc.green('encore')} [${validCommands.map((command) => pc.green(command)).join('|')}]`
+    );
     console.log();
     console.log('encore is a thin executable around the webpack or webpack-dev-server executables');
     console.log();
@@ -88,10 +91,16 @@ function showUsageInstructions() {
     console.log('       - Supports any webpack options (e.g. --watch)');
     console.log();
     console.log(`    ${pc.green('dev-server')} : runs webpack-dev-server`);
-    console.log(`       - ${pc.yellow('--host')} The hostname/ip address the webpack-dev-server will bind to`);
+    console.log(
+        `       - ${pc.yellow('--host')} The hostname/ip address the webpack-dev-server will bind to`
+    );
     console.log(`       - ${pc.yellow('--port')} The port the webpack-dev-server will bind to`);
-    console.log(`       - ${pc.yellow('--keep-public-path')} Do not change the public path (it is usually prefixed by the dev server URL)`);
-    console.log(`       - ${pc.yellow('--public')} The public url for entry asset in entrypoints.json`);
+    console.log(
+        `       - ${pc.yellow('--keep-public-path')} Do not change the public path (it is usually prefixed by the dev server URL)`
+    );
+    console.log(
+        `       - ${pc.yellow('--public')} The public url for entry asset in entrypoints.json`
+    );
     console.log('       - Supports any webpack-dev-server options');
     console.log();
     console.log(`    ${pc.green('production')} : runs webpack for production`);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,12 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import globals from 'globals';
 import js from '@eslint/js';
-import nodePlugin from 'eslint-plugin-n';
-import jsdoc from 'eslint-plugin-jsdoc';
 import headers from 'eslint-plugin-headers';
+import jsdoc from 'eslint-plugin-jsdoc';
+import nodePlugin from 'eslint-plugin-n';
 import vitestPlugin from 'eslint-plugin-vitest';
+import globals from 'globals';
 
 export default [
     js.configs.recommended,
@@ -33,44 +33,29 @@ export default [
         },
     },
     {
-        'rules': {
-            'quotes': ['error', 'single'],
+        rules: {
             'no-undef': 'error',
-            'no-extra-semi': 'error',
-            'semi': 'error',
-            'no-template-curly-in-string': 'error',
             'no-caller': 'error',
-            'eqeqeq': 'error',
-            'brace-style': 'error',
-            'eol-last': 'error',
-            'indent': ['error', 4, { 'SwitchCase': 1 }],
+            eqeqeq: 'error',
             'no-extra-bind': 'warn',
             'no-empty': 'off',
-            'no-multiple-empty-lines': 'error',
-            'no-multi-spaces': 'error',
             'no-process-exit': 'warn',
-            'space-in-parens': 'error',
-            'no-trailing-spaces': 'error',
             'no-use-before-define': 'off',
-            'no-unused-vars': ['error', { 'args': 'none' }],
-            'key-spacing': 'error',
-            'space-infix-ops': 'error',
+            'no-unused-vars': ['error', { args: 'none' }],
             'no-unsafe-negation': 'error',
             'no-loop-func': 'warn',
-            'space-before-function-paren': ['error', 'never'],
-            'space-before-blocks': 'error',
-            'object-curly-spacing': ['error', 'always'],
-            'keyword-spacing': ['error', {
-                'after': true
-            }],
             'no-console': 'off',
             'jsdoc/require-jsdoc': 'off',
             'jsdoc/require-param-description': 'off',
             'jsdoc/require-property-description': 'off',
             'jsdoc/require-returns-description': 'off',
-            'jsdoc/tag-lines': ['warn', 'never', {
-                'startLines': 1
-            }],
+            'jsdoc/tag-lines': [
+                'warn',
+                'never',
+                {
+                    startLines: 1,
+                },
+            ],
             'n/no-unsupported-features/node-builtins': ['error'],
             'n/no-deprecated-api': 'error',
             'n/no-missing-import': 'error',
@@ -79,25 +64,28 @@ export default [
             'n/no-unpublished-import': 'error',
             'n/no-unpublished-require': 'off',
             'n/process-exit-as-throw': 'error',
-            'headers/header-format': ['error', {
-                source: 'string',
-                content: `This file is part of the Symfony Webpack Encore package.
+            'headers/header-format': [
+                'error',
+                {
+                    source: 'string',
+                    content: `This file is part of the Symfony Webpack Encore package.
 
 (c) Fabien Potencier <fabien@symfony.com>
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.`,
-                blockPrefix: '\n',
-            }]
+                    blockPrefix: '\n',
+                },
+            ],
         },
-        'settings': {
-            'jsdoc': {
-                'mode': 'typescript'
-            }
+        settings: {
+            jsdoc: {
+                mode: 'typescript',
+            },
         },
     },
     {
-        'files': ['test/**/*'],
+        files: ['test/**/*'],
         languageOptions: {
             ecmaVersion: 2025,
             globals: {
@@ -106,15 +94,15 @@ file that was distributed with this source code.`,
             },
         },
         rules: {
-            'n/no-unsupported-features/node-builtins': ['error', {
-                'ignores': [
-                    'import.meta.dirname',
-                    'import.meta.filename',
-                ]
-            }],
+            'n/no-unsupported-features/node-builtins': [
+                'error',
+                {
+                    ignores: ['import.meta.dirname', 'import.meta.filename'],
+                },
+            ],
             'vitest/expect-expect': 'off',
             'vitest/valid-expect': 'off',
-            'vitest/valid-describe-callback': 'off'
-        }
-    }
+            'vitest/valid-describe-callback': 'off',
+        },
+    },
 ];

--- a/index.js
+++ b/index.js
@@ -19,13 +19,14 @@
  * @typedef {{from: string, pattern?: RegExp|string, to?: string|null, includeSubdirectories?: boolean, context?: string}} CopyFilesOptions
  */
 
+import yargsParser from 'yargs-parser';
+
+import configGenerator from './lib/config-generator.js';
+import parseRuntime from './lib/config/parse-runtime.js';
+import validator from './lib/config/validator.js';
+import context from './lib/context.js';
 import EncoreProxy from './lib/EncoreProxy.js';
 import WebpackConfig from './lib/WebpackConfig.js';
-import configGenerator from './lib/config-generator.js';
-import validator from './lib/config/validator.js';
-import parseRuntime from './lib/config/parse-runtime.js';
-import context from './lib/context.js';
-import yargsParser from 'yargs-parser';
 
 let runtimeConfig = context.runtimeConfig;
 let webpackConfig = runtimeConfig ? new WebpackConfig(runtimeConfig) : null;
@@ -1607,7 +1608,10 @@ class Encore {
      * @returns {Encore}
      */
     when(condition, callback) {
-        if (typeof condition === 'function' && condition(this) || typeof condition === 'boolean' && condition) {
+        if (
+            (typeof condition === 'function' && condition(this)) ||
+            (typeof condition === 'boolean' && condition)
+        ) {
             callback(this);
         }
 
@@ -1672,11 +1676,7 @@ class Encore {
      */
     configureRuntimeEnvironment(environment, options = {}) {
         runtimeConfig = parseRuntime(
-            Object.assign(
-                {},
-                yargsParser([environment]),
-                options
-            ),
+            Object.assign({}, yargsParser([environment]), options),
             process.cwd()
         );
 

--- a/lib/EncoreProxy.js
+++ b/lib/EncoreProxy.js
@@ -7,8 +7,9 @@
  * file that was distributed with this source code.
  */
 
-import pc from 'picocolors';
 import levenshtein from 'fastest-levenshtein';
+import pc from 'picocolors';
+
 import prettyError from './utils/pretty-error.js';
 
 export default {
@@ -31,7 +32,9 @@ export default {
                     ];
 
                     if (!Encore.isRuntimeEnvironmentConfigured() && !safeMethods.includes(prop)) {
-                        throw new Error(`Encore.${prop}() cannot be called yet because the runtime environment doesn't appear to be configured. Make sure you're using the encore executable or call Encore.configureRuntimeEnvironment() first if you're purposely not calling Encore directly.`);
+                        throw new Error(
+                            `Encore.${prop}() cannot be called yet because the runtime environment doesn't appear to be configured. Make sure you're using the encore executable or call Encore.configureRuntimeEnvironment() first if you're purposely not calling Encore directly.`
+                        );
                     }
 
                     // Either a safe method has been called or the webpackConfig
@@ -43,14 +46,19 @@ export default {
                             // If the method returns a Promise (e.g. getWebpackConfig()),
                             // attach a .catch() so that async rejections are also
                             // pretty-printed instead of surfacing as unhandled rejections.
-                            if (res !== null && typeof res === 'object' && typeof res.then === 'function' && res !== target) {
+                            if (
+                                res !== null &&
+                                typeof res === 'object' &&
+                                typeof res.then === 'function' &&
+                                res !== target
+                            ) {
                                 return res.catch((error) => {
                                     prettyError(error);
                                     process.exit(1); // eslint-disable-line
                                 });
                             }
 
-                            return (res === target) ? EncoreProxy : res;
+                            return res === target ? EncoreProxy : res;
                         } catch (error) {
                             prettyError(error);
                             process.exit(1); // eslint-disable-line
@@ -78,7 +86,7 @@ export default {
                     }
 
                     let errorMessage = `${pc.red(`Encore.${prop}`)} is not a recognized property or method.`;
-                    if (minDistance < (prop.length / 3)) {
+                    if (minDistance < prop.length / 3) {
                         errorMessage += ` Did you mean ${pc.green(`Encore.${similarProperty}`)}?`;
                     }
 
@@ -86,18 +94,17 @@ export default {
                     // Only keep the 2nd line of the stack trace:
                     // - First line should be the index.js file
                     // - Second line should be the Webpack config file
-                    prettyError(
-                        new Error(errorMessage),
-                        { skipTrace: (traceLine, lineNumber) => lineNumber !== 1 }
-                    );
+                    prettyError(new Error(errorMessage), {
+                        skipTrace: (traceLine, lineNumber) => lineNumber !== 1,
+                    });
 
                     process.exit(1); // eslint-disable-line
                 }
 
                 return target[prop];
-            }
+            },
         });
 
         return EncoreProxy;
-    }
+    },
 };

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -23,13 +23,14 @@
  * @import { CopyFilesOptions } from '../index.js'
  */
 
-import path from 'path';
-import fs from 'fs';
 import crypto from 'crypto';
-import logger from './logger.js';
-import regexpEscaper from './utils/regexp-escaper.js';
+import fs from 'fs';
+import path from 'path';
+
 import pathUtil from './config/path-util.js';
 import featuresHelper from './features.js';
+import logger from './logger.js';
+import regexpEscaper from './utils/regexp-escaper.js';
 
 /**
  * @param {RuntimeConfig|null} runtimeConfig
@@ -114,10 +115,10 @@ class WebpackConfig {
          */
         this.sassOptions = {
             resolveUrlLoader: true,
-            resolveUrlLoaderOptions: {}
+            resolveUrlLoaderOptions: {},
         };
         this.preactOptions = {
-            preactCompat: false
+            preactCompat: false,
         };
         /** @type {{exclude: webpack.RuleSetCondition, useBuiltIns: 'usage'|'entry'|false, corejs: number|string|{ version: string, proposals: boolean }|null}} */
         this.babelOptions = {
@@ -129,7 +130,7 @@ class WebpackConfig {
         this.vueOptions = {
             useJsx: false,
             version: null,
-            runtimeCompilerBuild: null
+            runtimeCompilerBuild: null,
         };
         /** @type {Record<string, string[]>} */
         this.persistentCacheBuildDependencies = {};
@@ -252,7 +253,9 @@ class WebpackConfig {
             if (!fs.existsSync(parentPath)) {
                 const context = path.resolve(this.getContext());
                 if (outputPath.indexOf(context) !== 0) {
-                    throw new Error(`outputPath directory "${outputPath}" does not exist and is not located under the context directory "${context}". Please check the path you're passing to setOutputPath() or create this directory.`);
+                    throw new Error(
+                        `outputPath directory "${outputPath}" does not exist and is not located under the context directory "${context}". Please check the path you're passing to setOutputPath() or create this directory.`
+                    );
                 }
 
                 parentPath.split(path.sep).reduce((previousPath, directory) => {
@@ -275,11 +278,13 @@ class WebpackConfig {
             // technically, not starting with "/" is legal, but not
             // what you want in most cases. Let's warn the user that
             // they might be making a mistake.
-            logger.warning('The value passed to setPublicPath() should *usually* start with "/" or be a full URL (http://...). If you\'re not sure, then you should probably change your public path and make this message disappear.');
+            logger.warning(
+                'The value passed to setPublicPath() should *usually* start with "/" or be a full URL (http://...). If you\'re not sure, then you should probably change your public path and make this message disappear.'
+            );
         }
 
         // guarantee a single trailing slash
-        publicPath = publicPath.replace(/\/$/,'');
+        publicPath = publicPath.replace(/\/$/, '');
         publicPath = publicPath + '/';
 
         this.publicPath = publicPath;
@@ -295,7 +300,9 @@ class WebpackConfig {
          * intending to. Hence, the warning.
          */
         if (manifestKeyPrefix.indexOf('/') === 0) {
-            logger.warning(`The value passed to setManifestKeyPrefix "${manifestKeyPrefix}" starts with "/". This is allowed, but since the key prefix does not normally start with a "/", you may have just changed the prefix accidentally.`);
+            logger.warning(
+                `The value passed to setManifestKeyPrefix "${manifestKeyPrefix}" starts with "/". This is allowed, but since the key prefix does not normally start with a "/", you may have just changed the prefix accidentally.`
+            );
         }
 
         // guarantee a single trailing slash, except for blank strings
@@ -323,7 +330,9 @@ class WebpackConfig {
      */
     configureFriendlyErrorsPlugin(friendlyErrorsPluginOptionsCallback = () => {}) {
         if (typeof friendlyErrorsPluginOptionsCallback !== 'function') {
-            throw new Error('Argument 1 to configureFriendlyErrorsPlugin() must be a callback function');
+            throw new Error(
+                'Argument 1 to configureFriendlyErrorsPlugin() must be a callback function'
+            );
         }
 
         this.friendlyErrorsPluginOptionsCallback = friendlyErrorsPluginOptionsCallback;
@@ -356,7 +365,9 @@ class WebpackConfig {
      */
     configureCssMinimizerPlugin(cssMinimizerPluginOptionsCallback = () => {}) {
         if (typeof cssMinimizerPluginOptionsCallback !== 'function') {
-            throw new Error('Argument 1 to configureCssMinimizerPlugin() must be a callback function');
+            throw new Error(
+                'Argument 1 to configureCssMinimizerPlugin() must be a callback function'
+            );
         }
 
         this.cssMinimizerPluginOptionsCallback = cssMinimizerPluginOptionsCallback;
@@ -384,7 +395,7 @@ class WebpackConfig {
         const devServerUrl = pathUtil.calculateDevServerUrl(this.runtimeConfig);
 
         // if using dev-server, prefix the publicPath with the dev server URL
-        return devServerUrl.replace(/\/$/,'') + this.publicPath;
+        return devServerUrl.replace(/\/$/, '') + this.publicPath;
     }
 
     addEntry(name, src) {
@@ -420,7 +431,7 @@ class WebpackConfig {
 
         this.plugins.push({
             plugin: plugin,
-            priority: priority
+            priority: priority,
         });
     }
 
@@ -462,7 +473,9 @@ class WebpackConfig {
     configureBabel(callback, options = {}) {
         if (callback) {
             if (typeof callback !== 'function') {
-                throw new Error('Argument 1 to configureBabel() must be a callback function or null.');
+                throw new Error(
+                    'Argument 1 to configureBabel() must be a callback function or null.'
+                );
             }
 
             // When babelRcFileExists is explicitly known (set synchronously
@@ -470,7 +483,9 @@ class WebpackConfig {
             // deferred to build time (in config-generator.js) via the
             // async doesBabelRcFileExist() call.
             if (this.runtimeConfig.babelRcFileExists === true) {
-                throw new Error('The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json"). Use null as the first argument to remove this error.');
+                throw new Error(
+                    'The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json"). Use null as the first argument to remove this error.'
+                );
             }
         }
 
@@ -492,11 +507,15 @@ class WebpackConfig {
         for (const optionKey of Object.keys(options)) {
             if (optionKey === 'includeNodeModules') {
                 if (Object.keys(options).includes('exclude')) {
-                    throw new Error('"includeNodeModules" and "exclude" options can\'t be used together when calling configureBabel().');
+                    throw new Error(
+                        '"includeNodeModules" and "exclude" options can\'t be used together when calling configureBabel().'
+                    );
                 }
 
                 if (!Array.isArray(options[optionKey])) {
-                    throw new Error('Option "includeNodeModules" passed to configureBabel() must be an Array.');
+                    throw new Error(
+                        'Option "includeNodeModules" passed to configureBabel() must be an Array.'
+                    );
                 }
 
                 this.babelOptions['exclude'] = (filePath) => {
@@ -507,7 +526,7 @@ class WebpackConfig {
 
                     // Don't exclude whitelisted Node modules
                     const whitelistedModules = options[optionKey].map(
-                        module => path.join('node_modules', module) + path.sep
+                        (module) => path.join('node_modules', module) + path.sep
                     );
 
                     for (const modulePath of whitelistedModules) {
@@ -520,12 +539,20 @@ class WebpackConfig {
                     return true;
                 };
             } else if (!(optionKey in this.babelOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to configureBabel(). Valid keys are ${[...Object.keys(this.babelOptions), 'includeNodeModules'].join(', ')}`);
+                throw new Error(
+                    `Invalid option "${optionKey}" passed to configureBabel(). Valid keys are ${[...Object.keys(this.babelOptions), 'includeNodeModules'].join(', ')}`
+                );
             } else {
                 // When babelRcFileExists is explicitly known and the option
                 // is not whitelisted, warn that it won't be applied.
-                if (babelRcExplicitlyKnown && babelRcPresent && !whitelistedBabelOptions.includes(optionKey)) {
-                    logger.warning(`The "${optionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json").`);
+                if (
+                    babelRcExplicitlyKnown &&
+                    babelRcPresent &&
+                    !whitelistedBabelOptions.includes(optionKey)
+                ) {
+                    logger.warning(
+                        `The "${optionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json").`
+                    );
                 }
                 this.babelOptions[optionKey] = options[optionKey];
             }
@@ -545,7 +572,9 @@ class WebpackConfig {
         // deferred to build time (in config-generator.js) via the
         // async doesBabelRcFileExist() call.
         if (this.runtimeConfig.babelRcFileExists === true) {
-            throw new Error('The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json").');
+            throw new Error(
+                'The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (e.g. a ".babelrc" or "babel.config.js" file or "babel" key in "package.json").'
+            );
         }
 
         this.babelPresetEnvOptionsCallback = callback;
@@ -580,11 +609,15 @@ class WebpackConfig {
      */
     configureMiniCssExtractPlugin(loaderOptionsCallback, pluginOptionsCallback = () => {}) {
         if (typeof loaderOptionsCallback !== 'function') {
-            throw new Error('Argument 1 to configureMiniCssExtractPluginLoader() must be a callback function.');
+            throw new Error(
+                'Argument 1 to configureMiniCssExtractPluginLoader() must be a callback function.'
+            );
         }
 
         if (typeof pluginOptionsCallback !== 'function') {
-            throw new Error('Argument 2 to configureMiniCssExtractPluginLoader() must be a callback function.');
+            throw new Error(
+                'Argument 2 to configureMiniCssExtractPluginLoader() must be a callback function.'
+            );
         }
 
         this.miniCssExtractLoaderConfigurationCallback = loaderOptionsCallback;
@@ -632,7 +665,9 @@ class WebpackConfig {
         featuresHelper.ensurePackagesExistAndAreCorrectVersion('webpack-dev-server');
 
         if (typeof callback !== 'function') {
-            throw new Error('Argument 1 to configureDevServerOptions() must be a callback function.');
+            throw new Error(
+                'Argument 1 to configureDevServerOptions() must be a callback function.'
+            );
         }
 
         this.devServerOptionsConfigurationCallback = callback;
@@ -652,7 +687,9 @@ class WebpackConfig {
         }
 
         if (!options['test'] && !options['node_modules']) {
-            throw new Error('Either the "test" option or the "node_modules" option of addCacheGroup() must be set');
+            throw new Error(
+                'Either the "test" option or the "node_modules" option of addCacheGroup() must be set'
+            );
         }
 
         if (options['node_modules']) {
@@ -660,11 +697,11 @@ class WebpackConfig {
                 throw new Error('The "node_modules" option of addCacheGroup() must be an array');
             }
 
-            options.test = new RegExp(`[\\\\/]node_modules[\\\\/](${
-                options['node_modules']
+            options.test = new RegExp(
+                `[\\\\/]node_modules[\\\\/](${options['node_modules']
                     .map(regexpEscaper)
-                    .join('|')
-            })[\\\\/]`);
+                    .join('|')})[\\\\/]`
+            );
 
             delete options['node_modules'];
         }
@@ -680,8 +717,10 @@ class WebpackConfig {
             configs = [configs];
         }
 
-        if (configs.some(elt => typeof elt !== 'object')) {
-            throw new Error('copyFiles() must be called with either a config object or an array of config objects.');
+        if (configs.some((elt) => typeof elt !== 'object')) {
+            throw new Error(
+                'copyFiles() must be called with either a config object or an array of config objects.'
+            );
         }
 
         const defaultConfig = {
@@ -694,12 +733,16 @@ class WebpackConfig {
 
         for (const config of configs) {
             if (!config.from) {
-                throw new Error('Config objects passed to copyFiles() must have a "from" property.');
+                throw new Error(
+                    'Config objects passed to copyFiles() must have a "from" property.'
+                );
             }
 
             for (const configKey of Object.keys(config)) {
                 if (!(configKey in defaultConfig)) {
-                    throw new Error(`Invalid config option "${configKey}" passed to copyFiles(). Valid keys are ${Object.keys(defaultConfig).join(', ')}`);
+                    throw new Error(
+                        `Invalid config option "${configKey}" passed to copyFiles(). Valid keys are ${Object.keys(defaultConfig).join(', ')}`
+                    );
                 }
             }
 
@@ -713,13 +756,13 @@ class WebpackConfig {
                 }
 
                 if (!validPattern) {
-                    throw new Error(`Invalid pattern "${config.pattern}" passed to copyFiles(). Make sure it contains a valid regular expression.`);
+                    throw new Error(
+                        `Invalid pattern "${config.pattern}" passed to copyFiles(). Make sure it contains a valid regular expression.`
+                    );
                 }
             }
 
-            this.copyFilesConfigs.push(
-                Object.assign({}, defaultConfig, config)
-            );
+            this.copyFilesConfigs.push(Object.assign({}, defaultConfig, config));
         }
     }
 
@@ -751,7 +794,9 @@ class WebpackConfig {
 
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.sassOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to enableSassLoader(). Valid keys are ${Object.keys(this.sassOptions).join(', ')}`);
+                throw new Error(
+                    `Invalid option "${optionKey}" passed to enableSassLoader(). Valid keys are ${Object.keys(this.sassOptions).join(', ')}`
+                );
             }
 
             this.sassOptions[optionKey] = options[optionKey];
@@ -812,7 +857,9 @@ class WebpackConfig {
         }
 
         if (!buildDependencies.config) {
-            throw new Error('Argument 1 to enableBuildCache() should contain an object with at least a "config" key. See the documentation for this method.');
+            throw new Error(
+                'Argument 1 to enableBuildCache() should contain an object with at least a "config" key. See the documentation for this method.'
+            );
         }
 
         this.usePersistentCache = true;
@@ -842,7 +889,9 @@ class WebpackConfig {
 
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.preactOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to enablePreactPreset(). Valid keys are ${Object.keys(this.preactOptions).join(', ')}`);
+                throw new Error(
+                    `Invalid option "${optionKey}" passed to enablePreactPreset(). Valid keys are ${Object.keys(this.preactOptions).join(', ')}`
+                );
             }
 
             this.preactOptions[optionKey] = options[optionKey];
@@ -858,7 +907,9 @@ class WebpackConfig {
      */
     enableTypeScriptLoader(callback = () => {}) {
         if (this.useBabelTypeScriptPreset) {
-            throw new Error('Encore.enableTypeScriptLoader() can not be called when Encore.enableBabelTypeScriptPreset() has been called.');
+            throw new Error(
+                'Encore.enableTypeScriptLoader() can not be called when Encore.enableBabelTypeScriptPreset() has been called.'
+            );
         }
 
         this.useTypeScriptLoader = true;
@@ -875,25 +926,32 @@ class WebpackConfig {
      */
     enableForkedTypeScriptTypesChecking(forkedTypeScriptTypesCheckOptionsCallback = () => {}) {
         if (this.useBabelTypeScriptPreset) {
-            throw new Error('Encore.enableForkedTypeScriptTypesChecking() can not be called when Encore.enableBabelTypeScriptPreset() has been called.');
+            throw new Error(
+                'Encore.enableForkedTypeScriptTypesChecking() can not be called when Encore.enableBabelTypeScriptPreset() has been called.'
+            );
         }
 
         if (typeof forkedTypeScriptTypesCheckOptionsCallback !== 'function') {
-            throw new Error('Argument 1 to enableForkedTypeScriptTypesChecking() must be a callback function.');
+            throw new Error(
+                'Argument 1 to enableForkedTypeScriptTypesChecking() must be a callback function.'
+            );
         }
 
         this.useForkedTypeScriptTypeChecking = true;
-        this.forkedTypeScriptTypesCheckOptionsCallback =
-            forkedTypeScriptTypesCheckOptionsCallback;
+        this.forkedTypeScriptTypesCheckOptionsCallback = forkedTypeScriptTypesCheckOptionsCallback;
     }
 
     enableBabelTypeScriptPreset(options = {}) {
         if (this.useTypeScriptLoader) {
-            throw new Error('Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableTypeScriptLoader() has been called.');
+            throw new Error(
+                'Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableTypeScriptLoader() has been called.'
+            );
         }
 
         if (this.useForkedTypeScriptTypeChecking) {
-            throw new Error('Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableForkedTypeScriptTypesChecking() has been called.');
+            throw new Error(
+                'Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableForkedTypeScriptTypesChecking() has been called.'
+            );
         }
 
         this.useBabelTypeScriptPreset = true;
@@ -916,13 +974,17 @@ class WebpackConfig {
         // Check allowed keys
         for (const key of Object.keys(vueOptions)) {
             if (!(key in this.vueOptions)) {
-                throw new Error(`"${key}" is not a valid key for enableVueLoader(). Valid keys: ${Object.keys(this.vueOptions).join(', ')}.`);
+                throw new Error(
+                    `"${key}" is not a valid key for enableVueLoader(). Valid keys: ${Object.keys(this.vueOptions).join(', ')}.`
+                );
             }
 
             if (key === 'version') {
                 const validVersions = [3];
                 if (!validVersions.includes(vueOptions.version)) {
-                    throw new Error(`"${vueOptions.version}" is not a valid value for the "version" option passed to enableVueLoader(). Valid versions are: ${validVersions.join(', ')}.`);
+                    throw new Error(
+                        `"${vueOptions.version}" is not a valid value for the "version" option passed to enableVueLoader(). Valid versions are: ${validVersions.join(', ')}.`
+                    );
                 }
             }
 
@@ -936,7 +998,9 @@ class WebpackConfig {
      */
     enableBuildNotifications(enabled = true, notifierPluginOptionsCallback = () => {}) {
         if (typeof notifierPluginOptionsCallback !== 'function') {
-            throw new Error('Argument 2 to enableBuildNotifications() must be a callback function.');
+            throw new Error(
+                'Argument 2 to enableBuildNotifications() must be a callback function.'
+            );
         }
 
         this.useWebpackNotifier = enabled;
@@ -969,7 +1033,9 @@ class WebpackConfig {
         const validKeys = ['js', 'css', 'assets'];
         for (const key of Object.keys(configuredFilenames)) {
             if (!validKeys.includes(key)) {
-                throw new Error(`"${key}" is not a valid key for configureFilenames(). Valid keys: ${validKeys.join(', ')}. Use configureImageRule() or configureFontRule() to control image or font filenames.`);
+                throw new Error(
+                    `"${key}" is not a valid key for configureFilenames(). Valid keys: ${validKeys.join(', ')}. Use configureImageRule() or configureFontRule() to control image or font filenames.`
+                );
             }
         }
 
@@ -983,14 +1049,18 @@ class WebpackConfig {
     configureImageRule(options = {}, ruleCallback = () => {}) {
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.imageRuleOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to configureImageRule(). Valid keys are ${Object.keys(this.imageRuleOptions).join(', ')}`);
+                throw new Error(
+                    `Invalid option "${optionKey}" passed to configureImageRule(). Valid keys are ${Object.keys(this.imageRuleOptions).join(', ')}`
+                );
             }
 
             this.imageRuleOptions[optionKey] = options[optionKey];
         }
 
         if (this.imageRuleOptions.maxSize && this.imageRuleOptions.type !== 'asset') {
-            throw new Error('Invalid option "maxSize" passed to configureImageRule(): this option is only valid when "type" is set to "asset".');
+            throw new Error(
+                'Invalid option "maxSize" passed to configureImageRule(): this option is only valid when "type" is set to "asset".'
+            );
         }
 
         if (typeof ruleCallback !== 'function') {
@@ -1007,14 +1077,18 @@ class WebpackConfig {
     configureFontRule(options = {}, ruleCallback = () => {}) {
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.fontRuleOptions)) {
-                throw new Error(`Invalid option "${optionKey}" passed to configureFontRule(). Valid keys are ${Object.keys(this.fontRuleOptions).join(', ')}`);
+                throw new Error(
+                    `Invalid option "${optionKey}" passed to configureFontRule(). Valid keys are ${Object.keys(this.fontRuleOptions).join(', ')}`
+                );
             }
 
             this.fontRuleOptions[optionKey] = options[optionKey];
         }
 
         if (this.fontRuleOptions.maxSize && this.fontRuleOptions.type !== 'asset') {
-            throw new Error('Invalid option "maxSize" passed to configureFontRule(): this option is only valid when "type" is set to "asset".');
+            throw new Error(
+                'Invalid option "maxSize" passed to configureFontRule(): this option is only valid when "type" is set to "asset".'
+            );
         }
 
         if (typeof ruleCallback !== 'function') {
@@ -1039,15 +1113,13 @@ class WebpackConfig {
     autoProvideVariables(variables) {
         // do a few sanity checks, so we can give better user errors
         if (typeof variables === 'string' || Array.isArray(variables)) {
-            throw new Error('Invalid argument passed to autoProvideVariables: you must pass an object map - e.g. { $: "jquery" }');
+            throw new Error(
+                'Invalid argument passed to autoProvideVariables: you must pass an object map - e.g. { $: "jquery" }'
+            );
         }
 
         // merge new variables into the object
-        this.providedVariables = Object.assign(
-            {},
-            this.providedVariables,
-            variables
-        );
+        this.providedVariables = Object.assign({}, this.providedVariables, variables);
     }
 
     autoProvidejQuery() {
@@ -1075,7 +1147,9 @@ class WebpackConfig {
         }
 
         if (!(name in this.loaderConfigurationCallbacks)) {
-            throw new Error(`Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}" and the aliases "${Object.keys(aliases).join('", "')}".`);
+            throw new Error(
+                `Loader "${name}" is not configurable. Valid loaders are "${Object.keys(this.loaderConfigurationCallbacks).join('", "')}" and the aliases "${Object.keys(aliases).join('", "')}".`
+            );
         }
 
         if (typeof callback !== 'function') {
@@ -1097,11 +1171,15 @@ class WebpackConfig {
         const availableHashes = crypto.getHashes();
         for (const algorithm of algorithms) {
             if (typeof algorithm !== 'string') {
-                throw new Error('Argument 2 to enableIntegrityHashes() must be a string or an array of strings.');
+                throw new Error(
+                    'Argument 2 to enableIntegrityHashes() must be a string or an array of strings.'
+                );
             }
 
             if (!availableHashes.includes(algorithm)) {
-                throw new Error(`Invalid hash algorithm "${algorithm}" passed to enableIntegrityHashes().`);
+                throw new Error(
+                    `Invalid hash algorithm "${algorithm}" passed to enableIntegrityHashes().`
+                );
             }
         }
 
@@ -1125,14 +1203,19 @@ class WebpackConfig {
     }
 
     validateNameIsNewEntry(name) {
-        const entryNamesOverlapMsg = 'The entry names between addEntry(), addEntries(), and addStyleEntry() must be unique.';
+        const entryNamesOverlapMsg =
+            'The entry names between addEntry(), addEntries(), and addStyleEntry() must be unique.';
 
         if (this.entries.has(name)) {
-            throw new Error(`Duplicate name "${name}" already exists as an Entrypoint. ${entryNamesOverlapMsg}`);
+            throw new Error(
+                `Duplicate name "${name}" already exists as an Entrypoint. ${entryNamesOverlapMsg}`
+            );
         }
 
         if (this.styleEntries.has(name)) {
-            throw new Error(`The "${name}" already exists as a Style Entrypoint. ${entryNamesOverlapMsg}`);
+            throw new Error(
+                `The "${name}" already exists as a Style Entrypoint. ${entryNamesOverlapMsg}`
+            );
         }
     }
 }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -11,40 +11,42 @@
  * @import WebpackConfig from './WebpackConfig.js'
  */
 
+import fs from 'fs';
+import path from 'path';
 import { fileURLToPath } from 'url';
-import cssExtractLoaderUtil from './loaders/css-extract.js';
+
+import tmp from 'tmp';
+
 import pathUtil from './config/path-util.js';
+import babelLoaderUtil from './loaders/babel.js';
+import cssExtractLoaderUtil from './loaders/css-extract.js';
 // loaders utils
 import cssLoaderUtil from './loaders/css.js';
-import sassLoaderUtil from './loaders/sass.js';
+import handlebarsLoaderUtil from './loaders/handlebars.js';
 import lessLoaderUtil from './loaders/less.js';
+import sassLoaderUtil from './loaders/sass.js';
 import stylusLoaderUtil from './loaders/stylus.js';
-import babelLoaderUtil from './loaders/babel.js';
 import tsLoaderUtil from './loaders/typescript.js';
 import vueLoaderUtil from './loaders/vue.js';
-import handlebarsLoaderUtil from './loaders/handlebars.js';
-// plugins utils
-import miniCssExtractPluginUtil from './plugins/mini-css-extract.js';
+import logger from './logger.js';
+import assetOutputDisplay from './plugins/asset-output-display.js';
+import definePluginUtil from './plugins/define.js';
 import deleteUnusedEntriesPluginUtil from './plugins/delete-unused-entries.js';
 import entryFilesManifestPlugin from './plugins/entry-files-manifest.js';
-import manifestPluginUtil from './plugins/manifest.js';
-import variableProviderPluginUtil from './plugins/variable-provider.js';
-import definePluginUtil from './plugins/define.js';
-import terserPluginUtil from './plugins/terser.js';
-import optimizeCssAssetsUtil from './plugins/optimize-css-assets.js';
-import vuePluginUtil from './plugins/vue.js';
 import friendlyErrorPluginUtil from './plugins/friendly-errors.js';
-import assetOutputDisplay from './plugins/asset-output-display.js';
+import manifestPluginUtil from './plugins/manifest.js';
+// plugins utils
+import miniCssExtractPluginUtil from './plugins/mini-css-extract.js';
 import notifierPluginUtil from './plugins/notifier.js';
+import optimizeCssAssetsUtil from './plugins/optimize-css-assets.js';
 import PluginPriorities from './plugins/plugin-priorities.js';
+import terserPluginUtil from './plugins/terser.js';
+import variableProviderPluginUtil from './plugins/variable-provider.js';
+import vuePluginUtil from './plugins/vue.js';
 import applyOptionsCallback from './utils/apply-options-callback.js';
 import copyEntryTmpName from './utils/copyEntryTmpName.js';
 import getVueVersion from './utils/get-vue-version.js';
-import tmp from 'tmp';
-import fs from 'fs';
-import path from 'path';
 import stringEscaper from './utils/string-escaper.js';
-import logger from './logger.js';
 
 class ConfigGenerator {
     /**
@@ -59,18 +61,21 @@ class ConfigGenerator {
         // methods because they require async doesBabelRcFileExist()).
         await this._validateDeferredBabelConfig();
 
-        const devServerConfig = this.webpackConfig.useDevServer() ? this.buildDevServerConfig() : null;
+        const devServerConfig = this.webpackConfig.useDevServer()
+            ? this.buildDevServerConfig()
+            : null;
         /*
          * We need to configure the final runtime config later in the process.
          * The devServer https can be activated by setting devServer.server to
          * 'https' or { type: 'https' }. Only at this point can we determine
          * if https has been activated.
          */
-        if (this.webpackConfig.useDevServer() &&
-            (
-                devServerConfig.server === 'https'
-                || (typeof devServerConfig.server === 'object' && devServerConfig.server.type === 'https')
-            )) {
+        if (
+            this.webpackConfig.useDevServer() &&
+            (devServerConfig.server === 'https' ||
+                (typeof devServerConfig.server === 'object' &&
+                    devServerConfig.server.type === 'https'))
+        ) {
             this.webpackConfig.runtimeConfig.devServerFinalIsHttps = true;
         } else {
             this.webpackConfig.runtimeConfig.devServerFinalIsHttps = false;
@@ -113,19 +118,25 @@ class ConfigGenerator {
 
         config.performance = {
             // silence performance hints
-            hints: false
+            hints: false,
         };
 
         config.stats = this.buildStatsConfig();
 
         config.resolve = {
             extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx', '.vue', '.ts', '.tsx', '.svelte'],
-            alias: {}
+            alias: {},
         };
 
-        if (this.webpackConfig.useVueLoader && (this.webpackConfig.vueOptions.runtimeCompilerBuild === true || this.webpackConfig.vueOptions.runtimeCompilerBuild === null)) {
+        if (
+            this.webpackConfig.useVueLoader &&
+            (this.webpackConfig.vueOptions.runtimeCompilerBuild === true ||
+                this.webpackConfig.vueOptions.runtimeCompilerBuild === null)
+        ) {
             if (this.webpackConfig.vueOptions.runtimeCompilerBuild === null) {
-                logger.recommendation('To create a smaller (and CSP-compliant) build, see https://symfony.com/doc/current/frontend/encore/vuejs.html#runtime-compiler-build');
+                logger.recommendation(
+                    'To create a smaller (and CSP-compliant) build, see https://symfony.com/doc/current/frontend/encore/vuejs.html#runtime-compiler-build'
+                );
             }
 
             const vueVersion = getVueVersion(this.webpackConfig);
@@ -164,7 +175,9 @@ class ConfigGenerator {
         // Check from configureBabel(): if a callback was provided and an
         // external Babel config exists, that's an error.
         if (this.webpackConfig._configureBabelCalled && babelRcFileExists) {
-            throw new Error('The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json"). Use null as the first argument to remove this error.');
+            throw new Error(
+                'The "callback" argument of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json"). Use null as the first argument to remove this error.'
+            );
         }
 
         // Check from configureBabel(): warn about options that won't be applied
@@ -174,7 +187,9 @@ class ConfigGenerator {
         if (babelRcFileExists) {
             for (const optionKey of Object.keys(configureOptions)) {
                 if (!allowedOptionsWithExternalConfig.includes(optionKey)) {
-                    logger.warning(`The "${optionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json").`);
+                    logger.warning(
+                        `The "${optionKey}" option of configureBabel() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json").`
+                    );
                 }
             }
         }
@@ -182,7 +197,9 @@ class ConfigGenerator {
         // Check from configureBabelPresetEnv(): if configureBabelPresetEnv()
         // was called and an external Babel config exists, that's an error.
         if (this.webpackConfig._configureBabelPresetEnvCalled && babelRcFileExists) {
-            throw new Error('The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json").');
+            throw new Error(
+                'The "callback" argument of configureBabelPresetEnv() will not be used because your app already provides an external Babel configuration (e.g. a "babel.config.js" file or "babel" key in "package.json").'
+            );
         }
     }
 
@@ -202,19 +219,20 @@ class ConfigGenerator {
             entry[entryName] = entryChunks;
         }
 
-        const copyFilesConfigs = this.webpackConfig.copyFilesConfigs.filter(entry => {
-            const copyFrom = path.resolve(
-                this.webpackConfig.getContext(),
-                entry.from
-            );
+        const copyFilesConfigs = this.webpackConfig.copyFilesConfigs.filter((entry) => {
+            const copyFrom = path.resolve(this.webpackConfig.getContext(), entry.from);
 
             if (!fs.existsSync(copyFrom)) {
-                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" does not seem to exist. Nothing will be copied for this copyFiles() config object.`);
+                logger.warning(
+                    `The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" does not seem to exist. Nothing will be copied for this copyFiles() config object.`
+                );
                 return false;
             }
 
             if (!fs.lstatSync(copyFrom).isDirectory()) {
-                logger.warning(`The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" seems to be a file. Nothing will be copied for this copyFiles() config object.`);
+                logger.warning(
+                    `The "from" option of copyFiles() should be set to an existing directory but "${entry.from}" seems to be a file. Nothing will be copied for this copyFiles() config object.`
+                );
                 return false;
             }
 
@@ -226,19 +244,22 @@ class ConfigGenerator {
             fs.writeFileSync(
                 tmpFileObject.name,
                 copyFilesConfigs.reduce((buffer, entry, index) => {
-                    const copyFrom = path.resolve(
-                        this.webpackConfig.getContext(),
-                        entry.from
-                    );
+                    const copyFrom = path.resolve(this.webpackConfig.getContext(), entry.from);
 
                     let copyTo = entry.to;
                     if (copyTo === null) {
-                        copyTo = this.webpackConfig.useVersioning ? '[path][name].[hash:8].[ext]' : '[path][name].[ext]';
+                        copyTo = this.webpackConfig.useVersioning
+                            ? '[path][name].[hash:8].[ext]'
+                            : '[path][name].[ext]';
                     }
 
-                    const copyFilesLoaderPath = fileURLToPath(import.meta.resolve('./webpack/copy-files-loader.js'));
+                    const copyFilesLoaderPath = fileURLToPath(
+                        import.meta.resolve('./webpack/copy-files-loader.js')
+                    );
                     const copyFilesLoaderConfig = `${copyFilesLoaderPath}?${JSON.stringify({
-                        context: entry.context ? path.resolve(this.webpackConfig.getContext(), entry.context) : copyFrom,
+                        context: entry.context
+                            ? path.resolve(this.webpackConfig.getContext(), entry.context)
+                            : copyFrom,
                         filename: copyTo,
                         // the patternSource is base64 encoded in case
                         // it contains characters that don't work with
@@ -247,14 +268,17 @@ class ConfigGenerator {
                         patternFlags: entry.pattern.flags,
                     })}`;
 
-                    return buffer + `
+                    return (
+                        buffer +
+                        `
                         const context_${index} = require.context(
                             '${stringEscaper(`!!${copyFilesLoaderConfig}!${copyFrom}?copy-files-loader`)}',
                             ${!!entry.includeSubdirectories},
                             ${entry.pattern}
                         );
                         context_${index}.keys().forEach(context_${index});
-                    `;
+                    `
+                    );
                 }, '')
             );
 
@@ -277,11 +301,13 @@ class ConfigGenerator {
             filename: filename,
             // default "asset module" filename
             // this is overridden for the image & font rules
-            assetModuleFilename: this.webpackConfig.configuredFilenames.assets ? this.webpackConfig.configuredFilenames.assets : 'assets/[name].[hash:8][ext]',
+            assetModuleFilename: this.webpackConfig.configuredFilenames.assets
+                ? this.webpackConfig.configuredFilenames.assets
+                : 'assets/[name].[hash:8][ext]',
             // will use the CDN path (if one is available) so that split
             // chunks load internally through the CDN.
             publicPath: this.webpackConfig.getRealPublicPath(),
-            pathinfo: !this.webpackConfig.isProduction()
+            pathinfo: !this.webpackConfig.isProduction(),
         };
     }
 
@@ -298,7 +324,10 @@ class ConfigGenerator {
 
     async buildRulesConfig() {
         const applyRuleConfigurationCallback = (name, defaultRules) => {
-            return applyOptionsCallback(this.webpackConfig.loaderConfigurationCallbacks[name], defaultRules);
+            return applyOptionsCallback(
+                this.webpackConfig.loaderConfigurationCallbacks[name],
+                defaultRules
+            );
         };
 
         const generateAssetRuleConfig = (testRegex, ruleOptions, ruleCallback, ruleName) => {
@@ -314,22 +343,20 @@ class ConfigGenerator {
             }
 
             // apply callback from, for example, configureImageRule()
-            const ruleConfig = applyOptionsCallback(
-                ruleCallback,
-                {
-                    test: testRegex,
-                    oneOf: [
-                        {
-                            resourceQuery: /copy-files-loader/,
-                            type: 'javascript/auto',
-                        },{
-                            type: ruleOptions.type,
-                            generator: generatorOptions,
-                            parser: parserOptions
-                        }
-                    ]
-                },
-            );
+            const ruleConfig = applyOptionsCallback(ruleCallback, {
+                test: testRegex,
+                oneOf: [
+                    {
+                        resourceQuery: /copy-files-loader/,
+                        type: 'javascript/auto',
+                    },
+                    {
+                        type: ruleOptions.type,
+                        generator: generatorOptions,
+                        parser: parserOptions,
+                    },
+                ],
+            });
 
             // apply callback from lower-level configureLoaderRule()
             return applyRuleConfigurationCallback(ruleName, ruleConfig);
@@ -349,12 +376,12 @@ class ConfigGenerator {
             applyRuleConfigurationCallback('javascript', {
                 test: babelLoaderUtil.getTest(this.webpackConfig),
                 exclude: this.webpackConfig.babelOptions.exclude,
-                use: await babelLoaderUtil.getLoaders(this.webpackConfig)
+                use: await babelLoaderUtil.getLoaders(this.webpackConfig),
             }),
             applyRuleConfigurationCallback('css', {
                 resolve: {
                     mainFields: ['style', 'main'],
-                    extensions: cssExtensions.map(ext => `.${ext}`),
+                    extensions: cssExtensions.map((ext) => `.${ext}`),
                 },
                 test: new RegExp(`\\.(${cssExtensions.join('|')})$`),
                 oneOf: [
@@ -363,116 +390,152 @@ class ConfigGenerator {
                         use: cssExtractLoaderUtil.prependLoaders(
                             this.webpackConfig,
                             cssLoaderUtil.getLoaders(this.webpackConfig, true)
-                        )
+                        ),
                     },
                     {
                         use: cssExtractLoaderUtil.prependLoaders(
                             this.webpackConfig,
                             cssLoaderUtil.getLoaders(this.webpackConfig)
-                        )
-                    }
-                ]
-            })
+                        ),
+                    },
+                ],
+            }),
         ];
 
         if (this.webpackConfig.imageRuleOptions.enabled) {
-            rules.push(generateAssetRuleConfig(
-                /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
-                this.webpackConfig.imageRuleOptions,
-                this.webpackConfig.imageRuleCallback,
-                'images'
-            ));
+            rules.push(
+                generateAssetRuleConfig(
+                    /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
+                    this.webpackConfig.imageRuleOptions,
+                    this.webpackConfig.imageRuleCallback,
+                    'images'
+                )
+            );
         }
 
         if (this.webpackConfig.fontRuleOptions.enabled) {
-            rules.push(generateAssetRuleConfig(
-                /\.(woff|woff2|ttf|eot|otf)$/,
-                this.webpackConfig.fontRuleOptions,
-                this.webpackConfig.fontRuleCallback,
-                'fonts'
-            ));
+            rules.push(
+                generateAssetRuleConfig(
+                    /\.(woff|woff2|ttf|eot|otf)$/,
+                    this.webpackConfig.fontRuleOptions,
+                    this.webpackConfig.fontRuleCallback,
+                    'fonts'
+                )
+            );
         }
 
         if (this.webpackConfig.useSassLoader) {
-            rules.push(applyRuleConfigurationCallback('sass', {
-                resolve: {
-                    mainFields: ['sass', 'style', 'main'],
-                    extensions: ['.scss', '.sass', '.css']
-                },
-                test: /\.s[ac]ss$/,
-                oneOf: [
-                    {
-                        resourceQuery: /module/,
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig, true))
+            rules.push(
+                applyRuleConfigurationCallback('sass', {
+                    resolve: {
+                        mainFields: ['sass', 'style', 'main'],
+                        extensions: ['.scss', '.sass', '.css'],
                     },
-                    {
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, sassLoaderUtil.getLoaders(this.webpackConfig))
-                    }
-                ]
-            }));
+                    test: /\.s[ac]ss$/,
+                    oneOf: [
+                        {
+                            resourceQuery: /module/,
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                sassLoaderUtil.getLoaders(this.webpackConfig, true)
+                            ),
+                        },
+                        {
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                sassLoaderUtil.getLoaders(this.webpackConfig)
+                            ),
+                        },
+                    ],
+                })
+            );
         }
 
         if (this.webpackConfig.useLessLoader) {
-            rules.push(applyRuleConfigurationCallback('less', {
-                test: /\.less/,
-                oneOf: [
-                    {
-                        resourceQuery: /module/,
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig, true))
-                    },
-                    {
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, lessLoaderUtil.getLoaders(this.webpackConfig))
-                    }
-                ]
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('less', {
+                    test: /\.less/,
+                    oneOf: [
+                        {
+                            resourceQuery: /module/,
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                lessLoaderUtil.getLoaders(this.webpackConfig, true)
+                            ),
+                        },
+                        {
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                lessLoaderUtil.getLoaders(this.webpackConfig)
+                            ),
+                        },
+                    ],
+                })
+            );
         }
 
         if (this.webpackConfig.useStylusLoader) {
-            rules.push(applyRuleConfigurationCallback('stylus', {
-                test: /\.styl/,
-                oneOf: [
-                    {
-                        resourceQuery: /module/,
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig, true))
-                    },
-                    {
-                        use: cssExtractLoaderUtil.prependLoaders(this.webpackConfig, stylusLoaderUtil.getLoaders(this.webpackConfig))
-                    }
-                ]
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('stylus', {
+                    test: /\.styl/,
+                    oneOf: [
+                        {
+                            resourceQuery: /module/,
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                stylusLoaderUtil.getLoaders(this.webpackConfig, true)
+                            ),
+                        },
+                        {
+                            use: cssExtractLoaderUtil.prependLoaders(
+                                this.webpackConfig,
+                                stylusLoaderUtil.getLoaders(this.webpackConfig)
+                            ),
+                        },
+                    ],
+                })
+            );
         }
 
         if (this.webpackConfig.useSvelte) {
-            rules.push(applyRuleConfigurationCallback('svelte', {
-                resolve: {
-                    mainFields: ['svelte', 'browser', 'module', 'main'],
-                    extensions: ['.mjs', '.js', '.svelte'],
-                },
-                test: /\.svelte$/,
-                loader: 'svelte-loader',
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('svelte', {
+                    resolve: {
+                        mainFields: ['svelte', 'browser', 'module', 'main'],
+                        extensions: ['.mjs', '.js', '.svelte'],
+                    },
+                    test: /\.svelte$/,
+                    loader: 'svelte-loader',
+                })
+            );
         }
 
         if (this.webpackConfig.useVueLoader) {
-            rules.push(applyRuleConfigurationCallback('vue', {
-                test: /\.vue$/,
-                use: vueLoaderUtil.getLoaders(this.webpackConfig)
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('vue', {
+                    test: /\.vue$/,
+                    use: vueLoaderUtil.getLoaders(this.webpackConfig),
+                })
+            );
         }
 
         if (this.webpackConfig.useTypeScriptLoader) {
-            rules.push(applyRuleConfigurationCallback('typescript', {
-                test: /\.tsx?$/,
-                exclude: /node_modules/,
-                use: await tsLoaderUtil.getLoaders(this.webpackConfig)
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('typescript', {
+                    test: /\.tsx?$/,
+                    exclude: /node_modules/,
+                    use: await tsLoaderUtil.getLoaders(this.webpackConfig),
+                })
+            );
         }
 
         if (this.webpackConfig.useHandlebarsLoader) {
-            rules.push(applyRuleConfigurationCallback('handlebars', {
-                test: /\.(handlebars|hbs)$/,
-                use: handlebarsLoaderUtil.getLoaders(this.webpackConfig)
-            }));
+            rules.push(
+                applyRuleConfigurationCallback('handlebars', {
+                    test: /\.(handlebars|hbs)$/,
+                    use: handlebarsLoaderUtil.getLoaders(this.webpackConfig),
+                })
+            );
         }
 
         this.webpackConfig.loaders.forEach((loader) => {
@@ -507,13 +570,13 @@ class ConfigGenerator {
             const friendlyErrorPlugin = friendlyErrorPluginUtil(this.webpackConfig);
             plugins.push({
                 plugin: friendlyErrorPlugin,
-                priority: PluginPriorities.FriendlyErrorsWebpackPlugin
+                priority: PluginPriorities.FriendlyErrorsWebpackPlugin,
             });
 
             assetOutputDisplay(plugins, this.webpackConfig, friendlyErrorPlugin);
         }
 
-        this.webpackConfig.plugins.forEach(function(plugin) {
+        this.webpackConfig.plugins.forEach(function (plugin) {
             plugins.push(plugin);
         });
 
@@ -534,19 +597,17 @@ class ConfigGenerator {
     }
 
     buildOptimizationConfig() {
-        const optimization = {
-
-        };
+        const optimization = {};
 
         if (this.webpackConfig.isProduction()) {
             optimization.minimizer = [
                 terserPluginUtil(this.webpackConfig),
-                optimizeCssAssetsUtil(this.webpackConfig)
+                optimizeCssAssetsUtil(this.webpackConfig),
             ];
         }
 
         const splitChunks = {
-            chunks: this.webpackConfig.shouldSplitEntryChunks ? 'all' : 'async'
+            chunks: this.webpackConfig.shouldSplitEntryChunks ? 'all' : 'async',
         };
 
         const cacheGroups = {};
@@ -556,7 +617,7 @@ class ConfigGenerator {
                 {
                     name: groupName,
                     chunks: 'all',
-                    enforce: true
+                    enforce: true,
                 },
                 this.webpackConfig.cacheGroups[groupName]
             );
@@ -565,7 +626,9 @@ class ConfigGenerator {
         splitChunks.cacheGroups = cacheGroups;
 
         if (this.webpackConfig.shouldUseSingleRuntimeChunk === null) {
-            throw new Error('Either the Encore.enableSingleRuntimeChunk() or Encore.disableSingleRuntimeChunk() method should be called. The recommended setting is Encore.enableSingleRuntimeChunk().');
+            throw new Error(
+                'Either the Encore.enableSingleRuntimeChunk() or Encore.disableSingleRuntimeChunk() method should be called. The recommended setting is Encore.enableSingleRuntimeChunk().'
+            );
         }
 
         if (this.webpackConfig.shouldUseSingleRuntimeChunk) {
@@ -586,10 +649,7 @@ class ConfigGenerator {
         cache.type = /** @type {const} */ ('filesystem');
         cache.buildDependencies = this.webpackConfig.persistentCacheBuildDependencies;
 
-        applyOptionsCallback(
-            this.webpackConfig.persistentCacheCallback,
-            cache
-        );
+        applyOptionsCallback(this.webpackConfig.persistentCacheCallback, cache);
 
         return cache;
     }
@@ -599,7 +659,10 @@ class ConfigGenerator {
         // this still doesn't remove all output
         let stats = {};
 
-        if (!this.webpackConfig.runtimeConfig.outputJson && !this.webpackConfig.runtimeConfig.profile) {
+        if (
+            !this.webpackConfig.runtimeConfig.outputJson &&
+            !this.webpackConfig.runtimeConfig.profile
+        ) {
             stats = {
                 hash: false,
                 version: false,
@@ -623,7 +686,7 @@ class ConfigGenerator {
 
     buildWatchOptionsConfig() {
         const watchOptions = {
-            ignored: /node_modules/
+            ignored: /node_modules/,
         };
 
         return applyOptionsCallback(
@@ -658,7 +721,9 @@ class ConfigGenerator {
         // configureDevServerOptions() takes precedence if it sets "server".
         // Use object form { type: ... } so webpack-cli can merge --server-type on top.
         if (this.webpackConfig.runtimeConfig.devServerServerType) {
-            devServerOptions.server = { type: this.webpackConfig.runtimeConfig.devServerServerType };
+            devServerOptions.server = {
+                type: this.webpackConfig.runtimeConfig.devServerServerType,
+            };
         }
 
         return applyOptionsCallback(
@@ -672,7 +737,7 @@ class ConfigGenerator {
  * @param {WebpackConfig} webpackConfig A configured WebpackConfig object
  * @returns {Promise<import('webpack').Configuration>} The final webpack config object
  */
-export default async function(webpackConfig) {
+export default async function (webpackConfig) {
     const generator = new ConfigGenerator(webpackConfig);
 
     return generator.getWebpackConfig();

--- a/lib/config/parse-runtime.js
+++ b/lib/config/parse-runtime.js
@@ -7,16 +7,17 @@
  * file that was distributed with this source code.
  */
 
-import RuntimeConfig from './RuntimeConfig.js';
-import packageUp from '../utils/package-up.js';
 import path from 'path';
+
+import packageUp from '../utils/package-up.js';
+import RuntimeConfig from './RuntimeConfig.js';
 
 /**
  * @param {object} argv
  * @param {string} cwd
  * @returns {RuntimeConfig}
  */
-export default function(argv, cwd) {
+export default function (argv, cwd) {
     const runtimeConfig = new RuntimeConfig();
     runtimeConfig.command = argv._[0];
 
@@ -59,7 +60,9 @@ export default function(argv, cwd) {
         const packagesPath = packageUp({ cwd });
 
         if (null === packagesPath) {
-            throw new Error('Cannot determine webpack context. (Are you executing webpack from a directory outside of your project?). Try passing the --context option.');
+            throw new Error(
+                'Cannot determine webpack context. (Are you executing webpack from a directory outside of your project?). Try passing the --context option.'
+            );
         }
 
         runtimeConfig.context = path.dirname(packagesPath);

--- a/lib/config/path-util.js
+++ b/lib/config/path-util.js
@@ -16,6 +16,7 @@
  */
 
 import path from 'path';
+
 import logger from '../logger.js';
 
 export default {
@@ -27,9 +28,11 @@ export default {
      */
     getContentBase(webpackConfig) {
         // strip trailing slash (for Unix or Windows)
-        const outputPath = webpackConfig.outputPath.replace(/\/$/,'').replace(/\\$/, '');
+        const outputPath = webpackConfig.outputPath.replace(/\/$/, '').replace(/\\$/, '');
         // use the manifestKeyPrefix if available
-        const publicPath = webpackConfig.manifestKeyPrefix ? webpackConfig.manifestKeyPrefix.replace(/\/$/,'') : webpackConfig.publicPath.replace(/\/$/,'');
+        const publicPath = webpackConfig.manifestKeyPrefix
+            ? webpackConfig.manifestKeyPrefix.replace(/\/$/, '')
+            : webpackConfig.publicPath.replace(/\/$/, '');
 
         /*
          * We use the intersection of the publicPath (or manifestKeyPrefix) and outputPath
@@ -56,7 +59,9 @@ export default {
             contentBase = path.dirname(contentBase);
         }
 
-        throw new Error(`Unable to determine contentBase option for webpack's devServer configuration. The ${webpackConfig.manifestKeyPrefix ? 'manifestKeyPrefix' : 'publicPath'} (${webpackConfig.manifestKeyPrefix ? webpackConfig.manifestKeyPrefix : webpackConfig.publicPath}) string does not exist in the outputPath (${webpackConfig.outputPath}), and so the "document root" cannot be determined.`);
+        throw new Error(
+            `Unable to determine contentBase option for webpack's devServer configuration. The ${webpackConfig.manifestKeyPrefix ? 'manifestKeyPrefix' : 'publicPath'} (${webpackConfig.manifestKeyPrefix ? webpackConfig.manifestKeyPrefix : webpackConfig.publicPath}) string does not exist in the outputPath (${webpackConfig.outputPath}), and so the "document root" cannot be determined.`
+        );
     },
 
     /**
@@ -91,7 +96,9 @@ export default {
              * choose your manifestKeyPrefix.
              */
 
-            throw new Error('Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use when building your manifest keys. This is happening because you passed an absolute URL to setPublicPath().');
+            throw new Error(
+                'Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use when building your manifest keys. This is happening because you passed an absolute URL to setPublicPath().'
+            );
         }
 
         let outputPath = webpackConfig.outputPath;
@@ -118,7 +125,9 @@ export default {
         if (!outputPath.includes(publicPath)) {
             const suggestion = publicPath.substr(publicPath.lastIndexOf('/') + 1) + '/';
 
-            throw new Error(`Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. ${suggestion}) to use when building your manifest keys. This is caused by setOutputPath() (${outputPath}) and setPublicPath() (${publicPath}) containing paths that don't seem compatible.`);
+            throw new Error(
+                `Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. ${suggestion}) to use when building your manifest keys. This is caused by setOutputPath() (${outputPath}) and setPublicPath() (${publicPath}) containing paths that don't seem compatible.`
+            );
         }
     },
 
@@ -128,7 +137,9 @@ export default {
      */
     calculateDevServerUrl(runtimeConfig) {
         if (runtimeConfig.devServerFinalIsHttps === null) {
-            logger.warning('The final devServerFinalHttpsConfig was never calculated. This may cause some paths to incorrectly use or not use https and could be a bug.');
+            logger.warning(
+                'The final devServerFinalHttpsConfig was never calculated. This may cause some paths to incorrectly use or not use https and could be a bug.'
+            );
         }
 
         if (runtimeConfig.devServerPublic) {
@@ -144,5 +155,5 @@ export default {
         }
 
         return `http${runtimeConfig.devServerFinalIsHttps ? 's' : ''}://${runtimeConfig.devServerHost}:${runtimeConfig.devServerPort}`;
-    }
+    },
 };

--- a/lib/config/validator.js
+++ b/lib/config/validator.js
@@ -11,8 +11,8 @@
  * @import WebpackConfig from '../WebpackConfig.js'
  */
 
-import pathUtil from './path-util.js';
 import logger from './../logger.js';
+import pathUtil from './path-util.js';
 
 class Validator {
     /**
@@ -34,19 +34,26 @@ class Validator {
 
     _validateBasic() {
         if (this.webpackConfig.outputPath === null) {
-            throw new Error('Missing output path: Call setOutputPath() to control where the files will be written.');
+            throw new Error(
+                'Missing output path: Call setOutputPath() to control where the files will be written.'
+            );
         }
 
         if (this.webpackConfig.publicPath === null) {
-            throw new Error('Missing public path: Call setPublicPath() to control the public path relative to where the files are written (the output path).');
+            throw new Error(
+                'Missing public path: Call setPublicPath() to control the public path relative to where the files are written (the output path).'
+            );
         }
 
-        if (this.webpackConfig.entries.size === 0
-            && this.webpackConfig.styleEntries.size === 0
-            && this.webpackConfig.copyFilesConfigs.length === 0
-            && this.webpackConfig.plugins.length === 0
+        if (
+            this.webpackConfig.entries.size === 0 &&
+            this.webpackConfig.styleEntries.size === 0 &&
+            this.webpackConfig.copyFilesConfigs.length === 0 &&
+            this.webpackConfig.plugins.length === 0
         ) {
-            throw new Error('No entries found! You must call addEntry() or addEntries() or addStyleEntry() or copyFiles() or addPlugin() at least once - otherwise... there is nothing to webpack!');
+            throw new Error(
+                'No entries found! You must call addEntry() or addEntries() or addStyleEntry() or copyFiles() or addPlugin() at least once - otherwise... there is nothing to webpack!'
+            );
         }
     }
 
@@ -60,7 +67,9 @@ class Validator {
         }
 
         if (this.webpackConfig.useVersioning) {
-            throw new Error('Don\'t enable versioning with the dev-server. A good setting is Encore.enableVersioning(Encore.isProduction()).');
+            throw new Error(
+                "Don't enable versioning with the dev-server. A good setting is Encore.enableVersioning(Encore.isProduction())."
+            );
         }
 
         /*
@@ -71,20 +80,24 @@ class Validator {
          * (see #59), but we want to warn the user.
          */
         if (this.webpackConfig.publicPath.includes('://')) {
-            logger.warning(`Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues. Your assets will load from the publicPath (${this.webpackConfig.publicPath}) instead of from the dev server URL.`);
+            logger.warning(
+                `Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues. Your assets will load from the publicPath (${this.webpackConfig.publicPath}) instead of from the dev server URL.`
+            );
         }
     }
 
     _validateCacheGroupNames() {
         for (const groupName of Object.keys(this.webpackConfig.cacheGroups)) {
             if (['defaultVendors', 'default'].includes(groupName)) {
-                logger.warning(`Passing "${groupName}" to addCacheGroup() is not recommended, as it will override the built-in cache group by this name.`);
+                logger.warning(
+                    `Passing "${groupName}" to addCacheGroup() is not recommended, as it will override the built-in cache group by this name.`
+                );
             }
         }
     }
 }
 
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     const validator = new Validator(webpackConfig);
 
     validator.validate();

--- a/lib/context.js
+++ b/lib/context.js
@@ -12,5 +12,5 @@
  */
 
 export default {
-    runtimeConfig: null
+    runtimeConfig: null,
 };

--- a/lib/features.js
+++ b/lib/features.js
@@ -24,52 +24,39 @@ const features = {
         method: 'enableSassLoader()',
         packages: [
             { name: 'sass-loader', enforce_version: true },
-            [{ name: 'sass' }, { name: 'sass-embedded' }, { name: 'node-sass' }]
+            [{ name: 'sass' }, { name: 'sass-embedded' }, { name: 'node-sass' }],
         ],
-        description: 'load Sass files'
+        description: 'load Sass files',
     },
     less: {
         method: 'enableLessLoader()',
-        packages: [
-            { name: 'less-loader', enforce_version: true },
-        ],
-        description: 'load LESS files'
+        packages: [{ name: 'less-loader', enforce_version: true }],
+        description: 'load LESS files',
     },
     stylus: {
         method: 'enableStylusLoader()',
-        packages: [
-            { name: 'stylus-loader', enforce_version: true },
-        ],
-        description: 'load Stylus files'
+        packages: [{ name: 'stylus-loader', enforce_version: true }],
+        description: 'load Stylus files',
     },
     postcss: {
         method: 'enablePostCssLoader()',
-        packages: [
-            { name: 'postcss-loader', enforce_version: true }
-        ],
-        description: 'process through PostCSS'
+        packages: [{ name: 'postcss-loader', enforce_version: true }],
+        description: 'process through PostCSS',
     },
     react: {
         method: 'enableReactPreset()',
-        packages: [
-            { name: '@babel/preset-react', enforce_version: true }
-        ],
-        description: 'process React JS files'
+        packages: [{ name: '@babel/preset-react', enforce_version: true }],
+        description: 'process React JS files',
     },
     preact: {
         method: 'enablePreactPreset()',
-        packages: [
-            { name: '@babel/plugin-transform-react-jsx', enforce_version: true }
-        ],
-        description: 'process Preact JS files'
+        packages: [{ name: '@babel/plugin-transform-react-jsx', enforce_version: true }],
+        description: 'process Preact JS files',
     },
     typescript: {
         method: 'enableTypeScriptLoader()',
-        packages: [
-            { name: 'typescript' },
-            { name: 'ts-loader', enforce_version: true },
-        ],
-        description: 'process TypeScript files'
+        packages: [{ name: 'typescript' }, { name: 'ts-loader', enforce_version: true }],
+        description: 'process TypeScript files',
     },
     forkedtypecheck: {
         method: 'enableForkedTypeScriptTypesChecking()',
@@ -78,7 +65,7 @@ const features = {
             { name: 'ts-loader', enforce_version: true },
             { name: 'fork-ts-checker-webpack-plugin', enforce_version: true },
         ],
-        description: 'check TypeScript types in a separate process'
+        description: 'check TypeScript types in a separate process',
     },
     'typescript-babel': {
         method: 'enableBabelTypeScriptPreset',
@@ -86,7 +73,7 @@ const features = {
             { name: 'typescript' },
             { name: '@babel/preset-typescript', enforce_version: true },
         ],
-        description: 'process TypeScript files with Babel'
+        description: 'process TypeScript files with Babel',
     },
     vue3: {
         method: 'enableVueLoader()',
@@ -95,53 +82,42 @@ const features = {
         packages: [
             { name: 'vue', enforce_version: true },
             { name: 'vue-loader', enforce_version: true },
-            { name: '@vue/compiler-sfc' }
+            { name: '@vue/compiler-sfc' },
         ],
-        description: 'load Vue files'
+        description: 'load Vue files',
     },
     'vue3-jsx': {
         method: 'enableVueLoader()',
-        packages: [
-            { name: '@vue/babel-plugin-jsx' },
-        ],
-        description: 'use Vue with JSX support'
+        packages: [{ name: '@vue/babel-plugin-jsx' }],
+        description: 'use Vue with JSX support',
     },
     notifier: {
         method: 'enableBuildNotifications()',
-        packages: [
-            { name: 'webpack-notifier', enforce_version: true },
-        ],
-        description: 'display build notifications'
+        packages: [{ name: 'webpack-notifier', enforce_version: true }],
+        description: 'display build notifications',
     },
     handlebars: {
         method: 'enableHandlebarsLoader()',
-        packages: [
-            { name: 'handlebars' },
-            { name: 'handlebars-loader', enforce_version: true }
-        ],
-        description: 'load Handlebars files'
+        packages: [{ name: 'handlebars' }, { name: 'handlebars-loader', enforce_version: true }],
+        description: 'load Handlebars files',
     },
     stimulus: {
         method: 'enableStimulusBridge()',
-        packages: [
-            { name: '@symfony/stimulus-bridge', enforce_version: true }
-        ],
-        description: 'enable Stimulus bridge'
+        packages: [{ name: '@symfony/stimulus-bridge', enforce_version: true }],
+        description: 'enable Stimulus bridge',
     },
     svelte: {
         method: 'enableSvelte()',
         packages: [
             { name: 'svelte', enforce_version: true },
-            { name: 'svelte-loader', enforce_version: true }
+            { name: 'svelte-loader', enforce_version: true },
         ],
-        description: 'process Svelte JS files'
+        description: 'process Svelte JS files',
     },
     'webpack-dev-server': {
         method: 'configureDevServerOptions()',
-        packages: [
-            { name: 'webpack-dev-server' }
-        ],
-        description: 'run the Webpack development server'
+        packages: [{ name: 'webpack-dev-server' }],
+        description: 'run the Webpack development server',
     },
 };
 
@@ -154,7 +130,7 @@ function getFeatureConfig(featureName) {
 }
 
 export default {
-    ensurePackagesExistAndAreCorrectVersion: function(featureName, method = null) {
+    ensurePackagesExistAndAreCorrectVersion: function (featureName, method = null) {
         const config = getFeatureConfig(featureName);
 
         packageHelper.ensurePackagesExist(
@@ -163,7 +139,7 @@ export default {
         );
     },
 
-    getMissingPackageRecommendations: function(featureName) {
+    getMissingPackageRecommendations: function (featureName) {
         const config = getFeatureConfig(featureName);
 
         return packageHelper.getMissingPackageRecommendations(
@@ -172,11 +148,11 @@ export default {
         );
     },
 
-    getFeatureMethod: function(featureName) {
+    getFeatureMethod: function (featureName) {
         return getFeatureConfig(featureName).method;
     },
 
-    getFeatureDescription: function(featureName) {
+    getFeatureDescription: function (featureName) {
         return getFeatureConfig(featureName).description;
     },
 };

--- a/lib/friendly-errors/asset-output-display-plugin.js
+++ b/lib/friendly-errors/asset-output-display-plugin.js
@@ -14,21 +14,18 @@ function AssetOutputDisplayPlugin(outputPath, friendlyErrorsPlugin) {
     this.friendlyErrorsPlugin = friendlyErrorsPlugin;
 }
 
-AssetOutputDisplayPlugin.prototype.apply = function(compiler) {
+AssetOutputDisplayPlugin.prototype.apply = function (compiler) {
     const emit = (compilation, callback) => {
         // completely reset messages key to avoid adding more and more messages
         // when using watch
         this.friendlyErrorsPlugin.compilationSuccessInfo.messages = [
-            `${pc.yellow(Object.keys(compilation.assets).length)} files written to ${pc.yellow(this.outputPath)}`
+            `${pc.yellow(Object.keys(compilation.assets).length)} files written to ${pc.yellow(this.outputPath)}`,
         ];
 
         callback();
     };
 
-    compiler.hooks.emit.tapAsync(
-        { name: 'AssetOutputDisplayPlugin' },
-        emit
-    );
+    compiler.hooks.emit.tapAsync({ name: 'AssetOutputDisplayPlugin' }, emit);
 };
 
 export default AssetOutputDisplayPlugin;

--- a/lib/friendly-errors/formatters/missing-css-file.js
+++ b/lib/friendly-errors/formatters/missing-css-file.js
@@ -16,12 +16,12 @@ function formatErrors(errors) {
 
     let messages = [];
 
-    messages.push(
-        pc.red('Module build failed: Module not found:')
-    );
+    messages.push(pc.red('Module build failed: Module not found:'));
     for (let error of errors) {
         messages.push(`"${error.file}" contains a reference to the file "${error.ref}".`);
-        messages.push('This file can not be found, please check it for typos or update it if the file got moved.');
+        messages.push(
+            'This file can not be found, please check it for typos or update it if the file got moved.'
+        );
         messages.push('');
     }
 
@@ -29,9 +29,7 @@ function formatErrors(errors) {
 }
 
 function format(errors) {
-    return formatErrors(errors.filter((e) => (
-        e.type === 'missing-css-file'
-    )));
+    return formatErrors(errors.filter((e) => e.type === 'missing-css-file'));
 }
 
 export default format;

--- a/lib/friendly-errors/formatters/missing-loader.js
+++ b/lib/friendly-errors/formatters/missing-loader.js
@@ -8,6 +8,7 @@
  */
 
 import pc from 'picocolors';
+
 import loaderFeatures from '../../features.js';
 
 function formatErrors(errors) {
@@ -24,13 +25,19 @@ function formatErrors(errors) {
             let neededCode = `Encore.${loaderFeatures.getFeatureMethod(error.loaderName)}`;
             fixes.push(`Add ${pc.green(neededCode)} to your Webpack config file.`);
 
-            const packageRecommendations = loaderFeatures.getMissingPackageRecommendations(error.loaderName);
+            const packageRecommendations = loaderFeatures.getMissingPackageRecommendations(
+                error.loaderName
+            );
 
             if (packageRecommendations) {
-                fixes.push(`${packageRecommendations.message}\n              ${packageRecommendations.installCommand}`);
+                fixes.push(
+                    `${packageRecommendations.message}\n              ${packageRecommendations.installCommand}`
+                );
             }
         } else {
-            fixes.push('You may need to install and configure a special loader for this file type.');
+            fixes.push(
+                'You may need to install and configure a special loader for this file type.'
+            );
         }
 
         // vue hides their filenames (via a stacktrace) inside error.origin
@@ -39,14 +46,13 @@ function formatErrors(errors) {
             messages.push(error.origin);
             messages.push('');
         } else {
-            messages = messages.concat([
-                pc.red(`Error loading ${pc.yellow(error.file)}`),
-                ''
-            ]);
+            messages = messages.concat([pc.red(`Error loading ${pc.yellow(error.file)}`), '']);
         }
 
         if (error.loaderName) {
-            messages.push(`${pc.bgGreen(pc.black('FIX'))} To ${loaderFeatures.getFeatureDescription(error.loaderName)}:`);
+            messages.push(
+                `${pc.bgGreen(pc.black('FIX'))} To ${loaderFeatures.getFeatureDescription(error.loaderName)}:`
+            );
         } else {
             messages.push(`${pc.bgGreen(pc.black('FIX'))} To load "${error.file}":`);
         }
@@ -63,9 +69,7 @@ function formatErrors(errors) {
 }
 
 function format(errors) {
-    return formatErrors(errors.filter((e) => (
-        e.type === 'loader-not-enabled'
-    )));
+    return formatErrors(errors.filter((e) => e.type === 'loader-not-enabled'));
 }
 
 export default format;

--- a/lib/friendly-errors/formatters/missing-postcss-config.js
+++ b/lib/friendly-errors/formatters/missing-postcss-config.js
@@ -18,38 +18,40 @@ function formatErrors(errors) {
     // there will be an error for *every* file, but showing
     // the error over and over again is not helpful
 
-    messages.push(
-        pc.red('Module build failed: Error: No PostCSS Config found')
-    );
+    messages.push(pc.red('Module build failed: Error: No PostCSS Config found'));
     messages.push('');
-    messages.push(`${pc.bgGreen(pc.black('FIX'))} Create a PostCSS config file at the root of your project.`);
+    messages.push(
+        `${pc.bgGreen(pc.black('FIX'))} Create a PostCSS config file at the root of your project.`
+    );
     messages.push('');
     messages.push('Here are two examples to get you started:');
     messages.push('');
     messages.push(pc.bold('Option 1: ESM') + ` (${pc.yellow('postcss.config.js')})`);
-    messages.push(pc.yellow(`
+    messages.push(
+        pc.yellow(`
 export default {
   plugins: {
     'autoprefixer': {},
   }
 }
-    `));
+    `)
+    );
     messages.push(pc.bold('Option 2: CJS') + ` (${pc.yellow('postcss.config.cjs')})`);
-    messages.push(pc.yellow(`
+    messages.push(
+        pc.yellow(`
 module.exports = {
   plugins: {
     'autoprefixer': {},
   }
 }
-    `));
+    `)
+    );
 
     return messages;
 }
 
 function format(errors) {
-    return formatErrors(errors.filter((e) => (
-        e.type === 'missing-postcss-config'
-    )));
+    return formatErrors(errors.filter((e) => e.type === 'missing-postcss-config'));
 }
 
 export default format;

--- a/lib/friendly-errors/transformers/missing-css-file.js
+++ b/lib/friendly-errors/transformers/missing-css-file.js
@@ -14,7 +14,7 @@ function isMissingConfigError(e) {
         return false;
     }
 
-    if (!e.message.includes('Module not found: Error: Can\'t resolve')) {
+    if (!e.message.includes("Module not found: Error: Can't resolve")) {
         return false;
     }
 
@@ -22,8 +22,8 @@ function isMissingConfigError(e) {
 }
 
 function getReference(error) {
-    const index = error.message.indexOf('Can\'t resolve \'') + 15;
-    const endIndex = error.message.indexOf('\' in \'');
+    const index = error.message.indexOf("Can't resolve '") + 15;
+    const endIndex = error.message.indexOf("' in '");
 
     return error.message.substring(index, endIndex);
 }

--- a/lib/friendly-errors/transformers/missing-loader.js
+++ b/lib/friendly-errors/transformers/missing-loader.js
@@ -99,8 +99,8 @@ function transform(error, webpackConfig) {
 /*
  * Returns a factory to get the function.
  */
-export default function(webpackConfig) {
-    return function(error) {
+export default function (webpackConfig) {
+    return function (error) {
         return transform(error, webpackConfig);
     };
 }

--- a/lib/loaders/babel.js
+++ b/lib/loaders/babel.js
@@ -12,6 +12,7 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
@@ -37,7 +38,7 @@ export default {
 
         // configure babel (unless the user is specifying .babelrc)
         // todo - add a sanity check for their babelrc contents
-        if (!await webpackConfig.doesBabelRcFileExist()) {
+        if (!(await webpackConfig.doesBabelRcFileExist())) {
             let presetEnvOptions = {
                 // modules don't need to be transformed - webpack will parse
                 // the modules for us. This is a performance improvement
@@ -55,15 +56,18 @@ export default {
 
             Object.assign(babelConfig, {
                 presets: [
-                    [fileURLToPath(import.meta.resolve('@babel/preset-env')), presetEnvOptions]
+                    [fileURLToPath(import.meta.resolve('@babel/preset-env')), presetEnvOptions],
                 ],
-                plugins: []
+                plugins: [],
             });
 
             if (webpackConfig.useBabelTypeScriptPreset) {
                 loaderFeatures.ensurePackagesExistAndAreCorrectVersion('typescript-babel');
 
-                babelConfig.presets.push([fileURLToPath(import.meta.resolve('@babel/preset-typescript')), webpackConfig.babelTypeScriptPresetOptions]);
+                babelConfig.presets.push([
+                    fileURLToPath(import.meta.resolve('@babel/preset-typescript')),
+                    webpackConfig.babelTypeScriptPresetOptions,
+                ]);
             }
 
             if (webpackConfig.useReact) {
@@ -74,7 +78,7 @@ export default {
                     applyOptionsCallback(webpackConfig.babelReactPresetOptionsCallback, {
                         // TODO: To remove when Babel 8, "automatic" will become the default value
                         runtime: 'automatic',
-                    })
+                    }),
                 ]);
             }
 
@@ -84,30 +88,37 @@ export default {
                 if (webpackConfig.preactOptions.preactCompat) {
                     // If preact-compat is enabled tell babel to
                     // transform JSX into React.createElement calls.
-                    babelConfig.plugins.push([fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx'))]);
+                    babelConfig.plugins.push([
+                        fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx')),
+                    ]);
                 } else {
                     // If preact-compat is disabled tell babel to
                     // transform JSX into Preact h() calls.
                     babelConfig.plugins.push([
                         fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx')),
-                        { 'pragma': 'h' }
+                        { pragma: 'h' },
                     ]);
                 }
             }
 
             if (webpackConfig.useVueLoader && webpackConfig.vueOptions.useJsx) {
                 loaderFeatures.ensurePackagesExistAndAreCorrectVersion('vue3-jsx');
-                babelConfig.plugins.push(fileURLToPath(import.meta.resolve('@vue/babel-plugin-jsx')));
+                babelConfig.plugins.push(
+                    fileURLToPath(import.meta.resolve('@vue/babel-plugin-jsx'))
+                );
             }
 
-            babelConfig = applyOptionsCallback(webpackConfig.babelConfigurationCallback, babelConfig);
+            babelConfig = applyOptionsCallback(
+                webpackConfig.babelConfigurationCallback,
+                babelConfig
+            );
         }
 
         return [
             {
                 loader: fileURLToPath(import.meta.resolve('babel-loader')),
-                options: babelConfig
-            }
+                options: babelConfig,
+            },
         ];
     },
 
@@ -125,5 +136,5 @@ export default {
         }
 
         return new RegExp(`\\.(${extensions.join('|')})$`);
-    }
+    },
 };

--- a/lib/loaders/css-extract.js
+++ b/lib/loaders/css-extract.js
@@ -12,7 +12,9 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
 export default {
@@ -25,24 +27,31 @@ export default {
      */
     prependLoaders(webpackConfig, loaders) {
         if (!webpackConfig.extractCss) {
-
             const options = {};
 
             // If the CSS extraction is disabled, use the
             // style-loader instead.
-            return [{
-                loader: fileURLToPath(import.meta.resolve('style-loader')),
-                options: applyOptionsCallback(webpackConfig.styleLoaderConfigurationCallback, options)
-
-            }, ...loaders];
+            return [
+                {
+                    loader: fileURLToPath(import.meta.resolve('style-loader')),
+                    options: applyOptionsCallback(
+                        webpackConfig.styleLoaderConfigurationCallback,
+                        options
+                    ),
+                },
+                ...loaders,
+            ];
         }
 
-        return [{
-            loader: MiniCssExtractPlugin.loader,
-            options: applyOptionsCallback(
-                webpackConfig.miniCssExtractLoaderConfigurationCallback,
-                {}
-            ),
-        }, ...loaders];
-    }
+        return [
+            {
+                loader: MiniCssExtractPlugin.loader,
+                options: applyOptionsCallback(
+                    webpackConfig.miniCssExtractLoaderConfigurationCallback,
+                    {}
+                ),
+            },
+            ...loaders,
+        ];
+    },
 };

--- a/lib/loaders/css.js
+++ b/lib/loaders/css.js
@@ -12,6 +12,7 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
@@ -41,13 +42,16 @@ export default {
             // is used, we set it to 1, so that postcss-loader is applied
             // to @import resources.
             importLoaders: usePostCssLoader ? 1 : 0,
-            modules: modulesConfig
+            modules: modulesConfig,
         };
 
         const cssLoaders = [
             {
                 loader: fileURLToPath(import.meta.resolve('css-loader')),
-                options: applyOptionsCallback(webpackConfig.cssLoaderConfigurationCallback, options)
+                options: applyOptionsCallback(
+                    webpackConfig.cssLoaderConfigurationCallback,
+                    options
+                ),
             },
         ];
 
@@ -55,15 +59,18 @@ export default {
             loaderFeatures.ensurePackagesExistAndAreCorrectVersion('postcss');
 
             const postCssLoaderOptions = {
-                sourceMap: webpackConfig.useSourceMaps
+                sourceMap: webpackConfig.useSourceMaps,
             };
 
             cssLoaders.push({
                 loader: fileURLToPath(import.meta.resolve('postcss-loader')),
-                options: applyOptionsCallback(webpackConfig.postCssLoaderOptionsCallback, postCssLoaderOptions)
+                options: applyOptionsCallback(
+                    webpackConfig.postCssLoaderOptionsCallback,
+                    postCssLoaderOptions
+                ),
             });
         }
 
         return cssLoaders;
-    }
+    },
 };

--- a/lib/loaders/handlebars.js
+++ b/lib/loaders/handlebars.js
@@ -12,6 +12,7 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
@@ -28,8 +29,11 @@ export default {
         return [
             {
                 loader: fileURLToPath(import.meta.resolve('handlebars-loader')),
-                options: applyOptionsCallback(webpackConfig.handlebarsConfigurationCallback, options)
-            }
+                options: applyOptionsCallback(
+                    webpackConfig.handlebarsConfigurationCallback,
+                    options
+                ),
+            },
         ];
-    }
+    },
 };

--- a/lib/loaders/less.js
+++ b/lib/loaders/less.js
@@ -12,9 +12,10 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
-import cssLoader from './css.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import cssLoader from './css.js';
 
 export default {
     /**
@@ -26,15 +27,15 @@ export default {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('less');
 
         const config = {
-            sourceMap: webpackConfig.useSourceMaps
+            sourceMap: webpackConfig.useSourceMaps,
         };
 
         return [
             ...cssLoader.getLoaders(webpackConfig, useCssModules),
             {
                 loader: fileURLToPath(import.meta.resolve('less-loader')),
-                options: applyOptionsCallback(webpackConfig.lessLoaderOptionsCallback, config)
+                options: applyOptionsCallback(webpackConfig.lessLoaderOptionsCallback, config),
             },
         ];
-    }
+    },
 };

--- a/lib/loaders/sass.js
+++ b/lib/loaders/sass.js
@@ -12,9 +12,10 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
-import cssLoader from './css.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import cssLoader from './css.js';
 
 export default {
     /**
@@ -34,27 +35,32 @@ export default {
                 loader: fileURLToPath(import.meta.resolve('resolve-url-loader')),
                 options: Object.assign(
                     {
-                        sourceMap: webpackConfig.useSourceMaps
+                        sourceMap: webpackConfig.useSourceMaps,
                     },
                     webpackConfig.sassOptions.resolveUrlLoaderOptions
-                )
+                ),
             });
         }
 
-        const config = Object.assign({}, {
-            // needed by the resolve-url-loader
-            sourceMap: (true === webpackConfig.sassOptions.resolveUrlLoader) || webpackConfig.useSourceMaps,
-            sassOptions: {
-                // CSS minification is handled with mini-css-extract-plugin
-                outputStyle: 'expanded'
+        const config = Object.assign(
+            {},
+            {
+                // needed by the resolve-url-loader
+                sourceMap:
+                    true === webpackConfig.sassOptions.resolveUrlLoader ||
+                    webpackConfig.useSourceMaps,
+                sassOptions: {
+                    // CSS minification is handled with mini-css-extract-plugin
+                    outputStyle: 'expanded',
+                },
             }
-        });
+        );
 
         sassLoaders.push({
             loader: fileURLToPath(import.meta.resolve('sass-loader')),
-            options: applyOptionsCallback(webpackConfig.sassLoaderOptionsCallback, config)
+            options: applyOptionsCallback(webpackConfig.sassLoaderOptionsCallback, config),
         });
 
         return sassLoaders;
-    }
+    },
 };

--- a/lib/loaders/stylus.js
+++ b/lib/loaders/stylus.js
@@ -12,9 +12,10 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
-import cssLoader from './css.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import cssLoader from './css.js';
 
 export default {
     /**
@@ -26,15 +27,15 @@ export default {
         loaderFeatures.ensurePackagesExistAndAreCorrectVersion('stylus');
 
         const config = {
-            sourceMap: webpackConfig.useSourceMaps
+            sourceMap: webpackConfig.useSourceMaps,
         };
 
         return [
             ...cssLoader.getLoaders(webpackConfig, useCssModules),
             {
                 loader: fileURLToPath(import.meta.resolve('stylus-loader')),
-                options: applyOptionsCallback(webpackConfig.stylusLoaderOptionsCallback, config)
+                options: applyOptionsCallback(webpackConfig.stylusLoaderOptionsCallback, config),
             },
         ];
-    }
+    },
 };

--- a/lib/loaders/typescript.js
+++ b/lib/loaders/typescript.js
@@ -12,9 +12,10 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
-import babelLoader from './babel.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import babelLoader from './babel.js';
 
 export default {
     /**
@@ -39,7 +40,8 @@ export default {
             config.transpileOnly = true;
 
             // add forked ts types plugin to the stack
-            const { default: forkedTypesPluginUtil } = await import('../plugins/forked-ts-types.js');
+            const { default: forkedTypesPluginUtil } =
+                await import('../plugins/forked-ts-types.js');
             forkedTypesPluginUtil(webpackConfig);
         }
 
@@ -55,8 +57,8 @@ export default {
             {
                 loader: fileURLToPath(import.meta.resolve('ts-loader')),
                 // @see https://github.com/TypeStrong/ts-loader/blob/master/README.md#available-options
-                options: config
-            }
+                options: config,
+            },
         ]);
-    }
+    },
 };

--- a/lib/loaders/vue.js
+++ b/lib/loaders/vue.js
@@ -12,6 +12,7 @@
  */
 
 import { fileURLToPath } from 'url';
+
 import loaderFeatures from '../features.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 import getVueVersion from '../utils/get-vue-version.js';
@@ -30,8 +31,8 @@ export default {
         return [
             {
                 loader: fileURLToPath(import.meta.resolve('vue-loader')),
-                options: applyOptionsCallback(webpackConfig.vueLoaderOptionsCallback, options)
-            }
+                options: applyOptionsCallback(webpackConfig.vueLoaderOptionsCallback, options),
+            },
         ];
-    }
+    },
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,14 +11,14 @@ import pc from 'picocolors';
 
 const defaultConfig = {
     isVerbose: false,
-    quiet: false
+    quiet: false,
 };
 
 /** @type {Record<'debug'|'recommendation'|'warning'|'deprecation', Array<string>>} */
 let messages;
 let config = {};
 
-const reset = function() {
+const reset = function () {
     messages = {
         debug: [],
         recommendation: [],
@@ -81,5 +81,5 @@ export default {
 
     reset() {
         reset();
-    }
+    },
 };

--- a/lib/package-helper.js
+++ b/lib/package-helper.js
@@ -7,16 +7,21 @@
  * file that was distributed with this source code.
  */
 
-import { createRequire } from 'module';
-import pc from 'picocolors';
 import fs from 'fs';
-import logger from './logger.js';
+import { createRequire } from 'module';
+
+import pc from 'picocolors';
 import semver from 'semver';
+
+import logger from './logger.js';
 
 const require = createRequire(import.meta.url);
 
 function ensurePackagesExist(packagesConfig, requestedFeature) {
-    const missingPackagesRecommendation = getMissingPackageRecommendations(packagesConfig, requestedFeature);
+    const missingPackagesRecommendation = getMissingPackageRecommendations(
+        packagesConfig,
+        requestedFeature
+    );
 
     if (missingPackagesRecommendation) {
         throw `
@@ -102,8 +107,8 @@ function getMissingPackageRecommendations(packagesConfig, requestedFeature = nul
         return;
     }
 
-    const missingPackageNamesPicocolorsed = missingPackageConfigs.map(function(packageConfigs) {
-        const packageNames = packageConfigs.map(packageConfig => {
+    const missingPackageNamesPicocolorsed = missingPackageConfigs.map(function (packageConfigs) {
+        const packageNames = packageConfigs.map((packageConfig) => {
             return pc.green(packageConfig.name);
         });
 
@@ -125,7 +130,7 @@ function getMissingPackageRecommendations(packagesConfig, requestedFeature = nul
 
     return {
         message,
-        installCommand
+        installCommand,
     };
 }
 
@@ -160,11 +165,11 @@ function getInvalidPackageVersionRecommendations(packagesConfig) {
 
         if (semver.gtr(version, packageConfig.version)) {
             return [
-                `Webpack Encore requires version ${pc.green(packageConfig.version)} of ${pc.green(packageConfig.name)}. Your version ${pc.green(version)} is too new. The related feature *may* still work properly. If you have issues, try downgrading the library, or upgrading Encore.`
+                `Webpack Encore requires version ${pc.green(packageConfig.version)} of ${pc.green(packageConfig.name)}. Your version ${pc.green(version)} is too new. The related feature *may* still work properly. If you have issues, try downgrading the library, or upgrading Encore.`,
             ];
         } else {
             return [
-                `Webpack Encore requires version ${pc.green(packageConfig.version)} of ${pc.green(packageConfig.name)}, but your version (${pc.green(version)}) is too old. The related feature will probably *not* work correctly.`
+                `Webpack Encore requires version ${pc.green(packageConfig.version)} of ${pc.green(packageConfig.name)}, but your version (${pc.green(version)}) is too old. The related feature will probably *not* work correctly.`,
             ];
         }
     };
@@ -183,7 +188,9 @@ function addPackagesVersionConstraint(packages) {
 
         if (packageData.enforce_version) {
             if (!packageJsonData.devDependencies) {
-                logger.warning('Could not find devDependencies key on @symfony/webpack-encore package');
+                logger.warning(
+                    'Could not find devDependencies key on @symfony/webpack-encore package'
+                );
 
                 return newData;
             }

--- a/lib/plugins/asset-output-display.js
+++ b/lib/plugins/asset-output-display.js
@@ -27,7 +27,7 @@ import PluginPriorities from './plugin-priorities.js';
  * @param {FriendlyErrorsWebpackPlugin} friendlyErrorsPlugin
  * @returns {void}
  */
-export default function(plugins, webpackConfig, friendlyErrorsPlugin) {
+export default function (plugins, webpackConfig, friendlyErrorsPlugin) {
     if (webpackConfig.useDevServer()) {
         return;
     }
@@ -35,6 +35,6 @@ export default function(plugins, webpackConfig, friendlyErrorsPlugin) {
     const outputPath = pathUtil.getRelativeOutputPath(webpackConfig);
     plugins.push({
         plugin: new AssetOutputDisplayPlugin(outputPath, friendlyErrorsPlugin),
-        priority: PluginPriorities.AssetOutputDisplayPlugin
+        priority: PluginPriorities.AssetOutputDisplayPlugin,
     });
 }

--- a/lib/plugins/define.js
+++ b/lib/plugins/define.js
@@ -12,25 +12,24 @@
  */
 
 import webpack from 'webpack';
-import PluginPriorities from './plugin-priorities.js';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
+export default function (plugins, webpackConfig) {
     const definePluginOptions = {
-        'process.env.NODE_ENV': webpackConfig.isProduction()
-            ? '"production"'
-            : '"development"',
+        'process.env.NODE_ENV': webpackConfig.isProduction() ? '"production"' : '"development"',
     };
 
     plugins.push({
         plugin: new webpack.DefinePlugin(
             applyOptionsCallback(webpackConfig.definePluginOptionsCallback, definePluginOptions)
         ),
-        priority: PluginPriorities.DefinePlugin
+        priority: PluginPriorities.DefinePlugin,
     });
 }

--- a/lib/plugins/delete-unused-entries.js
+++ b/lib/plugins/delete-unused-entries.js
@@ -11,17 +11,17 @@
  * @import WebpackConfig from '../WebpackConfig.js'
  */
 
+import copyEntryTmpName from '../utils/copyEntryTmpName.js';
 import DeleteUnusedEntriesJSPlugin from '../webpack/delete-unused-entries-js-plugin.js';
 import PluginPriorities from './plugin-priorities.js';
-import copyEntryTmpName from '../utils/copyEntryTmpName.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
-    const entries = [... webpackConfig.styleEntries.keys()];
+export default function (plugins, webpackConfig) {
+    const entries = [...webpackConfig.styleEntries.keys()];
 
     if (webpackConfig.copyFilesConfigs.length > 0) {
         entries.push(copyEntryTmpName);
@@ -29,6 +29,6 @@ export default function(plugins, webpackConfig) {
 
     plugins.push({
         plugin: new DeleteUnusedEntriesJSPlugin(entries),
-        priority: PluginPriorities.DeleteUnusedEntriesJSPlugin
+        priority: PluginPriorities.DeleteUnusedEntriesJSPlugin,
     });
 }

--- a/lib/plugins/entry-files-manifest.js
+++ b/lib/plugins/entry-files-manifest.js
@@ -11,21 +11,21 @@
  * @import WebpackConfig from '../WebpackConfig.js'
  */
 
-import PluginPriorities from './plugin-priorities.js';
 import { EntryPointsPlugin } from '../webpack/entry-points-plugin.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
+export default function (plugins, webpackConfig) {
     plugins.push({
         plugin: new EntryPointsPlugin({
             publicPath: webpackConfig.getRealPublicPath(),
             outputPath: webpackConfig.outputPath,
-            integrityAlgorithms: webpackConfig.integrityAlgorithms
+            integrityAlgorithms: webpackConfig.integrityAlgorithms,
         }),
-        priority: PluginPriorities.EntryPointsPlugin
+        priority: PluginPriorities.EntryPointsPlugin,
     });
 }

--- a/lib/plugins/forked-ts-types.js
+++ b/lib/plugins/forked-ts-types.js
@@ -12,14 +12,15 @@
  */
 
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-import PluginPriorities from './plugin-priorities.js';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     const config = {};
 
     webpackConfig.addPlugin(

--- a/lib/plugins/friendly-errors.js
+++ b/lib/plugins/friendly-errors.js
@@ -12,37 +12,41 @@
  */
 
 import FriendlyErrorsWebpackPlugin from '@kocal/friendly-errors-webpack-plugin';
-import missingCssFileTransformer from '../friendly-errors/transformers/missing-css-file.js';
+
 import missingCssFileFormatter from '../friendly-errors/formatters/missing-css-file.js';
-import missingLoaderTransformerFactory from '../friendly-errors/transformers/missing-loader.js';
 import missingLoaderFormatter from '../friendly-errors/formatters/missing-loader.js';
-import missingPostCssConfigTransformer from '../friendly-errors/transformers/missing-postcss-config.js';
 import missingPostCssConfigFormatter from '../friendly-errors/formatters/missing-postcss-config.js';
+import missingCssFileTransformer from '../friendly-errors/transformers/missing-css-file.js';
+import missingLoaderTransformerFactory from '../friendly-errors/transformers/missing-loader.js';
+import missingPostCssConfigTransformer from '../friendly-errors/transformers/missing-postcss-config.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @returns {FriendlyErrorsWebpackPlugin}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     const friendlyErrorsPluginOptions = {
         clearConsole: false,
         additionalTransformers: [
             missingCssFileTransformer,
             missingLoaderTransformerFactory(webpackConfig),
-            missingPostCssConfigTransformer
+            missingPostCssConfigTransformer,
         ],
         additionalFormatters: [
             missingCssFileFormatter,
             missingLoaderFormatter,
-            missingPostCssConfigFormatter
+            missingPostCssConfigFormatter,
         ],
         compilationSuccessInfo: {
-            messages: []
-        }
+            messages: [],
+        },
     };
 
     return new FriendlyErrorsWebpackPlugin(
-        applyOptionsCallback(webpackConfig.friendlyErrorsPluginOptionsCallback, friendlyErrorsPluginOptions)
+        applyOptionsCallback(
+            webpackConfig.friendlyErrorsPluginOptionsCallback,
+            friendlyErrorsPluginOptions
+        )
     );
 }

--- a/lib/plugins/manifest.js
+++ b/lib/plugins/manifest.js
@@ -12,17 +12,18 @@
  */
 
 import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
-import PluginPriorities from './plugin-priorities.js';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 import copyEntryTmpName from '../utils/copyEntryTmpName.js';
 import manifestKeyPrefixHelper from '../utils/manifest-key-prefix-helper.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
+export default function (plugins, webpackConfig) {
     let manifestPluginOptions = {
         seed: {},
         basePath: manifestKeyPrefixHelper(webpackConfig),
@@ -34,7 +35,7 @@ export default function(plugins, webpackConfig) {
             const isJsOrJsMapFile = /\.js(\.map)?$/.test(file.name);
 
             return !isCopyEntry && !(isStyleEntry && isJsOrJsMapFile);
-        }
+        },
     };
 
     manifestPluginOptions = applyOptionsCallback(
@@ -57,6 +58,6 @@ export default function(plugins, webpackConfig) {
 
     plugins.push({
         plugin: new WebpackManifestPlugin(manifestPluginOptions),
-        priority: PluginPriorities.WebpackManifestPlugin
+        priority: PluginPriorities.WebpackManifestPlugin,
     });
 }

--- a/lib/plugins/mini-css-extract.js
+++ b/lib/plugins/mini-css-extract.js
@@ -12,15 +12,16 @@
  */
 
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import PluginPriorities from './plugin-priorities.js';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
+export default function (plugins, webpackConfig) {
     // Don't add the plugin if CSS extraction is disabled
     if (!webpackConfig.extractCss) {
         return;
@@ -48,7 +49,7 @@ export default function(plugins, webpackConfig) {
 
     const miniCssPluginOptions = {
         filename: filename,
-        chunkFilename: chunkFilename
+        chunkFilename: chunkFilename,
     };
 
     plugins.push({
@@ -58,6 +59,6 @@ export default function(plugins, webpackConfig) {
                 miniCssPluginOptions
             )
         ),
-        priority: PluginPriorities.MiniCssExtractPlugin
+        priority: PluginPriorities.MiniCssExtractPlugin,
     });
 }

--- a/lib/plugins/notifier.js
+++ b/lib/plugins/notifier.js
@@ -12,15 +12,15 @@
  */
 
 import pluginFeatures from '../features.js';
-import PluginPriorities from './plugin-priorities.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
+import PluginPriorities from './plugin-priorities.js';
 
 /**
  * @param {Array} plugins
  * @param {WebpackConfig} webpackConfig
  * @returns {Promise<void>}
  */
-export default async function(plugins, webpackConfig) {
+export default async function (plugins, webpackConfig) {
     if (!webpackConfig.useWebpackNotifier) {
         return;
     }
@@ -28,7 +28,7 @@ export default async function(plugins, webpackConfig) {
     pluginFeatures.ensurePackagesExistAndAreCorrectVersion('notifier');
 
     const notifierPluginOptions = {
-        title: 'Webpack Encore'
+        title: 'Webpack Encore',
     };
 
     const { default: WebpackNotifier } = await import('webpack-notifier');
@@ -36,6 +36,6 @@ export default async function(plugins, webpackConfig) {
         plugin: new WebpackNotifier(
             applyOptionsCallback(webpackConfig.notifierPluginOptionsCallback, notifierPluginOptions)
         ),
-        priority: PluginPriorities.WebpackNotifier
+        priority: PluginPriorities.WebpackNotifier,
     });
 }

--- a/lib/plugins/optimize-css-assets.js
+++ b/lib/plugins/optimize-css-assets.js
@@ -12,16 +12,20 @@
  */
 
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @returns {object}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     const minimizerPluginOptions = {};
 
     return new CssMinimizerPlugin(
-        applyOptionsCallback(webpackConfig.cssMinimizerPluginOptionsCallback, minimizerPluginOptions)
+        applyOptionsCallback(
+            webpackConfig.cssMinimizerPluginOptionsCallback,
+            minimizerPluginOptions
+        )
     );
 }

--- a/lib/plugins/terser.js
+++ b/lib/plugins/terser.js
@@ -12,13 +12,14 @@
  */
 
 import TerserPlugin from 'terser-webpack-plugin';
+
 import applyOptionsCallback from '../utils/apply-options-callback.js';
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @returns {object}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     const terserPluginOptions = {
         parallel: true,
     };

--- a/lib/plugins/variable-provider.js
+++ b/lib/plugins/variable-provider.js
@@ -12,6 +12,7 @@
  */
 
 import webpack from 'webpack';
+
 import PluginPriorities from './plugin-priorities.js';
 
 /**
@@ -19,11 +20,11 @@ import PluginPriorities from './plugin-priorities.js';
  * @param {WebpackConfig} webpackConfig
  * @returns {void}
  */
-export default function(plugins, webpackConfig) {
+export default function (plugins, webpackConfig) {
     if (Object.keys(webpackConfig.providedVariables).length > 0) {
         plugins.push({
             plugin: new webpack.ProvidePlugin(webpackConfig.providedVariables),
-            priority: PluginPriorities.ProvidePlugin
+            priority: PluginPriorities.ProvidePlugin,
         });
     }
 }

--- a/lib/plugins/vue.js
+++ b/lib/plugins/vue.js
@@ -18,7 +18,7 @@ import PluginPriorities from './plugin-priorities.js';
  * @param {WebpackConfig} webpackConfig
  * @returns {Promise<void>}
  */
-export default async function(plugins, webpackConfig) {
+export default async function (plugins, webpackConfig) {
     if (!webpackConfig.useVueLoader) {
         return;
     }
@@ -27,6 +27,6 @@ export default async function(plugins, webpackConfig) {
 
     plugins.push({
         plugin: new VueLoaderPlugin(),
-        priority: PluginPriorities.VueLoaderPlugin
+        priority: PluginPriorities.VueLoaderPlugin,
     });
 }

--- a/lib/utils/apply-options-callback.js
+++ b/lib/utils/apply-options-callback.js
@@ -18,7 +18,7 @@
  * @param {T} options
  * @returns {T}
  */
-export default function(optionsCallback, options) {
+export default function (optionsCallback, options) {
     const result = optionsCallback.call(options, options);
 
     if (typeof result === 'object') {

--- a/lib/utils/get-file-extension.js
+++ b/lib/utils/get-file-extension.js
@@ -10,7 +10,7 @@
 import path from 'path';
 import url from 'url';
 
-export default function(filename) {
+export default function (filename) {
     const parsedFilename = new url.URL(filename, 'http://foo');
     const extension = path.extname(parsedFilename.pathname);
     return extension ? extension.slice(1) : '';

--- a/lib/utils/get-vue-version.js
+++ b/lib/utils/get-vue-version.js
@@ -11,15 +11,16 @@
  * @import WebpackConfig from '../WebpackConfig.js'
  */
 
-import packageHelper from '../package-helper.js';
 import semver from 'semver';
+
 import logger from '../logger.js';
+import packageHelper from '../package-helper.js';
 
 /**
  * @param {WebpackConfig} webpackConfig
  * @returns {number|string|null}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     if (webpackConfig.vueOptions.version !== null) {
         return webpackConfig.vueOptions.version;
     }
@@ -39,11 +40,15 @@ export default function(webpackConfig) {
     }
 
     if (semver.satisfies(vueVersion, '^2')) {
-        throw new Error('The support for Vue 2 has been removed.' +
-            ' Please upgrade to Vue 3, and if necessary remove the "version" setting, or set it to 3 when calling ".enableVueLoader()".');
+        throw new Error(
+            'The support for Vue 2 has been removed.' +
+                ' Please upgrade to Vue 3, and if necessary remove the "version" setting, or set it to 3 when calling ".enableVueLoader()".'
+        );
     }
 
-    logger.warning(`Your version of vue "${vueVersion}" is newer than this version of Encore supports and may or may not function properly.`);
+    logger.warning(
+        `Your version of vue "${vueVersion}" is newer than this version of Encore supports and may or may not function properly.`
+    );
 
     return 3;
 }

--- a/lib/utils/manifest-key-prefix-helper.js
+++ b/lib/utils/manifest-key-prefix-helper.js
@@ -17,7 +17,7 @@
  * @param {WebpackConfig} webpackConfig
  * @returns {string}
  */
-export default function(webpackConfig) {
+export default function (webpackConfig) {
     let manifestPrefix = webpackConfig.manifestKeyPrefix;
     if (null === manifestPrefix) {
         if (null === webpackConfig.publicPath) {

--- a/lib/utils/package-up.js
+++ b/lib/utils/package-up.js
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'url';
  * @param {string} options.cwd The directory to start searching from.
  * @returns {string|undefined} The path to the nearest package.json file or undefined if not found.
  */
-export default function({ cwd }) {
+export default function ({ cwd }) {
     return findUpSync('package.json', { cwd });
 }
 

--- a/lib/utils/pretty-error.js
+++ b/lib/utils/pretty-error.js
@@ -26,13 +26,13 @@ const PrettyError = require('pretty-error');
  * @param {object} options
  * @returns {void}
  */
-export default function(error, options = {}) {
+export default function (error, options = {}) {
     const pe = new PrettyError();
 
     // Use the default terminal's color
     // for the error message.
     pe.appendStyle({
-        'pretty-error > header > message': { color: 'none' }
+        'pretty-error > header > message': { color: 'none' },
     });
 
     // Allow to skip some parts of the

--- a/lib/webpack/copy-files-loader.js
+++ b/lib/webpack/copy-files-loader.js
@@ -73,10 +73,9 @@ export default function loader(source) {
     // The "source" part of the regexp is base64 encoded
     // in case it contains characters that don't work with
     // the "inline loader" syntax
-    const pattern = options.regExp || new RegExp(
-        Buffer.from(options.patternSource, 'base64').toString(),
-        options.patternFlags
-    );
+    const pattern =
+        options.regExp ||
+        new RegExp(Buffer.from(options.patternSource, 'base64').toString(), options.patternFlags);
 
     // If the pattern does not match the resource's path
     // it probably means that the import was resolved using the

--- a/lib/webpack/delete-unused-entries-js-plugin.js
+++ b/lib/webpack/delete-unused-entries-js-plugin.js
@@ -10,7 +10,7 @@
 function DeleteUnusedEntriesJSPlugin(entriesToDelete = []) {
     this.entriesToDelete = entriesToDelete;
 }
-DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
+DeleteUnusedEntriesJSPlugin.prototype.apply = function (compiler) {
     const deleteEntries = (compilation) => {
         // loop over output chunks
         compilation.chunks.forEach((chunk) => {
@@ -31,7 +31,7 @@ DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
 
                 // then also look in auxiliary files for source maps
                 for (const filename of Array.from(chunk.auxiliaryFiles)) {
-                    if (removedFiles.map(name => `${name}.map`).includes(`${filename}`)) {
+                    if (removedFiles.map((name) => `${name}.map`).includes(`${filename}`)) {
                         removedFiles.push(filename);
                         // remove the output file
                         compilation.deleteAsset(filename);
@@ -44,19 +44,18 @@ DeleteUnusedEntriesJSPlugin.prototype.apply = function(compiler) {
                 // if there's some edge case where more .js files
                 // or 0 .js files might be deleted, I'd rather error
                 if (removedFiles.length === 0 || removedFiles.length > 2) {
-                    throw new Error(`Problem deleting JS entry for ${chunk.name}: ${removedFiles.length} files were deleted (${removedFiles.join(', ')})`);
+                    throw new Error(
+                        `Problem deleting JS entry for ${chunk.name}: ${removedFiles.length} files were deleted (${removedFiles.join(', ')})`
+                    );
                 }
             }
         });
     };
 
-    compiler.hooks.compilation.tap('DeleteUnusedEntriesJSPlugin', function(compilation) {
-        compilation.hooks.additionalAssets.tap(
-            'DeleteUnusedEntriesJsPlugin',
-            function() {
-                deleteEntries(compilation);
-            }
-        );
+    compiler.hooks.compilation.tap('DeleteUnusedEntriesJSPlugin', function (compilation) {
+        compilation.hooks.additionalAssets.tap('DeleteUnusedEntriesJsPlugin', function () {
+            deleteEntries(compilation);
+        });
     });
 };
 

--- a/lib/webpack/entry-points-plugin.js
+++ b/lib/webpack/entry-points-plugin.js
@@ -7,9 +7,10 @@
  * file that was distributed with this source code.
  */
 
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import crypto from 'crypto';
+
 import copyEntryTmpName from '../utils/copyEntryTmpName.js';
 
 /**
@@ -29,11 +30,7 @@ export class EntryPointsPlugin {
      * @param {string} options.outputPath The output path of the assets, from where they are saved
      * @param {Array<string>} options.integrityAlgorithms The algorithms to use for the integrity hash
      */
-    constructor({
-        publicPath,
-        outputPath,
-        integrityAlgorithms
-    }) {
+    constructor({ publicPath, outputPath, integrityAlgorithms }) {
         this.publicPath = publicPath;
         this.outputPath = outputPath;
         this.integrityAlgorithms = integrityAlgorithms;
@@ -43,96 +40,102 @@ export class EntryPointsPlugin {
      * @param {import('webpack').Compiler} compiler
      */
     apply(compiler) {
-        compiler.hooks.afterEmit.tapAsync({ name: 'EntryPointsPlugin' }, (compilation, callback) => {
-            const manifest = {
-                entrypoints: {},
-            };
+        compiler.hooks.afterEmit.tapAsync(
+            { name: 'EntryPointsPlugin' },
+            (compilation, callback) => {
+                const manifest = {
+                    entrypoints: {},
+                };
 
-            const stats = compilation.getStats().toJson({
-                assets: true,
-                moduleAssets: true,
-                relatedAssets: false,
-                chunkGroupAuxiliary: false,
-                chunks: false,
-                modules: false,
-                timings: false,
-                logging: false,
-                errorDetails: false,
-            });
+                const stats = compilation.getStats().toJson({
+                    assets: true,
+                    moduleAssets: true,
+                    relatedAssets: false,
+                    chunkGroupAuxiliary: false,
+                    chunks: false,
+                    modules: false,
+                    timings: false,
+                    logging: false,
+                    errorDetails: false,
+                });
 
-            for (const [entryName, entry] of Object.entries(stats.entrypoints)) {
-                // We don't want to include the temporary entry in the manifest
-                if (entryName === copyEntryTmpName) {
-                    continue;
-                }
-
-                manifest.entrypoints[entryName] = {};
-
-                for (const asset of entry.assets) {
-                    // We don't want to include hot-update files in the manifest
-                    if (asset.name.includes('.hot-update.')) {
+                for (const [entryName, entry] of Object.entries(stats.entrypoints)) {
+                    // We don't want to include the temporary entry in the manifest
+                    if (entryName === copyEntryTmpName) {
                         continue;
                     }
 
-                    const fileExtension = getFileExtension(asset.name);
-                    const assetPath = this.publicPath.slice(-1) === '/'
-                        ? `${this.publicPath}${asset.name}`
-                        : `${this.publicPath}/${asset.name}`;
+                    manifest.entrypoints[entryName] = {};
 
-                    if (!(fileExtension in manifest.entrypoints[entryName])) {
-                        manifest.entrypoints[entryName][fileExtension] = [];
+                    for (const asset of entry.assets) {
+                        // We don't want to include hot-update files in the manifest
+                        if (asset.name.includes('.hot-update.')) {
+                            continue;
+                        }
+
+                        const fileExtension = getFileExtension(asset.name);
+                        const assetPath =
+                            this.publicPath.slice(-1) === '/'
+                                ? `${this.publicPath}${asset.name}`
+                                : `${this.publicPath}/${asset.name}`;
+
+                        if (!(fileExtension in manifest.entrypoints[entryName])) {
+                            manifest.entrypoints[entryName][fileExtension] = [];
+                        }
+
+                        manifest.entrypoints[entryName][fileExtension].push(assetPath);
                     }
-
-                    manifest.entrypoints[entryName][fileExtension].push(assetPath);
                 }
-            }
 
-            if (this.integrityAlgorithms.length > 0) {
-                manifest.integrity = {};
+                if (this.integrityAlgorithms.length > 0) {
+                    manifest.integrity = {};
 
-                for (const entryName in manifest.entrypoints) {
-                    for (const fileType in manifest.entrypoints[entryName]) {
-                        for (const asset of manifest.entrypoints[entryName][fileType]) {
-                            if (asset in manifest.integrity) {
-                                continue;
-                            }
-
-                            // Drop query string if any
-                            const assetNormalized = asset.includes('?') ? asset.split('?')[0] : asset;
-                            if (assetNormalized in manifest.integrity) {
-                                continue;
-                            }
-
-                            const filePath = path.resolve(
-                                this.outputPath,
-                                assetNormalized.replace(this.publicPath, ''),
-                            );
-
-                            if (fs.existsSync(filePath)) {
-                                const fileHashes = [];
-
-                                for (const algorithm of this.integrityAlgorithms) {
-                                    const hash = crypto.createHash(algorithm);
-                                    const fileContent = fs.readFileSync(filePath, 'utf8');
-                                    hash.update(fileContent, 'utf8');
-
-                                    fileHashes.push(`${algorithm}-${hash.digest('base64')}`);
+                    for (const entryName in manifest.entrypoints) {
+                        for (const fileType in manifest.entrypoints[entryName]) {
+                            for (const asset of manifest.entrypoints[entryName][fileType]) {
+                                if (asset in manifest.integrity) {
+                                    continue;
                                 }
 
-                                manifest.integrity[asset] = fileHashes.join(' ');
+                                // Drop query string if any
+                                const assetNormalized = asset.includes('?')
+                                    ? asset.split('?')[0]
+                                    : asset;
+                                if (assetNormalized in manifest.integrity) {
+                                    continue;
+                                }
+
+                                const filePath = path.resolve(
+                                    this.outputPath,
+                                    assetNormalized.replace(this.publicPath, '')
+                                );
+
+                                if (fs.existsSync(filePath)) {
+                                    const fileHashes = [];
+
+                                    for (const algorithm of this.integrityAlgorithms) {
+                                        const hash = crypto.createHash(algorithm);
+                                        const fileContent = fs.readFileSync(filePath, 'utf8');
+                                        hash.update(fileContent, 'utf8');
+
+                                        fileHashes.push(`${algorithm}-${hash.digest('base64')}`);
+                                    }
+
+                                    manifest.integrity[asset] = fileHashes.join(' ');
+                                }
                             }
                         }
                     }
                 }
+
+                fs.writeFileSync(
+                    path.join(this.outputPath, 'entrypoints.json'),
+                    JSON.stringify(manifest, null, 2),
+                    { flag: 'w' }
+                );
+
+                callback();
             }
-
-            fs.writeFileSync(
-                path.join(this.outputPath, 'entrypoints.json'),
-                JSON.stringify(manifest, null, 2),
-                { flag: 'w' },
-            );
-
-            callback();
-        });
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,224 +1,227 @@
 {
-  "name": "@symfony/webpack-encore",
-  "version": "6.0.0",
-  "description": "Webpack Encore is a simpler way to integrate Webpack into your application",
-  "type": "module",
-  "exports": {
-    ".": "./index.js",
-    "./lib/plugins/plugin-priorities.js": "./lib/plugins/plugin-priorities.js"
-  },
-  "scripts": {
-    "test": "vitest run",
-    "lint": "eslint lib test index.js eslint.config.js --report-unused-disable-directives --max-warnings=0"
-  },
-  "bin": {
-    "encore": "bin/encore.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/symfony/webpack-encore.git"
-  },
-  "author": "Ryan Weaver <ryan@knpuniversity.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/symfony/webpack-encore/issues"
-  },
-  "engines": {
-    "node": "^22.13.0 || >=24.0"
-  },
-  "homepage": "https://github.com/symfony/webpack-encore",
-  "dependencies": {
-    "@kocal/friendly-errors-webpack-plugin": "^3.0.0",
-    "babel-loader": "^10.0.0",
-    "css-loader": "^7.1.0",
-    "css-minimizer-webpack-plugin": "^8.0.0",
-    "fastest-levenshtein": "^1.0.16",
-    "mini-css-extract-plugin": "^2.6.0",
-    "picocolors": "^1.1.0",
-    "pretty-error": "^4.0.0",
-    "resolve-url-loader": "^5.0.0",
-    "semver": "^7.3.2",
-    "style-loader": "^4.0.0",
-    "tapable": "^2.2.1",
-    "terser-webpack-plugin": "^5.3.0",
-    "tmp": "^0.2.5",
-    "webpack-manifest-plugin": "^5.0.1",
-    "yargs-parser": "^21.0.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.17.0",
-    "@babel/eslint-parser": "^7.17.0",
-    "@babel/plugin-transform-react-jsx": "^7.12.11",
-    "@babel/preset-env": "^7.16.0",
-    "@babel/preset-react": "^7.9.0",
-    "@babel/preset-typescript": "^7.0.0",
-    "@eslint/js": "^9.32.0",
-    "@hotwired/stimulus": "^3.0.0",
-    "@symfony/mock-module": "file:fixtures/stimulus/mock-module",
-    "@symfony/stimulus-bridge": "^3.0.0 || ^4.0.0",
-    "@vue/babel-plugin-jsx": "^1.0.0",
-    "@vue/compiler-sfc": "^3.0.2",
-    "autoprefixer": "^10.2.0",
-    "chai-fs": "^2.0.0",
-    "core-js": "^3.0.0",
-    "eslint": "^9.32.0",
-    "eslint-plugin-headers": "^1.3.3",
-    "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jsdoc": "^50.8.0",
-    "eslint-plugin-n": "^17.21.3",
-    "eslint-plugin-vitest": "^0.5.4",
-    "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
-    "fs-extra": "^10.0.0",
-    "get-port": "^7.2.0",
-    "globals": "^16.3.0",
-    "handlebars": "^4.7.7",
-    "handlebars-loader": "^1.7.0",
-    "http-server": "^14.1.0",
-    "less": "^4.0.0",
-    "less-loader": "^12.2.0",
-    "postcss": "^8.3.0",
-    "postcss-loader": "^8.1.1",
-    "preact": "^10.5.0",
-    "preact-compat": "^3.17.0",
-    "puppeteer": "^24.6.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "sass": "^1.17.0",
-    "sass-loader": "^16.0.1",
-    "strip-ansi": "^6.0.0",
-    "stylus": "^0.63.0",
-    "stylus-loader": "^8.1.0",
-    "svelte": "^3.50.0 || ^4.2.2 || ^5.0.0",
-    "svelte-loader": "^3.1.0",
-    "ts-loader": "^9.0.0",
-    "typescript": "^5.0.0",
-    "vitest": "^4.1.2",
-    "vue": "^3.2.14",
-    "vue-loader": "^17.0.0",
-    "webpack": "^5.82.0",
-    "webpack-cli": "^6.0.0 || ^7.0.0",
-    "webpack-dev-server": "^5.1.0",
-    "webpack-notifier": "^1.15.0"
-  },
-  "peerDependencies": {
-    "@babel/core": "^7.17.0",
-    "@babel/plugin-transform-react-jsx": "^7.12.11",
-    "@babel/preset-env": "^7.16.0",
-    "@babel/preset-react": "^7.9.0",
-    "@babel/preset-typescript": "^7.0.0",
-    "@symfony/stimulus-bridge": "^3.0.0 || ^4.0.0",
-    "@vue/babel-plugin-jsx": "^1.0.0",
-    "@vue/compiler-sfc": "^3.0.2",
-    "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
-    "handlebars": "^4.7.7",
-    "handlebars-loader": "^1.7.0",
-    "less": "^4.0.0",
-    "less-loader": "^12.2.0",
-    "postcss": "^8.3.0",
-    "postcss-loader": "^8.1.1",
-    "sass": "^1.17.0",
-    "sass-loader": "^16.0.1",
-    "stylus-loader": "^8.1.0",
-    "svelte": "^3.50.0 || ^4.2.2 || ^5.0.0",
-    "svelte-loader": "^3.1.0",
-    "ts-loader": "^9.0.0",
-    "typescript": "^5.0.0",
-    "vue": "^3.2.14",
-    "vue-loader": "^17.0.0",
-    "webpack": "^5.72",
-    "webpack-cli": "^6.0.0 || ^7.0.0",
-    "webpack-notifier": "^1.15.0"
-  },
-  "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": false
+    "name": "@symfony/webpack-encore",
+    "version": "6.0.0",
+    "description": "Webpack Encore is a simpler way to integrate Webpack into your application",
+    "type": "module",
+    "exports": {
+        ".": "./index.js",
+        "./lib/plugins/plugin-priorities.js": "./lib/plugins/plugin-priorities.js"
     },
-    "@babel/plugin-transform-react-jsx": {
-      "optional": true
+    "scripts": {
+        "test": "vitest run",
+        "lint": "eslint lib test index.js eslint.config.js --report-unused-disable-directives --max-warnings=0",
+        "fmt": "oxfmt",
+        "fmt:check": "oxfmt --check"
     },
-    "@babel/preset-env": {
-      "optional": false
+    "bin": {
+        "encore": "bin/encore.js"
     },
-    "@babel/preset-react": {
-      "optional": true
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/symfony/webpack-encore.git"
     },
-    "@babel/preset-typescript": {
-      "optional": true
+    "author": "Ryan Weaver <ryan@knpuniversity.com>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/symfony/webpack-encore/issues"
     },
-    "@symfony/stimulus-bridge": {
-      "optional": true
+    "engines": {
+        "node": "^22.13.0 || >=24.0"
     },
-    "@vue/babel-plugin-jsx": {
-      "optional": true
+    "homepage": "https://github.com/symfony/webpack-encore",
+    "dependencies": {
+        "@kocal/friendly-errors-webpack-plugin": "^3.0.0",
+        "babel-loader": "^10.0.0",
+        "css-loader": "^7.1.0",
+        "css-minimizer-webpack-plugin": "^8.0.0",
+        "fastest-levenshtein": "^1.0.16",
+        "mini-css-extract-plugin": "^2.6.0",
+        "picocolors": "^1.1.0",
+        "pretty-error": "^4.0.0",
+        "resolve-url-loader": "^5.0.0",
+        "semver": "^7.3.2",
+        "style-loader": "^4.0.0",
+        "tapable": "^2.2.1",
+        "terser-webpack-plugin": "^5.3.0",
+        "tmp": "^0.2.5",
+        "webpack-manifest-plugin": "^5.0.1",
+        "yargs-parser": "^21.0.0"
     },
-    "@vue/compiler-sfc": {
-      "optional": true
+    "devDependencies": {
+        "@babel/core": "^7.17.0",
+        "@babel/eslint-parser": "^7.17.0",
+        "@babel/plugin-transform-react-jsx": "^7.12.11",
+        "@babel/preset-env": "^7.16.0",
+        "@babel/preset-react": "^7.9.0",
+        "@babel/preset-typescript": "^7.0.0",
+        "@eslint/js": "^9.32.0",
+        "@hotwired/stimulus": "^3.0.0",
+        "@symfony/mock-module": "file:fixtures/stimulus/mock-module",
+        "@symfony/stimulus-bridge": "^3.0.0 || ^4.0.0",
+        "@vue/babel-plugin-jsx": "^1.0.0",
+        "@vue/compiler-sfc": "^3.0.2",
+        "autoprefixer": "^10.2.0",
+        "chai-fs": "^2.0.0",
+        "core-js": "^3.0.0",
+        "eslint": "^9.32.0",
+        "eslint-plugin-headers": "^1.3.3",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsdoc": "^50.8.0",
+        "eslint-plugin-n": "^17.21.3",
+        "eslint-plugin-vitest": "^0.5.4",
+        "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "fs-extra": "^10.0.0",
+        "get-port": "^7.2.0",
+        "globals": "^16.3.0",
+        "handlebars": "^4.7.7",
+        "handlebars-loader": "^1.7.0",
+        "http-server": "^14.1.0",
+        "less": "^4.0.0",
+        "less-loader": "^12.2.0",
+        "oxfmt": "^0.44.0",
+        "postcss": "^8.3.0",
+        "postcss-loader": "^8.1.1",
+        "preact": "^10.5.0",
+        "preact-compat": "^3.17.0",
+        "puppeteer": "^24.6.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "sass": "^1.17.0",
+        "sass-loader": "^16.0.1",
+        "strip-ansi": "^6.0.0",
+        "stylus": "^0.63.0",
+        "stylus-loader": "^8.1.0",
+        "svelte": "^3.50.0 || ^4.2.2 || ^5.0.0",
+        "svelte-loader": "^3.1.0",
+        "ts-loader": "^9.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.2",
+        "vue": "^3.2.14",
+        "vue-loader": "^17.0.0",
+        "webpack": "^5.82.0",
+        "webpack-cli": "^6.0.0 || ^7.0.0",
+        "webpack-dev-server": "^5.1.0",
+        "webpack-notifier": "^1.15.0"
     },
-    "fork-ts-checker-webpack-plugin": {
-      "optional": true
+    "peerDependencies": {
+        "@babel/core": "^7.17.0",
+        "@babel/plugin-transform-react-jsx": "^7.12.11",
+        "@babel/preset-env": "^7.16.0",
+        "@babel/preset-react": "^7.9.0",
+        "@babel/preset-typescript": "^7.0.0",
+        "@symfony/stimulus-bridge": "^3.0.0 || ^4.0.0",
+        "@vue/babel-plugin-jsx": "^1.0.0",
+        "@vue/compiler-sfc": "^3.0.2",
+        "fork-ts-checker-webpack-plugin": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "handlebars": "^4.7.7",
+        "handlebars-loader": "^1.7.0",
+        "less": "^4.0.0",
+        "less-loader": "^12.2.0",
+        "postcss": "^8.3.0",
+        "postcss-loader": "^8.1.1",
+        "sass": "^1.17.0",
+        "sass-loader": "^16.0.1",
+        "stylus-loader": "^8.1.0",
+        "svelte": "^3.50.0 || ^4.2.2 || ^5.0.0",
+        "svelte-loader": "^3.1.0",
+        "ts-loader": "^9.0.0",
+        "typescript": "^5.0.0",
+        "vue": "^3.2.14",
+        "vue-loader": "^17.0.0",
+        "webpack": "^5.72",
+        "webpack-cli": "^6.0.0 || ^7.0.0",
+        "webpack-notifier": "^1.15.0"
     },
-    "handlebars": {
-      "optional": true
+    "peerDependenciesMeta": {
+        "@babel/core": {
+            "optional": false
+        },
+        "@babel/plugin-transform-react-jsx": {
+            "optional": true
+        },
+        "@babel/preset-env": {
+            "optional": false
+        },
+        "@babel/preset-react": {
+            "optional": true
+        },
+        "@babel/preset-typescript": {
+            "optional": true
+        },
+        "@symfony/stimulus-bridge": {
+            "optional": true
+        },
+        "@vue/babel-plugin-jsx": {
+            "optional": true
+        },
+        "@vue/compiler-sfc": {
+            "optional": true
+        },
+        "fork-ts-checker-webpack-plugin": {
+            "optional": true
+        },
+        "handlebars": {
+            "optional": true
+        },
+        "handlebars-loader": {
+            "optional": true
+        },
+        "less": {
+            "optional": true
+        },
+        "less-loader": {
+            "optional": true
+        },
+        "postcss": {
+            "optional": true
+        },
+        "postcss-loader": {
+            "optional": true
+        },
+        "sass": {
+            "optional": true
+        },
+        "sass-loader": {
+            "optional": true
+        },
+        "stylus-loader": {
+            "optional": true
+        },
+        "svelte": {
+            "optional": true
+        },
+        "svelte-loader": {
+            "optional": true
+        },
+        "ts-loader": {
+            "optional": true
+        },
+        "typescript": {
+            "optional": true
+        },
+        "vue": {
+            "optional": true
+        },
+        "vue-loader": {
+            "optional": true
+        },
+        "webpack": {
+            "optional": false
+        },
+        "webpack-cli": {
+            "optional": false
+        },
+        "webpack-dev-server": {
+            "optional": true
+        },
+        "webpack-notifier": {
+            "optional": true
+        }
     },
-    "handlebars-loader": {
-      "optional": true
-    },
-    "less": {
-      "optional": true
-    },
-    "less-loader": {
-      "optional": true
-    },
-    "postcss": {
-      "optional": true
-    },
-    "postcss-loader": {
-      "optional": true
-    },
-    "sass": {
-      "optional": true
-    },
-    "sass-loader": {
-      "optional": true
-    },
-    "stylus-loader": {
-      "optional": true
-    },
-    "svelte": {
-      "optional": true
-    },
-    "svelte-loader": {
-      "optional": true
-    },
-    "ts-loader": {
-      "optional": true
-    },
-    "typescript": {
-      "optional": true
-    },
-    "vue": {
-      "optional": true
-    },
-    "vue-loader": {
-      "optional": true
-    },
-    "webpack": {
-      "optional": false
-    },
-    "webpack-cli": {
-      "optional": false
-    },
-    "webpack-dev-server": {
-      "optional": true
-    },
-    "webpack-notifier": {
-      "optional": true
-    }
-  },
-  "files": [
-    "lib/",
-    "bin/",
-    "index.js"
-  ],
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+    "files": [
+        "lib/",
+        "bin/",
+        "index.js"
+    ],
+    "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       less-loader:
         specifier: ^12.2.0
         version: 12.3.2(less@4.6.4)(webpack@5.105.4)
+      oxfmt:
+        specifier: ^0.44.0
+        version: 0.44.0
       postcss:
         specifier: ^8.3.0
         version: 8.5.8
@@ -1043,6 +1046,128 @@ packages:
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.44.0':
+    resolution: {integrity: sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.44.0':
+    resolution: {integrity: sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.44.0':
+    resolution: {integrity: sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.44.0':
+    resolution: {integrity: sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.44.0':
+    resolution: {integrity: sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.44.0':
+    resolution: {integrity: sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.44.0':
+    resolution: {integrity: sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.44.0':
+    resolution: {integrity: sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.44.0':
+    resolution: {integrity: sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.44.0':
+    resolution: {integrity: sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.44.0':
+    resolution: {integrity: sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.44.0':
+    resolution: {integrity: sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.44.0':
+    resolution: {integrity: sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.44.0':
+    resolution: {integrity: sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.44.0':
+    resolution: {integrity: sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.44.0':
+    resolution: {integrity: sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.44.0':
+    resolution: {integrity: sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.44.0':
+    resolution: {integrity: sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.44.0':
+    resolution: {integrity: sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -3585,6 +3710,11 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.44.0:
+    resolution: {integrity: sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4530,6 +4660,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -6000,6 +6134,63 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.122.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.44.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.44.0':
+    optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -8750,6 +8941,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.44.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.44.0
+      '@oxfmt/binding-android-arm64': 0.44.0
+      '@oxfmt/binding-darwin-arm64': 0.44.0
+      '@oxfmt/binding-darwin-x64': 0.44.0
+      '@oxfmt/binding-freebsd-x64': 0.44.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.44.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.44.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.44.0
+      '@oxfmt/binding-linux-arm64-musl': 0.44.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.44.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.44.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.44.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.44.0
+      '@oxfmt/binding-linux-x64-gnu': 0.44.0
+      '@oxfmt/binding-linux-x64-musl': 0.44.0
+      '@oxfmt/binding-openharmony-arm64': 0.44.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.44.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.44.0
+      '@oxfmt/binding-win32-x64-msvc': 0.44.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -9829,6 +10044,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  '@parcel/watcher': false
-  core-js: true
-  puppeteer: true
+    '@parcel/watcher': false
+    core-js: true
+    puppeteer: true

--- a/scripts/force-lowest-dependencies.js
+++ b/scripts/force-lowest-dependencies.js
@@ -7,8 +7,8 @@
  * file that was distributed with this source code.
  */
 
-import fs from 'fs/promises';
 import childProcess from 'child_process';
+import fs from 'fs/promises';
 
 /**
  * @param {string} dependency
@@ -31,9 +31,7 @@ function getLowestVersion(dependency, range) {
                     return;
                 }
 
-                const versions = stdout
-                    .split('\n')
-                    .filter(line => line);
+                const versions = stdout.split('\n').filter((line) => line);
 
                 if (versions.length === 0) {
                     reject(`Could not find a lowest version for "${dependency}@${range}"`);
@@ -69,20 +67,16 @@ const packageInfo = JSON.parse(data);
 const dependencyPromises = [];
 if (packageInfo.dependencies) {
     for (const dependency in packageInfo.dependencies) {
-        dependencyPromises.push(getLowestVersion(
-            dependency,
-            packageInfo.dependencies[dependency]
-        ));
+        dependencyPromises.push(getLowestVersion(dependency, packageInfo.dependencies[dependency]));
     }
 }
 
 const devDependencyPromises = [];
 if (packageInfo.devDependencies) {
     for (const devDependency in packageInfo.devDependencies) {
-        devDependencyPromises.push(getLowestVersion(
-            devDependency,
-            packageInfo.devDependencies[devDependency]
-        ));
+        devDependencyPromises.push(
+            getLowestVersion(devDependency, packageInfo.devDependencies[devDependency])
+        );
     }
 }
 

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -7,13 +7,15 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import WebpackConfig from '../lib/WebpackConfig.js';
-import RuntimeConfig from '../lib/config/RuntimeConfig.js';
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import webpack from 'webpack';
+
+import RuntimeConfig from '../lib/config/RuntimeConfig.js';
 import logger from '../lib/logger.js';
+import WebpackConfig from '../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -23,9 +25,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('WebpackConfig object', function() {
-
-    describe('setOutputPath', function() {
+describe('WebpackConfig object', function () {
+    describe('setOutputPath', function () {
         const removeDirectory = (targetPath) => {
             if (fs.existsSync(targetPath)) {
                 const files = fs.readdirSync(targetPath);
@@ -53,24 +54,22 @@ describe('WebpackConfig object', function() {
 
         afterEach(cleanupNewDirectories);
 
-        it('use absolute, existent path', function() {
+        it('use absolute, existent path', function () {
             const config = createConfig();
             config.setOutputPath(import.meta.dirname);
 
             expect(config.outputPath).toBe(import.meta.dirname);
         });
 
-        it('relative path, becomes absolute', function() {
+        it('relative path, becomes absolute', function () {
             const config = createConfig();
             config.setOutputPath('new_dir');
 
             // import.meta.dirname is the context
-            expect(config.outputPath).toBe(
-                path.join(import.meta.dirname, '/new_dir')
-            );
+            expect(config.outputPath).toBe(path.join(import.meta.dirname, '/new_dir'));
         });
 
-        it('non-existent path creates directory', function() {
+        it('non-existent path creates directory', function () {
             const targetPath = path.join(import.meta.dirname, 'new_dir');
             if (fs.existsSync(targetPath)) {
                 fs.rmdirSync(targetPath);
@@ -81,7 +80,7 @@ describe('WebpackConfig object', function() {
             expect(fs.existsSync(config.outputPath)).toBe(true);
         });
 
-        it('non-existent directory, 3 levels deep is created correctly', function() {
+        it('non-existent directory, 3 levels deep is created correctly', function () {
             var targetPath = path.join(import.meta.dirname, 'new_dir', 'subdir1', 'subdir2');
             if (fs.existsSync(targetPath)) {
                 fs.rmdirSync(targetPath);
@@ -92,7 +91,7 @@ describe('WebpackConfig object', function() {
             expect(fs.existsSync(config.outputPath)).toBe(true);
         });
 
-        it('non-existent path outside of the context directory works if only one directory has to be created', function() {
+        it('non-existent path outside of the context directory works if only one directory has to be created', function () {
             var targetPath = path.join(import.meta.dirname, '..', 'new_dir');
             if (fs.existsSync(targetPath)) {
                 fs.rmdirSync(targetPath);
@@ -103,7 +102,7 @@ describe('WebpackConfig object', function() {
             expect(fs.existsSync(config.outputPath)).toBe(true);
         });
 
-        it('non-existent path outside of the context directory throws an error if more than one directory has to be created', function() {
+        it('non-existent path outside of the context directory throws an error if more than one directory has to be created', function () {
             var targetPath = path.join(import.meta.dirname, '..', 'new_dir', 'subdir');
             if (fs.existsSync(targetPath)) {
                 fs.rmdirSync(targetPath);
@@ -114,29 +113,29 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('setPublicPath', function() {
-        it('/foo => /foo/', function() {
+    describe('setPublicPath', function () {
+        it('/foo => /foo/', function () {
             const config = createConfig();
             config.setPublicPath('/foo');
 
             expect(config.publicPath).toBe('/foo/');
         });
 
-        it('/foo/ => /foo/', function() {
+        it('/foo/ => /foo/', function () {
             const config = createConfig();
             config.setPublicPath('/foo/');
 
             expect(config.publicPath).toBe('/foo/');
         });
 
-        it('https://example.com => https://example.com/', function() {
+        it('https://example.com => https://example.com/', function () {
             const config = createConfig();
             config.setPublicPath('https://example.com');
 
             expect(config.publicPath).toBe('https://example.com/');
         });
 
-        it('You can omit the opening slash, but get a warning', function() {
+        it('You can omit the opening slash, but get a warning', function () {
             const config = createConfig();
             logger.reset();
             logger.quiet();
@@ -146,15 +145,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('getRealPublicPath', function() {
-        it('Returns normal with no dev server', function() {
+    describe('getRealPublicPath', function () {
+        it('Returns normal with no dev server', function () {
             const config = createConfig();
             config.setPublicPath('/public');
 
             expect(config.getRealPublicPath()).toBe('/public/');
         });
 
-        it('Prefix when using devServer', function() {
+        it('Prefix when using devServer', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -165,7 +164,7 @@ describe('WebpackConfig object', function() {
             expect(config.getRealPublicPath()).toBe('http://localhost:8080/public/');
         });
 
-        it('No prefix with devServer & devServerKeepPublicPath option', function() {
+        it('No prefix with devServer & devServerKeepPublicPath option', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -177,7 +176,7 @@ describe('WebpackConfig object', function() {
             expect(config.getRealPublicPath()).toBe('/public/');
         });
 
-        it('devServer does not prefix if publicPath is absolute', function() {
+        it('devServer does not prefix if publicPath is absolute', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -190,9 +189,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('setManifestKeyPrefix', function() {
-
-        it('You can set it!', function() {
+    describe('setManifestKeyPrefix', function () {
+        it('You can set it!', function () {
             const config = createConfig();
             config.setManifestKeyPrefix('foo');
 
@@ -200,7 +198,7 @@ describe('WebpackConfig object', function() {
             expect(config.manifestKeyPrefix).toBe('foo/');
         });
 
-        it('You can set it blank', function() {
+        it('You can set it blank', function () {
             const config = createConfig();
             config.setManifestKeyPrefix('');
 
@@ -208,7 +206,7 @@ describe('WebpackConfig object', function() {
             expect(config.manifestKeyPrefix).toBe('');
         });
 
-        it('You can use an opening slash, but get a warning', function() {
+        it('You can use an opening slash, but get a warning', function () {
             const config = createConfig();
 
             logger.reset();
@@ -218,15 +216,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('cleanupOutputBeforeBuild', function() {
-        it('Enabling it with default settings', function() {
+    describe('cleanupOutputBeforeBuild', function () {
+        it('Enabling it with default settings', function () {
             const config = createConfig();
             config.cleanupOutputBeforeBuild();
 
             expect(config.cleanupOutput).toBe(true);
         });
 
-        it('Setting paths and callback', function() {
+        it('Setting paths and callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.cleanupOutputBeforeBuild(callback);
@@ -235,7 +233,7 @@ describe('WebpackConfig object', function() {
             expect(config.cleanOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -244,8 +242,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureDefinePlugin', function() {
-        it('Setting callback', function() {
+    describe('configureDefinePlugin', function () {
+        it('Setting callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.configureDefinePlugin(callback);
@@ -253,7 +251,7 @@ describe('WebpackConfig object', function() {
             expect(config.definePluginOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -262,8 +260,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureFriendlyErrorsPlugin', function() {
-        it('Setting callback', function() {
+    describe('configureFriendlyErrorsPlugin', function () {
+        it('Setting callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.configureFriendlyErrorsPlugin(callback);
@@ -271,7 +269,7 @@ describe('WebpackConfig object', function() {
             expect(config.friendlyErrorsPluginOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -280,8 +278,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureManifestPlugin', function() {
-        it('Setting callback', function() {
+    describe('configureManifestPlugin', function () {
+        it('Setting callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.configureManifestPlugin(callback);
@@ -289,7 +287,7 @@ describe('WebpackConfig object', function() {
             expect(config.manifestPluginOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
             const callback = 'invalid';
 
@@ -299,8 +297,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureTerserPlugin', function() {
-        it('Setting callback', function() {
+    describe('configureTerserPlugin', function () {
+        it('Setting callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.configureTerserPlugin(callback);
@@ -308,7 +306,7 @@ describe('WebpackConfig object', function() {
             expect(config.terserPluginOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -317,8 +315,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureCssMinimizerPlugin', function() {
-        it('Setting callback', function() {
+    describe('configureCssMinimizerPlugin', function () {
+        it('Setting callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.configureCssMinimizerPlugin(callback);
@@ -326,7 +324,7 @@ describe('WebpackConfig object', function() {
             expect(config.cssMinimizerPluginOptionsCallback).toBe(callback);
         });
 
-        it('Setting invalid callback argument', function() {
+        it('Setting invalid callback argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -335,8 +333,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('addEntry', function() {
-        it('Calling with a duplicate entrypoint name throws an error', function() {
+    describe('addEntry', function () {
+        it('Calling with a duplicate entrypoint name throws an error', function () {
             const config = createConfig();
             config.addEntry('entry_foo', './foo.js');
 
@@ -345,7 +343,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as an Entrypoint');
         });
 
-        it('Calling with a duplicate of addStyleEntry', function() {
+        it('Calling with a duplicate of addStyleEntry', function () {
             const config = createConfig();
             config.addStyleEntry('main', './main.scss');
 
@@ -354,7 +352,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as a Style Entrypoint');
         });
 
-        it('Calling with a duplicate of addEntries', function() {
+        it('Calling with a duplicate of addEntries', function () {
             const config = createConfig();
             config.addEntries({ main: './foo.js' });
 
@@ -364,8 +362,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('addEntries', function() {
-        it('Calling with a duplicate entrypoint name throws an error', function() {
+    describe('addEntries', function () {
+        it('Calling with a duplicate entrypoint name throws an error', function () {
             const config = createConfig();
             config.addEntry('entry_foo', './foo.js');
 
@@ -374,7 +372,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as an Entrypoint');
         });
 
-        it('Calling with a duplicate of addStyleEntry', function() {
+        it('Calling with a duplicate of addStyleEntry', function () {
             const config = createConfig();
             config.addStyleEntry('main', './main.scss');
 
@@ -383,7 +381,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as a Style Entrypoint');
         });
 
-        it('Calling with a duplicate of addEntries', function() {
+        it('Calling with a duplicate of addEntries', function () {
             const config = createConfig();
             config.addEntries({ main: './foo.js' });
 
@@ -393,8 +391,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('addStyleEntry', function() {
-        it('Calling with a duplicate style entrypoint name throws an error', function() {
+    describe('addStyleEntry', function () {
+        it('Calling with a duplicate style entrypoint name throws an error', function () {
             const config = createConfig();
             config.addStyleEntry('entry_foo', './foo.css');
 
@@ -403,7 +401,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as a Style Entrypoint');
         });
 
-        it('Calling with a duplicate of addEntry', function() {
+        it('Calling with a duplicate of addEntry', function () {
             const config = createConfig();
             config.addEntry('main', './main.scss');
 
@@ -412,7 +410,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as an Entrypoint');
         });
 
-        it('Calling with a duplicate of addEntries', function() {
+        it('Calling with a duplicate of addEntries', function () {
             const config = createConfig();
             config.addEntries({ main: './main.js' });
 
@@ -422,8 +420,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('addCacheGroup', function() {
-        it('Calling it adds cache groups', function() {
+    describe('addCacheGroup', function () {
+        it('Calling it adds cache groups', function () {
             const config = createConfig();
             config.addCacheGroup('foo', { test: /foo/ });
             config.addCacheGroup('bar', { test: /bar/ });
@@ -434,9 +432,9 @@ describe('WebpackConfig object', function() {
             });
         });
 
-        it('Calling it using the "node_modules" option', function() {
+        it('Calling it using the "node_modules" option', function () {
             const config = createConfig();
-            config.addCacheGroup('foo', { node_modules: ['foo','bar', 'baz'] });
+            config.addCacheGroup('foo', { node_modules: ['foo', 'bar', 'baz'] });
 
             expect(config.cacheGroups).toEqual({
                 foo: {
@@ -445,47 +443,47 @@ describe('WebpackConfig object', function() {
             });
         });
 
-        it('Calling it with other SplitChunksPlugin options', function() {
+        it('Calling it with other SplitChunksPlugin options', function () {
             const config = createConfig();
             config.addCacheGroup('foo', {
                 test: /foo/,
                 chunks: 'initial',
-                minChunks: 2
+                minChunks: 2,
             });
 
             expect(config.cacheGroups).toEqual({
                 foo: {
                     test: /foo/,
                     chunks: 'initial',
-                    minChunks: 2
+                    minChunks: 2,
                 },
             });
         });
 
-        it('Calling it with an invalid name', function() {
+        it('Calling it with an invalid name', function () {
             const config = createConfig();
             expect(() => {
                 config.addCacheGroup(true, { test: /foo/ });
             }).toThrow('must be a string');
         });
 
-        it('Calling it with an invalid options parameter', function() {
+        it('Calling it with an invalid options parameter', function () {
             const config = createConfig();
             expect(() => {
                 config.addCacheGroup('foo', 'bar');
             }).toThrow('must be an object');
         });
 
-        it('Calling it with an invalid node_modules option', function() {
+        it('Calling it with an invalid node_modules option', function () {
             const config = createConfig();
             expect(() => {
                 config.addCacheGroup('foo', {
-                    'node_modules': 'foo'
+                    node_modules: 'foo',
                 });
             }).toThrow('must be an array');
         });
 
-        it('Calling it without the "test" or "node_modules" option', function() {
+        it('Calling it without the "test" or "node_modules" option', function () {
             const config = createConfig();
             expect(() => {
                 config.addCacheGroup('foo', { type: 'json' });
@@ -493,8 +491,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('copyFiles', function() {
-        it('Calling it adds files to be copied', function() {
+    describe('copyFiles', function () {
+        it('Calling it adds files to be copied', function () {
             const config = createConfig();
 
             // With multiple config objects
@@ -506,28 +504,32 @@ describe('WebpackConfig object', function() {
             // With a single config object
             config.copyFiles({ from: './baz' });
 
-            expect(config.copyFilesConfigs).toEqual([{
-                from: './foo',
-                pattern: /.*/,
-                to: null,
-                includeSubdirectories: true,
-                context: null,
-            }, {
-                from: './bar',
-                pattern: '/abc/',
-                to: 'bar',
-                includeSubdirectories: false,
-                context: null,
-            }, {
-                from: './baz',
-                pattern: /.*/,
-                to: null,
-                includeSubdirectories: true,
-                context: null,
-            }]);
+            expect(config.copyFilesConfigs).toEqual([
+                {
+                    from: './foo',
+                    pattern: /.*/,
+                    to: null,
+                    includeSubdirectories: true,
+                    context: null,
+                },
+                {
+                    from: './bar',
+                    pattern: '/abc/',
+                    to: 'bar',
+                    includeSubdirectories: false,
+                    context: null,
+                },
+                {
+                    from: './baz',
+                    pattern: /.*/,
+                    to: null,
+                    includeSubdirectories: true,
+                    context: null,
+                },
+            ]);
         });
 
-        it('Calling it with an invalid parameter', function() {
+        it('Calling it with an invalid parameter', function () {
             const config = createConfig();
 
             expect(() => {
@@ -539,7 +541,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be called with either a config object or an array of config objects');
         });
 
-        it('Calling it with a missing from key', function() {
+        it('Calling it with a missing from key', function () {
             const config = createConfig();
 
             expect(() => {
@@ -551,7 +553,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must have a "from" property');
         });
 
-        it('Calling it with an unknown config property', function() {
+        it('Calling it with an unknown config property', function () {
             const config = createConfig();
 
             expect(() => {
@@ -559,7 +561,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('Invalid config option "foo"');
         });
 
-        it('Calling it with an invalid "pattern" option', function() {
+        it('Calling it with an invalid "pattern" option', function () {
             const config = createConfig();
 
             expect(() => {
@@ -572,32 +574,32 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('autoProvideVariables', function() {
-        it('Calling multiple times merges', function() {
+    describe('autoProvideVariables', function () {
+        it('Calling multiple times merges', function () {
             const config = createConfig();
             config.autoProvideVariables({
                 $: 'jquery',
-                jQuery: 'jquery'
+                jQuery: 'jquery',
             });
             config.autoProvideVariables({
                 bar: './bar',
-                foo: './foo'
+                foo: './foo',
             });
             config.autoProvideVariables({
-                foo: './foo2'
+                foo: './foo2',
             });
 
-            expect(JSON.stringify(config.providedVariables))
-                .toBe(JSON.stringify({
+            expect(JSON.stringify(config.providedVariables)).toBe(
+                JSON.stringify({
                     $: 'jquery',
                     jQuery: 'jquery',
                     bar: './bar',
                     foo: './foo2',
-                }))
-            ;
+                })
+            );
         });
 
-        it('Calling with string throws an error', function() {
+        it('Calling with string throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -605,7 +607,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must pass an object');
         });
 
-        it('Calling with an Array throws an error', function() {
+        it('Calling with an Array throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -614,32 +616,34 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureBabel', function() {
-        beforeEach(function() {
+    describe('configureBabel', function () {
+        beforeEach(function () {
             logger.reset();
             logger.quiet();
         });
 
-        afterEach(function() {
+        afterEach(function () {
             logger.quiet(false);
         });
 
-        it('Calling method sets it', function() {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.configureBabel(testCallback);
             expect(config.babelConfigurationCallback).toBe(testCallback);
-            expect(String(config.babelOptions.exclude)).toBe(String(/(node_modules|bower_components)/));
+            expect(String(config.babelOptions.exclude)).toBe(
+                String(/(node_modules|bower_components)/)
+            );
         });
 
-        it('Calling with "exclude" option', function() {
+        it('Calling with "exclude" option', function () {
             const config = createConfig();
             config.configureBabel(() => {}, { exclude: 'foo' });
 
             expect(config.babelOptions.exclude).toBe('foo');
         });
 
-        it('Calling with "includeNodeModules" option', function() {
+        it('Calling with "includeNodeModules" option', function () {
             const config = createConfig();
             config.configureBabel(() => {}, { includeNodeModules: ['foo', 'bar'] });
 
@@ -658,7 +662,7 @@ describe('WebpackConfig object', function() {
                 path.join('test', 'bower_components', 'bar', 'index.js'),
                 path.join('test', 'bower_components', 'baz', 'index.js'),
                 path.join('test', 'node_modules', 'baz', 'lib', 'index.js'),
-                path.join('test', 'node_modules', 'baz', 'lib', 'foo', 'index.js')
+                path.join('test', 'node_modules', 'baz', 'lib', 'foo', 'index.js'),
             ];
 
             for (const filePath of includedPaths) {
@@ -670,14 +674,14 @@ describe('WebpackConfig object', function() {
             }
         });
 
-        it('Calling with "useBuiltIns" option', function() {
+        it('Calling with "useBuiltIns" option', function () {
             const config = createConfig();
-            config.configureBabel(() => { }, { useBuiltIns: 'foo' });
+            config.configureBabel(() => {}, { useBuiltIns: 'foo' });
 
             expect(config.babelOptions.useBuiltIns).toBe('foo');
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -685,7 +689,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be a callback function');
         });
 
-        it('Calling with a callback when .babelrc is present throws an error', function() {
+        it('Calling with a callback when .babelrc is present throws an error', function () {
             const config = createConfig();
             config.runtimeConfig.babelRcFileExists = true;
 
@@ -694,24 +698,26 @@ describe('WebpackConfig object', function() {
             }).toThrow('your app already provides an external Babel configuration');
         });
 
-        it('Calling with a whitelisted option when .babelrc is present works fine', function() {
+        it('Calling with a whitelisted option when .babelrc is present works fine', function () {
             const config = createConfig();
             config.runtimeConfig.babelRcFileExists = true;
             config.configureBabel(null, { includeNodeModules: ['foo'] });
             expect(logger.getMessages().warning).to.be.empty;
         });
 
-        it('Calling with a non-whitelisted option when .babelrc is present displays a warning', function() {
+        it('Calling with a non-whitelisted option when .babelrc is present displays a warning', function () {
             const config = createConfig();
             config.runtimeConfig.babelRcFileExists = true;
             config.configureBabel(null, { useBuiltIns: 'foo' });
 
             const warnings = logger.getMessages().warning;
             expect(warnings).toHaveLength(1);
-            expect(warnings[0]).toContain('your app already provides an external Babel configuration');
+            expect(warnings[0]).toContain(
+                'your app already provides an external Babel configuration'
+            );
         });
 
-        it('Pass invalid config', function() {
+        it('Pass invalid config', function () {
             const config = createConfig();
 
             expect(() => {
@@ -719,15 +725,18 @@ describe('WebpackConfig object', function() {
             }).toThrow('Invalid option "fake_option" passed to configureBabel()');
         });
 
-        it('Calling with both "includeNodeModules" and "exclude" options', function() {
+        it('Calling with both "includeNodeModules" and "exclude" options', function () {
             const config = createConfig();
 
             expect(() => {
-                config.configureBabel(() => {}, { exclude: 'foo', includeNodeModules: ['bar', 'baz'] });
-            }).toThrow('can\'t be used together');
+                config.configureBabel(() => {}, {
+                    exclude: 'foo',
+                    includeNodeModules: ['bar', 'baz'],
+                });
+            }).toThrow("can't be used together");
         });
 
-        it('Calling with an invalid "includeNodeModules" option value', function() {
+        it('Calling with an invalid "includeNodeModules" option value', function () {
             const config = createConfig();
 
             expect(() => {
@@ -736,24 +745,24 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureBabelPresetEnv', function() {
-        beforeEach(function() {
+    describe('configureBabelPresetEnv', function () {
+        beforeEach(function () {
             logger.reset();
             logger.quiet();
         });
 
-        afterEach(function() {
+        afterEach(function () {
             logger.quiet(false);
         });
 
-        it('Calling method sets it', function() {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.configureBabelPresetEnv(testCallback);
             expect(config.babelPresetEnvOptionsCallback).toBe(testCallback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -761,7 +770,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be a callback function');
         });
 
-        it('Calling with a callback when .babelrc is present throws an error', function() {
+        it('Calling with a callback when .babelrc is present throws an error', function () {
             const config = createConfig();
             config.runtimeConfig.babelRcFileExists = true;
 
@@ -771,16 +780,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureCssLoader', function() {
-        it('Calling method sets it', function() {
+    describe('configureCssLoader', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.configureCssLoader(testCallback);
             expect(config.cssLoaderConfigurationCallback).toBe(testCallback);
-
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -789,15 +797,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureMiniCssExtractPlugin', function() {
-        it('Calling method with its first parameter sets the loader\'s options', function() {
+    describe('configureMiniCssExtractPlugin', function () {
+        it("Calling method with its first parameter sets the loader's options", function () {
             const config = createConfig();
             const testCallback = () => {};
             config.configureMiniCssExtractPlugin(testCallback);
             expect(config.miniCssExtractLoaderConfigurationCallback).toBe(testCallback);
         });
 
-        it('Calling method with its second parameter sets the plugin\'s options', function() {
+        it("Calling method with its second parameter sets the plugin's options", function () {
             const config = createConfig();
             const testCallbackLoader = () => {};
             const testCallbackPlugin = () => {};
@@ -806,7 +814,7 @@ describe('WebpackConfig object', function() {
             expect(config.miniCssExtractPluginConfigurationCallback).toBe(testCallbackPlugin);
         });
 
-        it('Calling with non-callback as 1st parameter throws an error', function() {
+        it('Calling with non-callback as 1st parameter throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -814,7 +822,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be a callback function');
         });
 
-        it('Calling with non-callback as 2nd parameter throws an error', function() {
+        it('Calling with non-callback as 2nd parameter throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -823,15 +831,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureSplitChunks', function() {
-        it('Calling method sets it', function() {
+    describe('configureSplitChunks', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.configureSplitChunks(testCallback);
             expect(config.splitChunksConfigurationCallback).toBe(testCallback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -840,15 +848,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enablePostCssLoader', function() {
-        it('Call with no config', function() {
+    describe('enablePostCssLoader', function () {
+        it('Call with no config', function () {
             const config = createConfig();
             config.enablePostCssLoader();
 
             expect(config.usePostCssLoader).toBe(true);
         });
 
-        it('Pass options callback', function() {
+        it('Pass options callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.enablePostCssLoader(callback);
@@ -857,22 +865,22 @@ describe('WebpackConfig object', function() {
             expect(config.postCssLoaderOptionsCallback).toBe(callback);
         });
 
-        it('Pass invalid options callback', function() {
+        it('Pass invalid options callback', function () {
             const config = createConfig();
 
             expect(() => config.enablePostCssLoader('FOO')).toThrow('must be a callback function');
         });
     });
 
-    describe('enableSassLoader', function() {
-        it('Call with no config', function() {
+    describe('enableSassLoader', function () {
+        it('Call with no config', function () {
             const config = createConfig();
             config.enableSassLoader();
 
             expect(config.useSassLoader).toBe(true);
         });
 
-        it('Pass valid config', function() {
+        it('Pass valid config', function () {
             const config = createConfig();
             config.enableSassLoader(() => {}, { resolveUrlLoader: false });
 
@@ -880,7 +888,7 @@ describe('WebpackConfig object', function() {
             expect(config.sassOptions.resolveUrlLoader).toBe(false);
         });
 
-        it('Pass invalid config', function() {
+        it('Pass invalid config', function () {
             const config = createConfig();
 
             expect(() => {
@@ -888,7 +896,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('Invalid option "fake_option" passed to enableSassLoader()');
         });
 
-        it('Pass options callback', function() {
+        it('Pass options callback', function () {
             const config = createConfig();
             const callback = (options) => {};
             config.enableSassLoader(callback);
@@ -897,15 +905,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableLessLoader', function() {
-        it('Calling method sets it', function() {
+    describe('enableLessLoader', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             config.enableLessLoader();
 
             expect(config.useLessLoader).toBe(true);
         });
 
-        it('Calling with callback', function() {
+        it('Calling with callback', function () {
             const config = createConfig();
             const callback = (lessOptions) => {};
             config.enableLessLoader(callback);
@@ -913,7 +921,7 @@ describe('WebpackConfig object', function() {
             expect(config.lessLoaderOptionsCallback).toBe(callback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -922,15 +930,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableStylusLoader', function() {
-        it('Calling method sets it', function() {
+    describe('enableStylusLoader', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             config.enableStylusLoader();
 
             expect(config.useStylusLoader).toBe(true);
         });
 
-        it('Calling with callback', function() {
+        it('Calling with callback', function () {
             const config = createConfig();
             const callback = (stylusOptions) => {};
             config.enableStylusLoader(callback);
@@ -938,7 +946,7 @@ describe('WebpackConfig object', function() {
             expect(config.stylusLoaderOptionsCallback).toBe(callback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -947,8 +955,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableBuildCache', function() {
-        it('Calling method enables it', function() {
+    describe('enableBuildCache', function () {
+        it('Calling method enables it', function () {
             const config = createConfig();
             config.enableBuildCache({ config: ['foo.js'] });
 
@@ -956,7 +964,7 @@ describe('WebpackConfig object', function() {
             expect(config.persistentCacheBuildDependencies).to.eql({ config: ['foo.js'] });
         });
 
-        it('Calling with callback', function() {
+        it('Calling with callback', function () {
             const config = createConfig();
             const callback = (cache) => {};
             config.enableBuildCache({ config: ['foo.js'] }, callback);
@@ -964,7 +972,7 @@ describe('WebpackConfig object', function() {
             expect(config.persistentCacheCallback).toBe(callback);
         });
 
-        it('Calling without config key throws an error', function() {
+        it('Calling without config key throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -972,7 +980,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('should contain an object with at least a "config" key');
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -981,15 +989,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableReactPreset', function() {
-        it('Calling method sets it', function() {
+    describe('enableReactPreset', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.enableReactPreset(testCallback);
             expect(config.babelReactPresetOptionsCallback).toBe(testCallback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -998,8 +1006,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enablePreactPreset', function() {
-        it('Without preact-compat', function() {
+    describe('enablePreactPreset', function () {
+        it('Without preact-compat', function () {
             const config = createConfig();
             config.enablePreactPreset();
 
@@ -1007,35 +1015,35 @@ describe('WebpackConfig object', function() {
             expect(config.preactOptions.preactCompat).toBe(false);
         });
 
-        it('With preact-compat', function() {
+        it('With preact-compat', function () {
             const config = createConfig();
             config.enablePreactPreset({
-                preactCompat: true
+                preactCompat: true,
             });
 
             expect(config.usePreact).toBe(true);
             expect(config.preactOptions.preactCompat).toBe(true);
         });
 
-        it('With an invalid option', function() {
+        it('With an invalid option', function () {
             const config = createConfig();
             expect(() => {
                 config.enablePreactPreset({
-                    foo: true
+                    foo: true,
                 });
             }).toThrow('Invalid option "foo"');
         });
     });
 
-    describe('enableTypeScriptLoader', function() {
-        it('Calling method sets it', function() {
+    describe('enableTypeScriptLoader', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             const testCallback = () => {};
             config.enableTypeScriptLoader(testCallback);
             expect(config.tsConfigurationCallback).toBe(testCallback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1043,27 +1051,28 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be a callback function');
         });
 
-        it('TypeScript can not be compiled by ts-loader if Babel is already handling TypeScript', function() {
+        it('TypeScript can not be compiled by ts-loader if Babel is already handling TypeScript', function () {
             const config = createConfig();
             config.enableBabelTypeScriptPreset();
 
-            expect(function() {
+            expect(function () {
                 config.enableTypeScriptLoader();
-            }).toThrow('Encore.enableTypeScriptLoader() can not be called when Encore.enableBabelTypeScriptPreset() has been called.');
+            }).toThrow(
+                'Encore.enableTypeScriptLoader() can not be called when Encore.enableBabelTypeScriptPreset() has been called.'
+            );
         });
     });
 
-    describe('enableForkedTypeScriptTypesChecking', function() {
-        it('Calling method sets it', function() {
+    describe('enableForkedTypeScriptTypesChecking', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             config.enableTypeScriptLoader();
             const testCallback = () => {};
             config.enableForkedTypeScriptTypesChecking(testCallback);
-            expect(config.forkedTypeScriptTypesCheckOptionsCallback)
-                .toBe(testCallback);
+            expect(config.forkedTypeScriptTypesCheckOptionsCallback).toBe(testCallback);
         });
 
-        it('Calling with non-callback throws an error', function() {
+        it('Calling with non-callback throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1071,36 +1080,42 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be a callback function');
         });
 
-        it('TypeScript can not be compiled by Babel if forked types checking is enabled', function() {
+        it('TypeScript can not be compiled by Babel if forked types checking is enabled', function () {
             const config = createConfig();
             config.enableBabelTypeScriptPreset();
 
-            expect(function() {
+            expect(function () {
                 config.enableForkedTypeScriptTypesChecking();
-            }).toThrow('Encore.enableForkedTypeScriptTypesChecking() can not be called when Encore.enableBabelTypeScriptPreset() has been called.');
+            }).toThrow(
+                'Encore.enableForkedTypeScriptTypesChecking() can not be called when Encore.enableBabelTypeScriptPreset() has been called.'
+            );
         });
     });
 
-    describe('enableBabelTypeScriptPreset', function() {
-        it('TypeScript can not be compiled by Babel if ts-loader is already enabled (with typescript-loader)', function() {
+    describe('enableBabelTypeScriptPreset', function () {
+        it('TypeScript can not be compiled by Babel if ts-loader is already enabled (with typescript-loader)', function () {
             const config = createConfig();
             config.enableTypeScriptLoader();
 
-            expect(function() {
+            expect(function () {
                 config.enableBabelTypeScriptPreset();
-            }).toThrow('Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableTypeScriptLoader() has been called.');
+            }).toThrow(
+                'Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableTypeScriptLoader() has been called.'
+            );
         });
 
-        it('TypeScript can not be compiled by Babel if ts-loader is already enabled (with forked typescript types checking)', function() {
+        it('TypeScript can not be compiled by Babel if ts-loader is already enabled (with forked typescript types checking)', function () {
             const config = createConfig();
             config.enableForkedTypeScriptTypesChecking();
 
-            expect(function() {
+            expect(function () {
                 config.enableBabelTypeScriptPreset();
-            }).toThrow('Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableForkedTypeScriptTypesChecking() has been called.');
+            }).toThrow(
+                'Encore.enableBabelTypeScriptPreset() can not be called when Encore.enableForkedTypeScriptTypesChecking() has been called.'
+            );
         });
 
-        it('Options should be defined', function() {
+        it('Options should be defined', function () {
             const config = createConfig();
             const options = { isTSX: true };
 
@@ -1110,15 +1125,15 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableVueLoader', function() {
-        it('Call with no config', function() {
+    describe('enableVueLoader', function () {
+        it('Call with no config', function () {
             const config = createConfig();
             config.enableVueLoader();
 
             expect(config.useVueLoader).toBe(true);
         });
 
-        it('Pass config', function() {
+        it('Pass config', function () {
             const config = createConfig();
             const callback = (options) => {
                 options.preLoaders = { foo: 'foo-loader' };
@@ -1129,17 +1144,19 @@ describe('WebpackConfig object', function() {
             expect(config.vueLoaderOptionsCallback).toBe(callback);
         });
 
-        it('Should validate Encore-specific options', function() {
+        it('Should validate Encore-specific options', function () {
             const config = createConfig();
 
             expect(() => {
                 config.enableVueLoader(() => {}, {
                     notExisting: false,
                 });
-            }).toThrow('"notExisting" is not a valid key for enableVueLoader(). Valid keys: useJsx, version, runtimeCompilerBuild.');
+            }).toThrow(
+                '"notExisting" is not a valid key for enableVueLoader(). Valid keys: useJsx, version, runtimeCompilerBuild.'
+            );
         });
 
-        it('Should set Encore-specific options', function() {
+        it('Should set Encore-specific options', function () {
             const config = createConfig();
             config.enableVueLoader(() => {}, {
                 useJsx: true,
@@ -1152,32 +1169,34 @@ describe('WebpackConfig object', function() {
             });
         });
 
-        it('Should validate Vue version', function() {
+        it('Should validate Vue version', function () {
             const config = createConfig();
 
             expect(() => {
                 config.enableVueLoader(() => {}, {
                     version: 4,
                 });
-            }).toThrow('"4" is not a valid value for the "version" option passed to enableVueLoader(). Valid versions are: 3.');
+            }).toThrow(
+                '"4" is not a valid value for the "version" option passed to enableVueLoader(). Valid versions are: 3.'
+            );
         });
     });
-    describe('enableBuildNotifications', function() {
-        it('Calling method with default values', function() {
+    describe('enableBuildNotifications', function () {
+        it('Calling method with default values', function () {
             const config = createConfig();
             config.enableBuildNotifications();
 
             expect(config.useWebpackNotifier).toBe(true);
         });
 
-        it('Calling method without enabling it', function() {
+        it('Calling method without enabling it', function () {
             const config = createConfig();
             config.enableBuildNotifications(false);
 
             expect(config.useWebpackNotifier).toBe(false);
         });
 
-        it('Calling method with options callback', function() {
+        it('Calling method with options callback', function () {
             const config = createConfig();
             const callback = () => {};
             config.enableBuildNotifications(true, callback);
@@ -1186,23 +1205,24 @@ describe('WebpackConfig object', function() {
             expect(config.notifierPluginOptionsCallback).toBe(callback);
         });
 
-        it('Calling method with invalid options callback', function() {
+        it('Calling method with invalid options callback', function () {
             const config = createConfig();
 
-            expect(() => config.enableBuildNotifications(true, 'FOO')).toThrow('must be a callback function');
+            expect(() => config.enableBuildNotifications(true, 'FOO')).toThrow(
+                'must be a callback function'
+            );
         });
     });
 
-    describe('enableHandlebarsLoader', function() {
-
-        it('Call with no config', function() {
+    describe('enableHandlebarsLoader', function () {
+        it('Call with no config', function () {
             const config = createConfig();
             config.enableHandlebarsLoader();
 
             expect(config.useHandlebarsLoader).toBe(true);
         });
 
-        it('Pass config', function() {
+        it('Pass config', function () {
             const config = createConfig();
             const callback = (options) => {
                 options.debug = true;
@@ -1212,84 +1232,91 @@ describe('WebpackConfig object', function() {
             expect(config.useHandlebarsLoader).toBe(true);
             expect(config.handlebarsConfigurationCallback).toBe(callback);
         });
-
     });
 
-    describe('addPlugin', function() {
-        it('extends the current registered plugins', function() {
+    describe('addPlugin', function () {
+        it('extends the current registered plugins', function () {
             const config = createConfig();
             const nbOfPlugins = config.plugins.length;
 
             expect(nbOfPlugins).toBe(0);
 
-            config.addPlugin(new webpack.IgnorePlugin({
-                resourceRegExp: /^\.\/locale$/,
-                contextRegExp: /moment$/
-            }));
+            config.addPlugin(
+                new webpack.IgnorePlugin({
+                    resourceRegExp: /^\.\/locale$/,
+                    contextRegExp: /moment$/,
+                })
+            );
 
             expect(config.plugins.length).toBe(1);
             expect(config.plugins[0].plugin).toBeInstanceOf(webpack.IgnorePlugin);
             expect(config.plugins[0].priority).toBe(0);
         });
 
-        it('Calling it with a priority', function() {
+        it('Calling it with a priority', function () {
             const config = createConfig();
             const nbOfPlugins = config.plugins.length;
 
             expect(nbOfPlugins).toBe(0);
 
-            config.addPlugin(new webpack.IgnorePlugin({
-                resourceRegExp: /^\.\/locale$/,
-                contextRegExp: /moment$/
-            }), 10);
+            config.addPlugin(
+                new webpack.IgnorePlugin({
+                    resourceRegExp: /^\.\/locale$/,
+                    contextRegExp: /moment$/,
+                }),
+                10
+            );
 
             expect(config.plugins.length).toBe(1);
             expect(config.plugins[0].plugin).toBeInstanceOf(webpack.IgnorePlugin);
             expect(config.plugins[0].priority).toBe(10);
         });
 
-        it('Calling it with an invalid priority', function() {
+        it('Calling it with an invalid priority', function () {
             const config = createConfig();
             const nbOfPlugins = config.plugins.length;
 
             expect(nbOfPlugins).toBe(0);
 
             expect(() => {
-                config.addPlugin(new webpack.IgnorePlugin({
-                    resourceRegExp: /^\.\/locale$/,
-                    contextRegExp: /moment$/
-                }), 'foo');
+                config.addPlugin(
+                    new webpack.IgnorePlugin({
+                        resourceRegExp: /^\.\/locale$/,
+                        contextRegExp: /moment$/,
+                    }),
+                    'foo'
+                );
             }).toThrow('must be a number');
         });
     });
 
-    describe('addLoader', function() {
-        it('Adds a new loader', function() {
+    describe('addLoader', function () {
+        it('Adds a new loader', function () {
             const config = createConfig();
 
-            config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });
+            config.addLoader({ test: /\.custom$/, loader: 'custom-loader' });
 
-            expect(config.loaders).toEqual([{ 'test': /\.custom$/, 'loader': 'custom-loader' }]);
+            expect(config.loaders).toEqual([{ test: /\.custom$/, loader: 'custom-loader' }]);
         });
     });
 
-    describe('addAliases', function() {
-        it('Adds new aliases', function() {
+    describe('addAliases', function () {
+        it('Adds new aliases', function () {
             const config = createConfig();
 
             expect(config.aliases).toEqual({});
 
-            config.addAliases({ 'testA': 'src/testA', 'testB': 'src/testB' });
-            config.addAliases({ 'testC': 'src/testC' });
+            config.addAliases({ testA: 'src/testA', testB: 'src/testB' });
+            config.addAliases({ testC: 'src/testC' });
 
             expect(config.aliases).toEqual({
-                'testA': 'src/testA',
-                'testB': 'src/testB',
-                'testC': 'src/testC'
+                testA: 'src/testA',
+                testB: 'src/testB',
+                testC: 'src/testC',
             });
         });
 
-        it('Calling it with an invalid argument', function() {
+        it('Calling it with an invalid argument', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1298,56 +1325,55 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('addExternals', function() {
-        it('Adds new externals', function() {
+    describe('addExternals', function () {
+        it('Adds new externals', function () {
             const config = createConfig();
 
             expect(config.externals).toEqual([]);
 
-            config.addExternals({ 'jquery': 'jQuery', 'react': 'react', 'svelte': 'svelte' });
-            config.addExternals({ 'lodash': 'lodash' });
+            config.addExternals({ jquery: 'jQuery', react: 'react', svelte: 'svelte' });
+            config.addExternals({ lodash: 'lodash' });
             config.addExternals(/^(jquery|\$)$/i);
 
             expect(config.externals).toEqual([
-                { 'jquery': 'jQuery', 'react': 'react', 'svelte': 'svelte' },
-                { 'lodash': 'lodash' },
-                /^(jquery|\$)$/i
+                { jquery: 'jQuery', react: 'react', svelte: 'svelte' },
+                { lodash: 'lodash' },
+                /^(jquery|\$)$/i,
             ]);
         });
     });
 
-    describe('disableCssExtraction', function() {
-        it('By default the CSS extraction is enabled', function() {
+    describe('disableCssExtraction', function () {
+        it('By default the CSS extraction is enabled', function () {
             const config = createConfig();
 
             expect(config.extractCss).toBe(true);
         });
 
-        it('Calling it with no params disables the CSS extraction', function() {
+        it('Calling it with no params disables the CSS extraction', function () {
             const config = createConfig();
             config.disableCssExtraction();
 
             expect(config.extractCss).toBe(false);
         });
 
-        it('Calling it with boolean set to true disables CSS extraction', function() {
+        it('Calling it with boolean set to true disables CSS extraction', function () {
             const config = createConfig();
             config.disableCssExtraction(true);
 
             expect(config.extractCss).toBe(false);
         });
 
-        it('Calling it with boolean set to false enables CSS extraction', function() {
+        it('Calling it with boolean set to false enables CSS extraction', function () {
             const config = createConfig();
             config.disableCssExtraction(false);
 
             expect(config.extractCss).toBe(true);
         });
-
     });
 
-    describe('configureFilenames', function() {
-        it('Calling method sets it', function() {
+    describe('configureFilenames', function () {
+        it('Calling method sets it', function () {
             const config = createConfig();
             config.configureFilenames({
                 js: '[name].[contenthash].js',
@@ -1362,7 +1388,7 @@ describe('WebpackConfig object', function() {
             });
         });
 
-        it('Calling with non-object throws an error', function() {
+        it('Calling with non-object throws an error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1370,31 +1396,34 @@ describe('WebpackConfig object', function() {
             }).toThrow('must be an object');
         });
 
-        it('Calling with an unknown key throws an error', function() {
+        it('Calling with an unknown key throws an error', function () {
             const config = createConfig();
 
             expect(() => {
                 config.configureFilenames({
-                    foo: 'bar'
+                    foo: 'bar',
                 });
             }).toThrow('"foo" is not a valid key');
         });
     });
 
-    describe('configureImageRule', function() {
-        it('Calling method sets options and callback', function() {
+    describe('configureImageRule', function () {
+        it('Calling method sets options and callback', function () {
             const config = createConfig();
             const callback = () => {};
-            config.configureImageRule({
-                type: 'asset',
-                maxSize: 1024,
-            }, callback);
+            config.configureImageRule(
+                {
+                    type: 'asset',
+                    maxSize: 1024,
+                },
+                callback
+            );
 
             expect(config.imageRuleOptions.maxSize).to.equals(1024);
             expect(config.imageRuleCallback).to.equals(callback);
         });
 
-        it('Calling with invalid option throws error', function() {
+        it('Calling with invalid option throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1402,7 +1431,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('Invalid option "fake" passed');
         });
 
-        it('Setting maxSize for type of not asset throws error', function() {
+        it('Setting maxSize for type of not asset throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1410,7 +1439,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('this option is only valid when "type" is set to "asset"');
         });
 
-        it('Passing non callback to 2nd arg throws error', function() {
+        it('Passing non callback to 2nd arg throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1419,20 +1448,23 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureFontRule', function() {
-        it('Calling method sets options and callback', function() {
+    describe('configureFontRule', function () {
+        it('Calling method sets options and callback', function () {
             const config = createConfig();
             const callback = () => {};
-            config.configureFontRule({
-                type: 'asset',
-                maxSize: 1024,
-            }, callback);
+            config.configureFontRule(
+                {
+                    type: 'asset',
+                    maxSize: 1024,
+                },
+                callback
+            );
 
             expect(config.fontRuleOptions.maxSize).to.equals(1024);
             expect(config.fontRuleCallback).to.equals(callback);
         });
 
-        it('Calling with invalid option throws error', function() {
+        it('Calling with invalid option throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1440,7 +1472,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('Invalid option "fake" passed');
         });
 
-        it('Setting maxSize for type of not asset throws error', function() {
+        it('Setting maxSize for type of not asset throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1448,7 +1480,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('this option is only valid when "type" is set to "asset"');
         });
 
-        it('Passing non callback to 2nd arg throws error', function() {
+        it('Passing non callback to 2nd arg throws error', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1457,8 +1489,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureWatchOptions()', function() {
-        it('Pass config', function() {
+    describe('configureWatchOptions()', function () {
+        it('Pass config', function () {
             const config = createConfig();
             const callback = (watchOptions) => {
                 watchOptions.poll = 250;
@@ -1469,7 +1501,7 @@ describe('WebpackConfig object', function() {
             expect(config.watchOptionsConfigurationCallback).toBe(callback);
         });
 
-        it('Call method without a valid callback', function() {
+        it('Call method without a valid callback', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1482,8 +1514,8 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('configureLoaderRule()', function() {
-        it('works properly', function() {
+    describe('configureLoaderRule()', function () {
+        it('works properly', function () {
             const config = createConfig();
             const callback = (loader) => {};
 
@@ -1493,15 +1525,17 @@ describe('WebpackConfig object', function() {
             expect(config.loaderConfigurationCallbacks['javascript']).toBe(callback);
         });
 
-        it('Call method with a not supported loader', function() {
+        it('Call method with a not supported loader', function () {
             const config = createConfig();
 
             expect(() => {
                 config.configureLoaderRule('reason');
-            }).toThrow('Loader "reason" is not configurable. Valid loaders are "javascript", "css", "images", "fonts", "sass", "less", "stylus", "vue", "typescript", "handlebars", "svelte" and the aliases "js", "ts", "scss".');
+            }).toThrow(
+                'Loader "reason" is not configurable. Valid loaders are "javascript", "css", "images", "fonts", "sass", "less", "stylus", "vue", "typescript", "handlebars", "svelte" and the aliases "js", "ts", "scss".'
+            );
         });
 
-        it('Call method with not a valid callback', function() {
+        it('Call method with not a valid callback', function () {
             const config = createConfig();
 
             expect(() => {
@@ -1514,46 +1548,54 @@ describe('WebpackConfig object', function() {
         });
     });
 
-    describe('enableIntegrityHashes', function() {
-        it('Calling it without any option', function() {
+    describe('enableIntegrityHashes', function () {
+        it('Calling it without any option', function () {
             const config = createConfig();
             config.enableIntegrityHashes();
 
             expect(config.integrityAlgorithms).toEqual(['sha384']);
         });
 
-        it('Calling it without false as a first argument disables it', function() {
+        it('Calling it without false as a first argument disables it', function () {
             const config = createConfig();
             config.enableIntegrityHashes(false, 'sha1');
 
             expect(config.integrityAlgorithms).toEqual([]);
         });
 
-        it('Calling it with a single algorithm', function() {
+        it('Calling it with a single algorithm', function () {
             const config = createConfig();
             config.enableIntegrityHashes(true, 'sha1');
 
             expect(config.integrityAlgorithms).toEqual(['sha1']);
         });
 
-        it('Calling it with multiple algorithms', function() {
+        it('Calling it with multiple algorithms', function () {
             const config = createConfig();
             config.enableIntegrityHashes(true, ['sha1', 'sha256', 'sha512']);
 
             expect(config.integrityAlgorithms).toEqual(['sha1', 'sha256', 'sha512']);
         });
 
-        it('Calling it with an invalid algorithm', function() {
+        it('Calling it with an invalid algorithm', function () {
             const config = createConfig();
-            expect(() => config.enableIntegrityHashes(true, {})).toThrow('must be a string or an array of strings');
-            expect(() => config.enableIntegrityHashes(true, [1])).toThrow('must be a string or an array of strings');
-            expect(() => config.enableIntegrityHashes(true, 'foo')).toThrow('Invalid hash algorithm "foo"');
-            expect(() => config.enableIntegrityHashes(true, ['sha1', 'foo', 'sha256'])).toThrow('Invalid hash algorithm "foo"');
+            expect(() => config.enableIntegrityHashes(true, {})).toThrow(
+                'must be a string or an array of strings'
+            );
+            expect(() => config.enableIntegrityHashes(true, [1])).toThrow(
+                'must be a string or an array of strings'
+            );
+            expect(() => config.enableIntegrityHashes(true, 'foo')).toThrow(
+                'Invalid hash algorithm "foo"'
+            );
+            expect(() => config.enableIntegrityHashes(true, ['sha1', 'foo', 'sha256'])).toThrow(
+                'Invalid hash algorithm "foo"'
+            );
         });
     });
 
-    describe('validateNameIsNewEntry', function() {
-        it('Providing a new name does not throw an error', function() {
+    describe('validateNameIsNewEntry', function () {
+        it('Providing a new name does not throw an error', function () {
             const config = createConfig();
             config.addEntry('entry_foo', './foo.js');
 
@@ -1562,7 +1604,7 @@ describe('WebpackConfig object', function() {
             }).to.not.throw;
         });
 
-        it('Providing a name exists within Entries does throw an error', function() {
+        it('Providing a name exists within Entries does throw an error', function () {
             const config = createConfig();
             config.addEntry('entry_foo', './foo.js');
 
@@ -1571,7 +1613,7 @@ describe('WebpackConfig object', function() {
             }).toThrow('already exists as an Entrypoint');
         });
 
-        it('Providing a name exists within Style Entries does throw an error', function() {
+        it('Providing a name exists within Style Entries does throw an error', function () {
             const config = createConfig();
             config.addStyleEntry('entry_foo', './foo.js');
 

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -7,22 +7,24 @@
  * file that was distributed with this source code.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import child_process from 'node:child_process';
+import { promisify } from 'node:util';
 import path from 'path';
+
 import fs from 'fs-extra';
 import getPort from 'get-port';
-import { promisify } from 'node:util';
-import child_process from 'node:child_process';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
 import * as testSetup from '../helpers/setup.js';
 
 const exec = promisify(child_process.exec);
 
 const projectDir = path.resolve(import.meta.dirname, '../', '../');
 
-describe.sequential('bin/encore.js', function() {
+describe.sequential('bin/encore.js', function () {
     // being functional tests, these can take quite long
 
-    it('Basic smoke test', async function() {
+    it('Basic smoke test', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -59,7 +61,7 @@ export default await Encore.getWebpackConfig();
         expect(stdout).not.toContain('Time: ');
     });
 
-    it('Smoke test using the --json option', async function() {
+    it('Smoke test using the --json option', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -78,7 +80,9 @@ export default await Encore.getWebpackConfig();
         );
 
         const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
-        const { stdout } = await exec(`node ${binPath} dev --json --context=${testDir}`, { cwd: testDir });
+        const { stdout } = await exec(`node ${binPath} dev --json --context=${testDir}`, {
+            cwd: testDir,
+        });
 
         let parsedOutput = null;
         try {
@@ -98,7 +102,7 @@ export default await Encore.getWebpackConfig();
         expect(parsedOutput.modules.length).toBe(4);
     });
 
-    it('Smoke test using the --profile option', async function() {
+    it('Smoke test using the --profile option', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -117,7 +121,9 @@ export default await Encore.getWebpackConfig();
         );
 
         const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
-        const { stdout } = await exec(`node ${binPath} dev --profile --context=${testDir}`, { cwd: testDir });
+        const { stdout } = await exec(`node ${binPath} dev --profile --context=${testDir}`, {
+            cwd: testDir,
+        });
 
         expect(stdout).toContain('resolving: ');
         expect(stdout).toContain('restoring: ');
@@ -125,7 +131,7 @@ export default await Encore.getWebpackConfig();
         expect(stdout).toContain('building: ');
     });
 
-    it('Smoke test using the --keep-public-path option', async function() {
+    it('Smoke test using the --keep-public-path option', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -144,12 +150,15 @@ export default await Encore.getWebpackConfig();
         );
 
         const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
-        const { stdout } = await exec(`node ${binPath} dev --keep-public-path --context=${testDir}`, { cwd: testDir });
+        const { stdout } = await exec(
+            `node ${binPath} dev --keep-public-path --context=${testDir}`,
+            { cwd: testDir }
+        );
 
         expect(stdout).toContain('Compiled successfully');
     });
 
-    it('Display an error when calling an unknown method', async function() {
+    it('Display an error when calling an unknown method', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -187,10 +196,12 @@ export default await Encore.getWebpackConfig();
             return;
         }
 
-        throw new Error('This code should not be executed, it means that the `try` bloc didn\'t throw an exception.');
+        throw new Error(
+            "This code should not be executed, it means that the `try` bloc didn't throw an exception."
+        );
     });
 
-    it('Run the webpack-dev-server successfully', async function() {
+    it('Run the webpack-dev-server successfully', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -240,20 +251,28 @@ export default await Encore.getWebpackConfig();
             expect(err.stdout).toContain('webpack compiled successfully');
 
             expect(err.stderr).toContain('[webpack-dev-server] Project is running at:');
-            expect(err.stderr).toContain(`[webpack-dev-server] Loopback: http://localhost:${port}/`);
-            expect(err.stderr).toContain('[webpack-dev-server] Content not from webpack is served from');
+            expect(err.stderr).toContain(
+                `[webpack-dev-server] Loopback: http://localhost:${port}/`
+            );
+            expect(err.stderr).toContain(
+                '[webpack-dev-server] Content not from webpack is served from'
+            );
 
             // Verify entrypoints.json contains http:// URLs
-            const entrypoints = JSON.parse(fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8'));
+            const entrypoints = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8')
+            );
             expect(entrypoints.entrypoints.main.js[0]).toContain(`http://localhost:${port}/build/`);
 
             // Verify manifest.json contains http:// URLs
-            const manifest = JSON.parse(fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8'));
+            const manifest = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8')
+            );
             expect(manifest['build/main.js']).toContain(`http://localhost:${port}/build/`);
         }
     });
 
-    it('Run the webpack-dev-server with --server-type https', async function() {
+    it('Run the webpack-dev-server with --server-type https', async function () {
         const testDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -289,11 +308,14 @@ export default await Encore.getWebpackConfig();
         }, 5000);
 
         try {
-            await exec(`node ${binPath} dev-server --server-type https --context=${testDir} --port=${port}`, {
-                cwd: testDir,
-                env: Object.assign({}, process.env, { NO_COLOR: 'true' }),
-                signal: abortController.signal,
-            });
+            await exec(
+                `node ${binPath} dev-server --server-type https --context=${testDir} --port=${port}`,
+                {
+                    cwd: testDir,
+                    env: Object.assign({}, process.env, { NO_COLOR: 'true' }),
+                    signal: abortController.signal,
+                }
+            );
         } catch (err) {
             if (err.name !== 'AbortError') {
                 throw new Error('Error executing encore', { cause: err });
@@ -304,31 +326,41 @@ export default await Encore.getWebpackConfig();
             expect(err.stdout).toContain('webpack compiled successfully');
 
             expect(err.stderr).toContain('[webpack-dev-server] Project is running at:');
-            expect(err.stderr).toContain(`[webpack-dev-server] Loopback: https://localhost:${port}/`);
-            expect(err.stderr).toContain('[webpack-dev-server] Content not from webpack is served from');
+            expect(err.stderr).toContain(
+                `[webpack-dev-server] Loopback: https://localhost:${port}/`
+            );
+            expect(err.stderr).toContain(
+                '[webpack-dev-server] Content not from webpack is served from'
+            );
 
             // Verify entrypoints.json contains https:// URLs
-            const entrypoints = JSON.parse(fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8'));
-            expect(entrypoints.entrypoints.main.js[0]).toContain(`https://localhost:${port}/build/`);
+            const entrypoints = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'entrypoints.json'), 'utf8')
+            );
+            expect(entrypoints.entrypoints.main.js[0]).toContain(
+                `https://localhost:${port}/build/`
+            );
 
             // Verify manifest.json contains https:// URLs
-            const manifest = JSON.parse(fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8'));
+            const manifest = JSON.parse(
+                fs.readFileSync(path.join(testDir, 'build', 'manifest.json'), 'utf8')
+            );
             expect(manifest['build/main.js']).toContain(`https://localhost:${port}/build/`);
         }
     });
 
-    describe('Without webpack-dev-server installed', function() {
-        beforeAll(async function() {
+    describe('Without webpack-dev-server installed', function () {
+        beforeAll(async function () {
             await exec('pnpm remove webpack-dev-server', { cwd: projectDir });
         });
 
-        afterAll(async function() {
+        afterAll(async function () {
             // Re-install webpack-dev-server and ensure the project is in a clean state
             await exec('git checkout package.json', { cwd: projectDir });
             await exec('pnpm install --no-frozen-lockfile', { cwd: projectDir });
         }, 20000);
 
-        it('Throw an error when trying to use the webpack-dev-server if not installed', async function() {
+        it('Throw an error when trying to use the webpack-dev-server if not installed', async function () {
             const testDir = testSetup.createTestAppDir();
 
             fs.writeFileSync(
@@ -361,10 +393,12 @@ export default await Encore.getWebpackConfig();
             try {
                 await exec(`node ${binPath} dev-server --context=${testDir} --port=${port}`, {
                     cwd: testDir,
-                    env: Object.assign({}, process.env, { NO_COLOR: 'true' })
+                    env: Object.assign({}, process.env, { NO_COLOR: 'true' }),
                 });
             } catch (err) {
-                expect(err.stdout).toContain('Install webpack-dev-server to use the webpack Development Server');
+                expect(err.stdout).toContain(
+                    'Install webpack-dev-server to use the webpack Development Server'
+                );
                 expect(err.stdout).toContain('npm install webpack-dev-server --save-dev');
                 expect(err.stdout).not.toContain('Running webpack-dev-server ...');
                 expect(err.stdout).not.toContain('Compiled successfully in');

--- a/test/config-generator.js
+++ b/test/config-generator.js
@@ -7,18 +7,20 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
-import { fileURLToPath } from 'url';
-import WebpackConfig from '../lib/WebpackConfig.js';
-import RuntimeConfig from '../lib/config/RuntimeConfig.js';
-import configGenerator from '../lib/config-generator.js';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
-import webpack from 'webpack';
 import path from 'path';
-import logger from '../lib/logger.js';
+import { fileURLToPath } from 'url';
 
-const isWindows = (process.platform === 'win32');
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import webpack from 'webpack';
+import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
+
+import configGenerator from '../lib/config-generator.js';
+import RuntimeConfig from '../lib/config/RuntimeConfig.js';
+import logger from '../lib/logger.js';
+import WebpackConfig from '../lib/WebpackConfig.js';
+
+const isWindows = process.platform === 'win32';
 
 function createConfig(runtimeConfig = null) {
     runtimeConfig = runtimeConfig ? runtimeConfig : new RuntimeConfig();
@@ -64,10 +66,9 @@ function findRule(regex, rules) {
     throw new Error(`No rule found for regex ${regex}`);
 }
 
-describe('The config-generator function', function() {
-
-    describe('Test basic output properties', function() {
-        it('Returns an object with the correct properties', async function() {
+describe('The config-generator function', function () {
+    describe('Test basic output properties', function () {
+        it('Returns an object with the correct properties', async function () {
             // setting context explicitly to make test more dependable
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.context = '/foo/dir';
@@ -85,7 +86,7 @@ describe('The config-generator function', function() {
             expect(actualConfig.plugins).to.be.an('Array');
         });
 
-        it('entries and styleEntries are merged', async function() {
+        it('entries and styleEntries are merged', async function () {
             const config = createConfig();
             config.publicPath = '/';
             config.outputPath = '/tmp';
@@ -95,14 +96,16 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(JSON.stringify(actualConfig.entry)).toBe(JSON.stringify({
-                main: './main',
-                main2: './main2',
-                style: ['./bootstrap.css', './main.css']
-            }));
+            expect(JSON.stringify(actualConfig.entry)).toBe(
+                JSON.stringify({
+                    main: './main',
+                    main2: './main2',
+                    style: ['./bootstrap.css', './main.css'],
+                })
+            );
         });
 
-        it('addEntry and addEntries expectations are merged', async function() {
+        it('addEntry and addEntries expectations are merged', async function () {
             const config = createConfig();
             config.publicPath = '/';
             config.outputPath = '/tmp';
@@ -111,13 +114,15 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(JSON.stringify(actualConfig.entry)).toBe(JSON.stringify({
-                main: './main',
-                main2: './main2',
-            }));
+            expect(JSON.stringify(actualConfig.entry)).toBe(
+                JSON.stringify({
+                    main: './main',
+                    main2: './main2',
+                })
+            );
         });
 
-        it('addStyleEntry and addEntries expectations are merged', async function() {
+        it('addStyleEntry and addEntries expectations are merged', async function () {
             const config = createConfig();
             config.publicPath = '/';
             config.outputPath = '/tmp';
@@ -126,13 +131,15 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(JSON.stringify(actualConfig.entry)).toBe(JSON.stringify({
-                main: './main',
-                style: ['./bootstrap.css', './main.css'],
-            }));
+            expect(JSON.stringify(actualConfig.entry)).toBe(
+                JSON.stringify({
+                    main: './main',
+                    style: ['./bootstrap.css', './main.css'],
+                })
+            );
         });
 
-        it('addEntry, addStyleEntry and addEntries expectations are merged', async function() {
+        it('addEntry, addStyleEntry and addEntries expectations are merged', async function () {
             const config = createConfig();
             config.publicPath = '/';
             config.outputPath = '/tmp';
@@ -142,14 +149,16 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(JSON.stringify(actualConfig.entry)).toBe(JSON.stringify({
-                main: './main',
-                main2: './main2',
-                style: ['./bootstrap.css', './main.css'],
-            }));
+            expect(JSON.stringify(actualConfig.entry)).toBe(
+                JSON.stringify({
+                    main: './main',
+                    main2: './main2',
+                    style: ['./bootstrap.css', './main.css'],
+                })
+            );
         });
 
-        it('basic output', async function() {
+        it('basic output', async function () {
             const config = createConfig();
 
             config.outputPath = '/tmp/public-path';
@@ -164,8 +173,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test source maps changes', function() {
-        it('without sourcemaps', async function() {
+    describe('Test source maps changes', function () {
+        it('without sourcemaps', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -178,7 +187,7 @@ describe('The config-generator function', function() {
             expect(JSON.stringify(actualConfig.module.rules)).not.toContain('?sourceMap');
         });
 
-        it('with sourcemaps', async function() {
+        it('with sourcemaps', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -192,8 +201,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test publicPath and manifestKeyPrefix variants', function() {
-        it('with normal publicPath, manifestKeyPrefix matches it', async function() {
+    describe('Test publicPath and manifestKeyPrefix variants', function () {
+        it('with normal publicPath, manifestKeyPrefix matches it', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/web/build';
             config.addEntry('main', './main');
@@ -208,7 +217,7 @@ describe('The config-generator function', function() {
             expect(manifestPlugin.options.basePath).toBe('build/');
         });
 
-        it('when manifestKeyPrefix is set, that is used instead', async function() {
+        it('when manifestKeyPrefix is set, that is used instead', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/web/build';
             config.addEntry('main', './main');
@@ -225,7 +234,7 @@ describe('The config-generator function', function() {
             expect(manifestPlugin.options.basePath).toBe('/build/');
         });
 
-        it('manifestKeyPrefix can be empty', async function() {
+        it('manifestKeyPrefix can be empty', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/web/build';
             config.addEntry('main', './main');
@@ -239,8 +248,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test versioning changes', function() {
-        it('with versioning', async function() {
+    describe('Test versioning changes', function () {
+        it('with versioning', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -256,8 +265,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test production changes', function() {
-        it('not in production', async function() {
+    describe('Test production changes', function () {
+        it('not in production', async function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.context = '/tmp/context';
             runtimeConfig.environment = 'dev';
@@ -275,7 +284,7 @@ describe('The config-generator function', function() {
             expect(actualConfig.optimization.minimizer).toBeUndefined();
         });
 
-        it('YES to production', async function() {
+        it('YES to production', async function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.environment = 'production';
             const config = createConfig(runtimeConfig);
@@ -292,8 +301,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('enableSassLoader() adds the sass-loader', function() {
-        it('without enableSassLoader()', async function() {
+    describe('enableSassLoader() adds the sass-loader', function () {
+        it('without enableSassLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -305,7 +314,7 @@ describe('The config-generator function', function() {
             expect(JSON.stringify(actualConfig.module.rules)).not.toContain('sass-loader');
         });
 
-        it('enableSassLoader()', async function() {
+        it('enableSassLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -318,8 +327,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('enableLessLoader() adds the less-loader', function() {
-        it('without enableLessLoader()', async function() {
+    describe('enableLessLoader() adds the less-loader', function () {
+        it('without enableLessLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -331,7 +340,7 @@ describe('The config-generator function', function() {
             expect(JSON.stringify(actualConfig.module.rules)).not.toContain('less-loader');
         });
 
-        it('enableLessLoader()', async function() {
+        it('enableLessLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -344,8 +353,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('enableStylusLoader() adds the stylus-loader', function() {
-        it('without enableStylusLoader()', async function() {
+    describe('enableStylusLoader() adds the stylus-loader', function () {
+        it('without enableStylusLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -357,7 +366,7 @@ describe('The config-generator function', function() {
             expect(JSON.stringify(actualConfig.module.rules)).not.toContain('stylus-loader');
         });
 
-        it('enableStylusLoader()', async function() {
+        it('enableStylusLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -370,9 +379,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('enableHandlebarsLoader() adds the handlebars-loader', function() {
-
-        it('without enableHandlebarsLoader()', async function() {
+    describe('enableHandlebarsLoader() adds the handlebars-loader', function () {
+        it('without enableHandlebarsLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -382,7 +390,7 @@ describe('The config-generator function', function() {
             expect(JSON.stringify(actualConfig.module.rules)).not.toContain('handlebars-loader');
         });
 
-        it('enableHandlebarsLoader()', async function() {
+        it('enableHandlebarsLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -395,21 +403,24 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('addLoader() adds a custom loader', function() {
-        it('addLoader()', async function() {
+    describe('addLoader() adds a custom loader', function () {
+        it('addLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
-            config.addLoader({ 'test': /\.custom$/, 'loader': 'custom-loader' });
+            config.addLoader({ test: /\.custom$/, loader: 'custom-loader' });
 
             const actualConfig = await configGenerator(config);
 
-            expect(actualConfig.module.rules).to.deep.include({ 'test': /\.custom$/, 'loader': 'custom-loader' });
+            expect(actualConfig.module.rules).to.deep.include({
+                test: /\.custom$/,
+                loader: 'custom-loader',
+            });
         });
     });
 
-    describe('enableVueLoader() with runtimeCompilerBuild sets Vue alias', function() {
-        it('defaults to "true"', async function() {
+    describe('enableVueLoader() with runtimeCompilerBuild sets Vue alias', function () {
+        it('defaults to "true"', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -419,11 +430,11 @@ describe('The config-generator function', function() {
             const actualConfig = await configGenerator(config);
 
             expect(actualConfig.resolve.alias).toEqual({
-                'vue$': 'vue/dist/vue.esm-bundler.js',
+                vue$: 'vue/dist/vue.esm-bundler.js',
             });
         });
 
-        it('no alias for false', async function() {
+        it('no alias for false', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -436,8 +447,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('addAliases() adds new aliases', function() {
-        it('without addAliases()', async function() {
+    describe('addAliases() adds new aliases', function () {
+        it('without addAliases()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -447,48 +458,48 @@ describe('The config-generator function', function() {
             expect(actualConfig.resolve.alias).toEqual({});
         });
 
-        it('with addAliases()', async function() {
+        it('with addAliases()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addAliases({
-                'testA': 'src/testA',
-                'testB': 'src/testB'
+                testA: 'src/testA',
+                testB: 'src/testB',
             });
 
             const actualConfig = await configGenerator(config);
 
             expect(actualConfig.resolve.alias).toEqual({
-                'testA': 'src/testA',
-                'testB': 'src/testB'
+                testA: 'src/testA',
+                testB: 'src/testB',
             });
         });
 
-        it('with addAliases() that overwrites pre-defined aliases', async function() {
+        it('with addAliases() that overwrites pre-defined aliases', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.enableVueLoader(() => {}, { version: 3 }); // Adds the 'vue$' alias
             config.enablePreactPreset({ preactCompat: true }); // Adds the 'react' and 'react-dom' aliases
             config.addAliases({
-                'foo': 'bar',
-                'vue$': 'new-vue$',
+                foo: 'bar',
+                vue$: 'new-vue$',
                 'react-dom': 'new-react-dom',
             });
 
             const actualConfig = await configGenerator(config);
 
             expect(actualConfig.resolve.alias).toEqual({
-                'foo': 'bar',
-                'vue$': 'new-vue$',
+                foo: 'bar',
+                vue$: 'new-vue$',
                 'react-dom': 'new-react-dom',
-                'react': 'preact/compat' // Keeps predefined aliases that are not overwritten
+                react: 'preact/compat', // Keeps predefined aliases that are not overwritten
             });
         });
     });
 
-    describe('addExternals() adds new externals', function() {
-        it('without addExternals()', async function() {
+    describe('addExternals() adds new externals', function () {
+        it('without addExternals()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -498,26 +509,28 @@ describe('The config-generator function', function() {
             expect(actualConfig.externals).toEqual([]);
         });
 
-        it('with addExternals()', async function() {
+        it('with addExternals()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addExternals({
-                'jquery': 'jQuery',
-                'react': 'react'
+                jquery: 'jQuery',
+                react: 'react',
             });
 
             const actualConfig = await configGenerator(config);
 
-            expect(actualConfig.externals).toEqual([{
-                'jquery': 'jQuery',
-                'react': 'react'
-            }]);
+            expect(actualConfig.externals).toEqual([
+                {
+                    jquery: 'jQuery',
+                    react: 'react',
+                },
+            ]);
         });
     });
 
-    describe('.js rule receives different configuration', function() {
-        it('Use default config', async function() {
+    describe('.js rule receives different configuration', function () {
+        it('Use default config', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -528,12 +541,14 @@ describe('The config-generator function', function() {
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
 
             // check for the default env preset only
-            expect(jsRule.use[0].options.presets[0]).contains(fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            expect(jsRule.use[0].options.presets[0]).contains(
+                fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
         });
     });
 
-    describe('cleanupOutputBeforeBuild() configures output cleaning', function() {
-        it('without cleanupOutputBeforeBuild()', async function() {
+    describe('cleanupOutputBeforeBuild() configures output cleaning', function () {
+        it('without cleanupOutputBeforeBuild()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -544,7 +559,7 @@ describe('The config-generator function', function() {
             expect(actualConfig.output.clean).toBe(false);
         });
 
-        it('with cleanupOutputBeforeBuild()', async function() {
+        it('with cleanupOutputBeforeBuild()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -557,8 +572,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('test for devServer config', function() {
-        it('no devServer config when not enabled', async function() {
+    describe('test for devServer config', function () {
+        it('no devServer config when not enabled', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = false;
             config.publicPath = '/';
@@ -569,7 +584,7 @@ describe('The config-generator function', function() {
             expect(actualConfig.devServer).toBeUndefined();
         });
 
-        it('devServer with custom options', async function() {
+        it('devServer with custom options', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerPort = 9090;
@@ -579,20 +594,22 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(actualConfig.devServer).to.have.nested.property('static.directory',
-                isWindows ? 'C:\\tmp\\public' : '/tmp/public');
+            expect(actualConfig.devServer).to.have.nested.property(
+                'static.directory',
+                isWindows ? 'C:\\tmp\\public' : '/tmp/public'
+            );
 
             // this should be set when running the config generator
             expect(config.runtimeConfig.devServerFinalIsHttps).is.false;
         });
 
-        it('devServer enabled with https via configureDevServerOptions', async function() {
+        it('devServer enabled with https via configureDevServerOptions', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
             config.setPublicPath('/');
             config.addEntry('main', './main');
-            config.configureDevServerOptions(options => {
+            config.configureDevServerOptions((options) => {
                 options.server = 'https';
             });
 
@@ -601,19 +618,19 @@ describe('The config-generator function', function() {
             expect(config.runtimeConfig.devServerFinalIsHttps).is.true;
         });
 
-        it('devServer enabled only via config', async function() {
+        it('devServer enabled only via config', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
             config.setPublicPath('/');
             config.addEntry('main', './main');
-            config.configureDevServerOptions(options => {
+            config.configureDevServerOptions((options) => {
                 options.server = {
-                    'type': 'https',
+                    type: 'https',
                     options: {
                         key: 'https.key',
                         cert: 'https.cert',
-                    }
+                    },
                 };
             });
 
@@ -632,19 +649,21 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('test for addPlugin config', function() {
+    describe('test for addPlugin config', function () {
         function CustomPlugin1() {}
         function CustomPlugin2() {}
         function CustomPlugin3() {}
 
-        it('extra plugin is set correctly', async function() {
+        it('extra plugin is set correctly', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
-            config.addPlugin(new webpack.IgnorePlugin({
-                contextRegExp: /^\.\/locale$/,
-                resourceRegExp: /moment$/
-            }));
+            config.addPlugin(
+                new webpack.IgnorePlugin({
+                    contextRegExp: /^\.\/locale$/,
+                    resourceRegExp: /moment$/,
+                })
+            );
 
             const actualConfig = await configGenerator(config);
 
@@ -652,7 +671,7 @@ describe('The config-generator function', function() {
             expect(ignorePlugin).to.not.be.undefined;
         });
 
-        it('by default custom plugins are added after the last plugin with a priority of 0 and are kept in order', async function() {
+        it('by default custom plugins are added after the last plugin with a priority of 0 and are kept in order', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
@@ -668,7 +687,7 @@ describe('The config-generator function', function() {
             expect(plugins[plugins.length - 2]).toBeInstanceOf(CustomPlugin3);
         });
 
-        it('plugins can be sorted relatively to each other', async function() {
+        it('plugins can be sorted relatively to each other', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
@@ -685,8 +704,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test filenames changes', function() {
-        it('without versioning', async function() {
+    describe('Test filenames changes', function () {
+        it('without versioning', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -706,7 +725,7 @@ describe('The config-generator function', function() {
             expect(miniCssExtractPlugin.options.filename).toBe('[name].foo.css');
         });
 
-        it('with versioning', async function() {
+        it('with versioning', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -728,8 +747,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('configuration for assets (images and fonts)', function() {
-        it('no custom config', async function() {
+    describe('configuration for assets (images and fonts)', function () {
+        it('no custom config', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -737,35 +756,42 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            const imagesRule = findRule(/\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/, actualConfig.module.rules).oneOf[1];
+            const imagesRule = findRule(
+                /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
+                actualConfig.module.rules
+            ).oneOf[1];
             expect(imagesRule.type).toBe('asset/resource');
             expect(imagesRule.generator).to.eql({ filename: 'images/[name].[hash:8][ext]' });
             expect(imagesRule.parser).to.eql({});
             expect(imagesRule).to.include.keys('type', 'generator', 'parser');
 
-            const fontsRule = findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules).oneOf[1];
+            const fontsRule = findRule(/\.(woff|woff2|ttf|eot|otf)$/, actualConfig.module.rules)
+                .oneOf[1];
             expect(fontsRule.type).toBe('asset/resource');
             expect(fontsRule.generator).to.eql({ filename: 'fonts/[name].[hash:8][ext]' });
         });
 
-        it('with configureImageRule() custom options', async function() {
+        it('with configureImageRule() custom options', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
             config.configureImageRule({
                 type: 'asset/resource',
-                filename: 'file.[hash][ext]'
+                filename: 'file.[hash][ext]',
             });
 
             const actualConfig = await configGenerator(config);
 
-            const imagesRule = findRule(/\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/, actualConfig.module.rules).oneOf[1];
+            const imagesRule = findRule(
+                /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
+                actualConfig.module.rules
+            ).oneOf[1];
             expect(imagesRule.type).toBe('asset/resource');
             expect(imagesRule.generator).to.eql({ filename: 'file.[hash][ext]' });
         });
 
-        it('with configureImageRule() and maxSize', async function() {
+        it('with configureImageRule() and maxSize', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -777,11 +803,14 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            const imagesRule = findRule(/\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/, actualConfig.module.rules).oneOf[1];
+            const imagesRule = findRule(
+                /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
+                actualConfig.module.rules
+            ).oneOf[1];
             expect(imagesRule.parser).to.eql({ dataUrlCondition: { maxSize: 3000 } });
         });
 
-        it('with configureImageRule() disabled', async function() {
+        it('with configureImageRule() disabled', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -792,15 +821,15 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(function() {
+            expect(function () {
                 findRule(/\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/, actualConfig.module.rules);
             }).toThrow();
         });
     });
 
-    describe('Test preact preset', function() {
-        describe('Without preact-compat', function() {
-            it('enablePreactPreset() does not add aliases to use preact-compat', async function() {
+    describe('Test preact preset', function () {
+        describe('Without preact-compat', function () {
+            it('enablePreactPreset() does not add aliases to use preact-compat', async function () {
                 const config = createConfig();
                 config.outputPath = '/tmp/public/build';
                 config.setPublicPath('/build/');
@@ -811,8 +840,8 @@ describe('The config-generator function', function() {
             });
         });
 
-        describe('With preact-compat', function() {
-            it('enablePreactPreset({ preactCompat: true }) adds aliases to use preact-compat', async function() {
+        describe('With preact-compat', function () {
+            it('enablePreactPreset({ preactCompat: true }) adds aliases to use preact-compat', async function () {
                 const config = createConfig();
                 config.outputPath = '/tmp/public/build';
                 config.setPublicPath('/build/');
@@ -826,8 +855,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test enableBuildCache()', function() {
-        it('with full arguments', async function() {
+    describe('Test enableBuildCache()', function () {
+        it('with full arguments', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -840,11 +869,11 @@ describe('The config-generator function', function() {
             expect(actualConfig.cache).to.eql({
                 type: 'filesystem',
                 buildDependencies: { config: ['foo.js'] },
-                version: 5
+                version: 5,
             });
         });
 
-        it('with sourcemaps', async function() {
+        it('with sourcemaps', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public-path';
             config.publicPath = '/public-path';
@@ -858,8 +887,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test configureBabel()', function() {
-        it('without configureBabel()', async function() {
+    describe('Test configureBabel()', function () {
+        it('without configureBabel()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -870,18 +899,20 @@ describe('The config-generator function', function() {
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             expect(String(jsRule.exclude)).toBe(String(/(node_modules|bower_components)/));
 
-            const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
-            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            const babelLoader = jsRule.use.find((loader) => /babel-loader/.test(loader.loader));
+            const babelEnvPreset = babelLoader.options.presets.find(
+                ([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
             expect(babelEnvPreset[1].useBuiltIns).toBe(false);
         });
 
-        it('with configureBabel() and a different exclude rule', async function() {
+        it('with configureBabel() and a different exclude rule', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
             config.configureBabel(() => {}, {
-                exclude: /foo/
+                exclude: /foo/,
             });
 
             const actualConfig = await configGenerator(config);
@@ -890,29 +921,31 @@ describe('The config-generator function', function() {
             expect(String(jsRule.exclude)).toBe(String(/foo/));
         });
 
-        it('with configureBabel() and some whitelisted modules', async function() {
+        it('with configureBabel() and some whitelisted modules', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
             config.configureBabel(() => {}, {
-                includeNodeModules: ['foo']
+                includeNodeModules: ['foo'],
             });
 
             const actualConfig = await configGenerator(config);
 
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
             expect(jsRule.exclude).to.be.a('Function');
-            expect(jsRule.exclude(path.join('test', 'node_modules', 'foo', 'index.js'))).toBe(false);
+            expect(jsRule.exclude(path.join('test', 'node_modules', 'foo', 'index.js'))).toBe(
+                false
+            );
             expect(jsRule.exclude(path.join('test', 'node_modules', 'bar', 'index.js'))).toBe(true);
         });
 
-        it('with configureBabel() and a different useBuiltIns value', async function() {
+        it('with configureBabel() and a different useBuiltIns value', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
-            config.configureBabel(() => { }, {
+            config.configureBabel(() => {}, {
                 useBuiltIns: 'usage',
                 corejs: 3,
             });
@@ -920,15 +953,17 @@ describe('The config-generator function', function() {
             const actualConfig = await configGenerator(config);
 
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
-            const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
-            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            const babelLoader = jsRule.use.find((loader) => /babel-loader/.test(loader.loader));
+            const babelEnvPreset = babelLoader.options.presets.find(
+                ([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
             expect(babelEnvPreset[1].useBuiltIns).toBe('usage');
             expect(babelEnvPreset[1].corejs).toBe(3);
         });
     });
 
-    describe('Test configureBabelPresetEnv()', function() {
-        it('without configureBabelPresetEnv()', async function() {
+    describe('Test configureBabelPresetEnv()', function () {
+        it('without configureBabelPresetEnv()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -937,31 +972,35 @@ describe('The config-generator function', function() {
             const actualConfig = await configGenerator(config);
 
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
-            const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
-            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            const babelLoader = jsRule.use.find((loader) => /babel-loader/.test(loader.loader));
+            const babelEnvPreset = babelLoader.options.presets.find(
+                ([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
             expect(babelEnvPreset[1].useBuiltIns).toBe(false);
         });
 
-        it('with configureBabelPresetEnv()', async function() {
+        it('with configureBabelPresetEnv()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.addEntry('main', './main');
-            config.configureBabelPresetEnv(options => {
+            config.configureBabelPresetEnv((options) => {
                 options.useBuiltIns = 'usage';
             });
 
             const actualConfig = await configGenerator(config);
 
             const jsRule = findRule(/\.(m?jsx?)$/, actualConfig.module.rules);
-            const babelLoader = jsRule.use.find(loader => /babel-loader/.test(loader.loader));
-            const babelEnvPreset = babelLoader.options.presets.find(([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            const babelLoader = jsRule.use.find((loader) => /babel-loader/.test(loader.loader));
+            const babelEnvPreset = babelLoader.options.presets.find(
+                ([name]) => name === fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
             expect(babelEnvPreset[1].useBuiltIns).toBe('usage');
         });
     });
 
-    describe('Test shouldSplitEntryChunks', function() {
-        it('splits entry chunks', async function() {
+    describe('Test shouldSplitEntryChunks', function () {
+        it('splits entry chunks', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
@@ -973,17 +1012,17 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test shouldUseSingleRuntimeChunk', function() {
-        beforeAll(function() {
+    describe('Test shouldUseSingleRuntimeChunk', function () {
+        beforeAll(function () {
             logger.reset();
             logger.quiet();
         });
 
-        afterAll(function() {
+        afterAll(function () {
             logger.quiet(false);
         });
 
-        it('Set to true', async function() {
+        it('Set to true', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
@@ -994,7 +1033,7 @@ describe('The config-generator function', function() {
             expect(logger.getMessages().deprecation).to.be.empty;
         });
 
-        it('Set to false', async function() {
+        it('Set to false', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
@@ -1005,7 +1044,7 @@ describe('The config-generator function', function() {
             expect(logger.getMessages().deprecation).to.be.empty;
         });
 
-        it('Not set should throw an error', async function() {
+        it('Not set should throw an error', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.shouldUseSingleRuntimeChunk = null;
@@ -1015,17 +1054,19 @@ describe('The config-generator function', function() {
                 await configGenerator(config);
                 expect.fail('Expected configGenerator to throw');
             } catch (e) {
-                expect(e.message).toContain('Either the Encore.enableSingleRuntimeChunk() or Encore.disableSingleRuntimeChunk() method should be called');
+                expect(e.message).toContain(
+                    'Either the Encore.enableSingleRuntimeChunk() or Encore.disableSingleRuntimeChunk() method should be called'
+                );
             }
         });
     });
 
-    describe('Test buildWatchOptionsConfig()', function() {
-        it('Set webpack watch options', async function() {
+    describe('Test buildWatchOptionsConfig()', function () {
+        it('Set webpack watch options', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build/');
-            config.configureWatchOptions(watchOptions => {
+            config.configureWatchOptions((watchOptions) => {
                 watchOptions.poll = 250;
             });
 
@@ -1037,17 +1078,17 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('Test configureLoaderRule()', function() {
+    describe('Test configureLoaderRule()', function () {
         let config;
 
-        beforeEach(function() {
+        beforeEach(function () {
             config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/');
             config.enableSingleRuntimeChunk();
         });
 
-        it('configure rule for "javascript"', async function() {
+        it('configure rule for "javascript"', async function () {
             config.configureLoaderRule('javascript', (loaderRule) => {
                 loaderRule.test = /\.m?js$/;
                 loaderRule.use[0].options.fooBar = 'fooBar';
@@ -1061,7 +1102,7 @@ describe('The config-generator function', function() {
             expect(rule.use[0].options.fooBar).toBe('fooBar');
         });
 
-        it('configure rule for the alias "js"', async function() {
+        it('configure rule for the alias "js"', async function () {
             config.configureLoaderRule('js', (loaderRule) => {
                 loaderRule.test = /\.m?js$/;
                 loaderRule.use[0].options.fooBar = 'fooBar';
@@ -1075,7 +1116,7 @@ describe('The config-generator function', function() {
             expect(rule.use[0].options.fooBar).toBe('fooBar');
         });
 
-        it('configure rule for "css"', async function() {
+        it('configure rule for "css"', async function () {
             config.configureLoaderRule('css', (loaderRule) => {
                 loaderRule.camelCase = true;
             });
@@ -1086,29 +1127,33 @@ describe('The config-generator function', function() {
             expect(rule.camelCase).toBe(true);
         });
 
-        it('configure rule for "images"', async function() {
+        it('configure rule for "images"', async function () {
             config.configureLoaderRule('images', (loaderRule) => {
                 loaderRule.oneOf[1].generator.filename = 'dirname-images/[hash:42][ext]';
             });
 
             const webpackConfig = await configGenerator(config);
-            const rule = findRule(/\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/, webpackConfig.module.rules).oneOf[1];
+            const rule = findRule(
+                /\.(png|jpg|jpeg|gif|ico|svg|webp|avif)$/,
+                webpackConfig.module.rules
+            ).oneOf[1];
 
             expect(rule.generator.filename).toBe('dirname-images/[hash:42][ext]');
         });
 
-        it('configure rule for "fonts"', async function() {
+        it('configure rule for "fonts"', async function () {
             config.configureLoaderRule('fonts', (loader) => {
                 loader.oneOf[1].generator.filename = 'dirname-fonts/[hash:42][ext]';
             });
 
             const webpackConfig = await configGenerator(config);
-            const rule = findRule(/\.(woff|woff2|ttf|eot|otf)$/, webpackConfig.module.rules).oneOf[1];
+            const rule = findRule(/\.(woff|woff2|ttf|eot|otf)$/, webpackConfig.module.rules)
+                .oneOf[1];
 
             expect(rule.generator.filename).toBe('dirname-fonts/[hash:42][ext]');
         });
 
-        it('configure rule for "sass"', async function() {
+        it('configure rule for "sass"', async function () {
             config.enableSassLoader();
             config.configureLoaderRule('sass', (loaderRule) => {
                 loaderRule.oneOf[1].use[2].options.fooBar = 'fooBar';
@@ -1120,7 +1165,7 @@ describe('The config-generator function', function() {
             expect(rule.oneOf[1].use[2].options.fooBar).toBe('fooBar');
         });
 
-        it('configure rule for the alias "scss"', async function() {
+        it('configure rule for the alias "scss"', async function () {
             config.enableSassLoader();
             config.configureLoaderRule('scss', (loaderRule) => {
                 loaderRule.oneOf[1].use[2].options.fooBar = 'fooBar';
@@ -1132,7 +1177,7 @@ describe('The config-generator function', function() {
             expect(rule.oneOf[1].use[2].options.fooBar).toBe('fooBar');
         });
 
-        it('configure rule for "less"', async function() {
+        it('configure rule for "less"', async function () {
             config.enableLessLoader((options) => {
                 options.optionA = 'optionA';
             });
@@ -1147,7 +1192,7 @@ describe('The config-generator function', function() {
             expect(rule.oneOf[1].use[2].options.optionB).toBe('optionB');
         });
 
-        it('configure rule for "stylus"', async function() {
+        it('configure rule for "stylus"', async function () {
             config.enableStylusLoader((options) => {
                 options.optionA = 'optionA';
             });
@@ -1162,7 +1207,7 @@ describe('The config-generator function', function() {
             expect(rule.oneOf[1].use[2].options.optionB).toBe('optionB');
         });
 
-        it('configure rule for "vue"', async function() {
+        it('configure rule for "vue"', async function () {
             config.enableVueLoader((options) => {
                 options.shadowMode = true;
             });
@@ -1177,7 +1222,7 @@ describe('The config-generator function', function() {
             expect(rule.use[0].options.prettify).toBe(false);
         });
 
-        it('configure rule for "typescript" and "ts"', async function() {
+        it('configure rule for "typescript" and "ts"', async function () {
             config.enableTypeScriptLoader((options) => {
                 options.silent = true;
             });
@@ -1192,7 +1237,7 @@ describe('The config-generator function', function() {
             expect(rule.use[1].options.happyPackMode).toBe(true);
         });
 
-        it('configure rule for the alias "ts"', async function() {
+        it('configure rule for the alias "ts"', async function () {
             config.enableTypeScriptLoader((options) => {
                 options.silent = true;
             });
@@ -1207,7 +1252,7 @@ describe('The config-generator function', function() {
             expect(rule.use[1].options.happyPackMode).toBe(true);
         });
 
-        it('configure rule for "handlebars"', async function() {
+        it('configure rule for "handlebars"', async function () {
             config.enableHandlebarsLoader((options) => {
                 options.debug = true;
             });
@@ -1223,8 +1268,8 @@ describe('The config-generator function', function() {
         });
     });
 
-    describe('enablePostCssLoader() makes the CSS rule process .postcss file', function() {
-        it('without enablePostCssLoader()', async function() {
+    describe('enablePostCssLoader() makes the CSS rule process .postcss file', function () {
+        it('without enablePostCssLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -1233,15 +1278,15 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(function() {
+            expect(function () {
                 findRule(/\.(css)$/, actualConfig.module.rules);
             }).not.toThrow();
-            expect(function() {
+            expect(function () {
                 findRule(/\.(css|pcss|postcss)$/, actualConfig.module.rules);
             }).toThrow();
         });
 
-        it('with enablePostCssLoader()', async function() {
+        it('with enablePostCssLoader()', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -1251,17 +1296,17 @@ describe('The config-generator function', function() {
 
             const actualConfig = await configGenerator(config);
 
-            expect(function() {
+            expect(function () {
                 findRule(/\.(css)$/, actualConfig.module.rules);
             }).toThrow();
-            expect(function() {
+            expect(function () {
                 findRule(/\.(css|pcss|postcss)$/, actualConfig.module.rules);
             }).to.not.throw();
         });
     });
 
-    describe('Test addCacheGroup()', function() {
-        it('Calling it adds cache groups', async function() {
+    describe('Test addCacheGroup()', function () {
+        it('Calling it adds cache groups', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
@@ -1278,13 +1323,13 @@ describe('The config-generator function', function() {
             });
         });
 
-        it('Calling it using the "node_modules" option', async function() {
+        it('Calling it using the "node_modules" option', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';
             config.enableSingleRuntimeChunk();
             config.addEntry('main', './main');
-            config.addCacheGroup('foo', { node_modules: ['foo','bar', 'baz'] });
+            config.addCacheGroup('foo', { node_modules: ['foo', 'bar', 'baz'] });
 
             const actualConfig = await configGenerator(config);
 
@@ -1298,7 +1343,7 @@ describe('The config-generator function', function() {
             });
         });
 
-        it('Calling it and overriding default options', async function() {
+        it('Calling it and overriding default options', async function () {
             const config = createConfig();
             config.outputPath = '/tmp/output/public-path';
             config.publicPath = '/public-path';

--- a/test/config/parse-runtime.js
+++ b/test/config/parse-runtime.js
@@ -7,13 +7,15 @@
  * file that was distributed with this source code.
  */
 
+import path from 'path';
+
+import fs from 'fs-extra';
 import { describe, it, expect } from 'vitest';
+import yargsParser from 'yargs-parser';
+
 import parseArgv from '../../lib/config/parse-runtime.js';
 import WebpackConfig from '../../lib/WebpackConfig.js';
 import * as testSetup from '../helpers/setup.js';
-import fs from 'fs-extra';
-import path from 'path';
-import yargsParser from 'yargs-parser';
 
 function createArgv(argv) {
     return yargsParser(argv);
@@ -21,16 +23,13 @@ function createArgv(argv) {
 
 function createTestDirectory() {
     const projectDir = testSetup.createTestAppDir();
-    fs.writeFileSync(
-        path.join(projectDir, 'package.json'),
-        '{}'
-    );
+    fs.writeFileSync(path.join(projectDir, 'package.json'), '{}');
 
     return projectDir;
 }
 
-describe('parse-runtime', function() {
-    it('Basic usage', function() {
+describe('parse-runtime', function () {
+    it('Basic usage', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['foobar', '--bar', '--help']), testDir);
 
@@ -42,7 +41,7 @@ describe('parse-runtime', function() {
         expect(config.babelRcFileExists).toBeNull();
     });
 
-    it('dev command', function() {
+    it('dev command', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['dev', '--bar']), testDir);
 
@@ -50,7 +49,7 @@ describe('parse-runtime', function() {
         expect(config.isValidCommand).toBe(true);
     });
 
-    it('production command', function() {
+    it('production command', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['production', '--bar']), testDir);
 
@@ -58,7 +57,7 @@ describe('parse-runtime', function() {
         expect(config.isValidCommand).toBe(true);
     });
 
-    it('dev-server command', function() {
+    it('dev-server command', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['dev-server', '--bar']), testDir);
 
@@ -70,18 +69,32 @@ describe('parse-runtime', function() {
         expect(config.devServerPublic).toBeNull();
     });
 
-    it('dev-server command with options', function() {
+    it('dev-server command with options', function () {
         const testDir = createTestDirectory();
-        const config = parseArgv(createArgv(['dev-server', '--bar', '--host', 'foohost.l', '--port', '9999']), testDir);
+        const config = parseArgv(
+            createArgv(['dev-server', '--bar', '--host', 'foohost.l', '--port', '9999']),
+            testDir
+        );
 
         expect(config.environment).toBe('dev');
         expect(config.devServerHost).toBe('foohost.l');
         expect(config.devServerPort).toBe(9999);
     });
 
-    it('dev-server command server-type https', function() {
+    it('dev-server command server-type https', function () {
         const testDir = createTestDirectory();
-        const config = parseArgv(createArgv(['dev-server', '--server-type', 'https', '--host', 'foohost.l', '--port', '9999']), testDir);
+        const config = parseArgv(
+            createArgv([
+                'dev-server',
+                '--server-type',
+                'https',
+                '--host',
+                'foohost.l',
+                '--port',
+                '9999',
+            ]),
+            testDir
+        );
 
         expect(config.useDevServer).toBe(true);
         expect(config.devServerServerType).toBe('https');
@@ -89,26 +102,26 @@ describe('parse-runtime', function() {
         expect(config.devServerPort).toBe(9999);
     });
 
-    it('dev-server command public', function() {
+    it('dev-server command public', function () {
         const testDir = createTestDirectory();
-        const config = parseArgv(createArgv(['dev-server', '--public', 'https://my-domain:8080']), testDir);
+        const config = parseArgv(
+            createArgv(['dev-server', '--public', 'https://my-domain:8080']),
+            testDir
+        );
 
         expect(config.devServerPublic).toBe('https://my-domain:8080');
     });
 
-    it('--context is parsed correctly', function() {
+    it('--context is parsed correctly', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['dev', '--context', '/tmp/custom-context']), testDir);
 
         expect(config.context).toBe('/tmp/custom-context');
     });
 
-    it('babel config in package.json detected when present', async function() {
+    it('babel config in package.json detected when present', async function () {
         const projectDir = createTestDirectory();
-        fs.writeFileSync(
-            path.join(projectDir, 'package.json'),
-            '{"babel": {}}'
-        );
+        fs.writeFileSync(path.join(projectDir, 'package.json'), '{"babel": {}}');
 
         const runtimeConfig = parseArgv(createArgv(['dev']), projectDir);
         const webpackConfig = new WebpackConfig(runtimeConfig);
@@ -116,12 +129,9 @@ describe('parse-runtime', function() {
         expect(await webpackConfig.doesBabelRcFileExist()).toBe(true);
     });
 
-    it('.babelrc detected when present', async function() {
+    it('.babelrc detected when present', async function () {
         const projectDir = createTestDirectory();
-        fs.writeFileSync(
-            path.join(projectDir, '.babelrc'),
-            '{}'
-        );
+        fs.writeFileSync(path.join(projectDir, '.babelrc'), '{}');
 
         const runtimeConfig = parseArgv(createArgv(['dev']), projectDir);
         const webpackConfig = new WebpackConfig(runtimeConfig);
@@ -129,12 +139,9 @@ describe('parse-runtime', function() {
         expect(await webpackConfig.doesBabelRcFileExist()).toBe(true);
     });
 
-    it('babel.config.json detected when present', async function() {
+    it('babel.config.json detected when present', async function () {
         const projectDir = createTestDirectory();
-        fs.writeFileSync(
-            path.join(projectDir, 'babel.config.json'),
-            '{}'
-        );
+        fs.writeFileSync(path.join(projectDir, 'babel.config.json'), '{}');
 
         const runtimeConfig = parseArgv(createArgv(['dev']), projectDir);
         const webpackConfig = new WebpackConfig(runtimeConfig);
@@ -142,7 +149,7 @@ describe('parse-runtime', function() {
         expect(await webpackConfig.doesBabelRcFileExist()).toBe(true);
     });
 
-    it('dev-server command --keep-public-path', function() {
+    it('dev-server command --keep-public-path', function () {
         const testDir = createTestDirectory();
         const config = parseArgv(createArgv(['dev-server', '--keep-public-path']), testDir);
 

--- a/test/config/path-util.js
+++ b/test/config/path-util.js
@@ -7,12 +7,14 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
-import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
-import pathUtil from '../../lib/config/path-util.js';
-import configGenerator from '../../lib/config-generator.js';
 import process from 'process';
+
+import { describe, it, expect } from 'vitest';
+
+import configGenerator from '../../lib/config-generator.js';
+import pathUtil from '../../lib/config/path-util.js';
+import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -23,11 +25,11 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-const isWindows = (process.platform === 'win32');
+const isWindows = process.platform === 'win32';
 
-describe('path-util getContentBase()', function() {
-    describe('getContentBase()', function() {
-        it('contentBase is calculated correctly', function() {
+describe('path-util getContentBase()', function () {
+    describe('getContentBase()', function () {
+        it('contentBase is calculated correctly', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.outputPath = isWindows ? 'C:\\tmp\\public\\build' : '/tmp/public/build';
@@ -40,7 +42,7 @@ describe('path-util getContentBase()', function() {
             expect(actualContentBase).toBe(isWindows ? 'C:\\tmp\\public' : '/tmp/public');
         });
 
-        it('contentBase works ok with manifestKeyPrefix', function() {
+        it('contentBase works ok with manifestKeyPrefix', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.outputPath = isWindows ? 'C:\\tmp\\public\\build' : '/tmp/public/build';
@@ -53,7 +55,7 @@ describe('path-util getContentBase()', function() {
             expect(actualContentBase).toBe(isWindows ? 'C:\\tmp\\public' : '/tmp/public');
         });
 
-        it('contentBase is calculated correctly with no public path', function() {
+        it('contentBase is calculated correctly with no public path', function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.outputPath = isWindows ? 'C:\\tmp\\public' : '/tmp/public';
@@ -67,8 +69,8 @@ describe('path-util getContentBase()', function() {
         });
     });
 
-    describe('validatePublicPathAndManifestKeyPrefix', function() {
-        it('manifestKeyPrefix is correctly not required on windows', function() {
+    describe('validatePublicPathAndManifestKeyPrefix', function () {
+        it('manifestKeyPrefix is correctly not required on windows', function () {
             const config = createConfig();
             config.outputPath = 'C:\\projects\\webpack-encore\\web\\build';
             config.setPublicPath('/build/');
@@ -78,7 +80,7 @@ describe('path-util getContentBase()', function() {
             pathUtil.validatePublicPathAndManifestKeyPrefix(config);
         });
 
-        it('with absolute publicPath, manifestKeyPrefix must be set', function() {
+        it('with absolute publicPath, manifestKeyPrefix must be set', function () {
             const config = createConfig();
             config.outputPath = '/tmp/public/build';
             config.setPublicPath('/build');
@@ -87,10 +89,12 @@ describe('path-util getContentBase()', function() {
 
             expect(() => {
                 pathUtil.validatePublicPathAndManifestKeyPrefix(config);
-            }).toThrow('Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use');
+            }).toThrow(
+                'Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use'
+            );
         });
 
-        it('when outputPath and publicPath are incompatible, manifestKeyPrefix must be set', function() {
+        it('when outputPath and publicPath are incompatible, manifestKeyPrefix must be set', function () {
             const config = createConfig();
 
             config.outputPath = isWindows ? 'C:\\tmp\\public\\build' : '/tmp/public/build';
@@ -100,12 +104,14 @@ describe('path-util getContentBase()', function() {
 
             expect(() => {
                 pathUtil.validatePublicPathAndManifestKeyPrefix(config);
-            }).toThrow('Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use');
+            }).toThrow(
+                'Cannot determine how to prefix the keys in manifest.json. Call Encore.setManifestKeyPrefix() to choose what path (e.g. build/) to use'
+            );
         });
     });
 
-    describe('getRelativeOutputPath', function() {
-        it('basic usage', function() {
+    describe('getRelativeOutputPath', function () {
+        it('basic usage', function () {
             const config = createConfig();
             if (isWindows) {
                 config.runtimeConfig.context = 'C:\\projects\\webpack-encore';
@@ -120,8 +126,8 @@ describe('path-util getContentBase()', function() {
         });
     });
 
-    describe('calculateDevServerUrl', function() {
-        it('no https, no public', function() {
+    describe('calculateDevServerUrl', function () {
+        it('no https, no public', function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.devServerFinalIsHttps = false;
             runtimeConfig.devServerPublic = false;
@@ -131,7 +137,7 @@ describe('path-util getContentBase()', function() {
             expect(pathUtil.calculateDevServerUrl(runtimeConfig)).toBe('http://localhost:8080');
         });
 
-        it('yes https, no public', function() {
+        it('yes https, no public', function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.devServerFinalIsHttps = true;
             runtimeConfig.devServerPublic = false;
@@ -141,7 +147,7 @@ describe('path-util getContentBase()', function() {
             expect(pathUtil.calculateDevServerUrl(runtimeConfig)).toBe('https://localhost:8080');
         });
 
-        it('no https, yes public not absolute', function() {
+        it('no https, yes public not absolute', function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.devServerFinalIsHttps = false;
             runtimeConfig.devServerPublic = 'myhost.local:9090';
@@ -149,7 +155,7 @@ describe('path-util getContentBase()', function() {
             expect(pathUtil.calculateDevServerUrl(runtimeConfig)).toBe('http://myhost.local:9090');
         });
 
-        it('yes https, yes public not absolute', function() {
+        it('yes https, yes public not absolute', function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.devServerFinalIsHttps = true;
             runtimeConfig.devServerPublic = 'myhost.local:9090';
@@ -157,7 +163,7 @@ describe('path-util getContentBase()', function() {
             expect(pathUtil.calculateDevServerUrl(runtimeConfig)).toBe('https://myhost.local:9090');
         });
 
-        it('yes public and is absolute', function() {
+        it('yes public and is absolute', function () {
             const runtimeConfig = new RuntimeConfig();
             runtimeConfig.devServerFinalIsHttps = false;
             runtimeConfig.devServerPublic = 'https://myhost.local:9090';
@@ -166,8 +172,8 @@ describe('path-util getContentBase()', function() {
         });
     });
 
-    describe('calculateDevServerUrl with configGenerator integration', function() {
-        it('generates http URL without server option', async function() {
+    describe('calculateDevServerUrl with configGenerator integration', function () {
+        it('generates http URL without server option', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -180,10 +186,12 @@ describe('path-util getContentBase()', function() {
             // Run config generator to set devServerFinalIsHttps
             await configGenerator(config);
 
-            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe('http://localhost:8080');
+            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe(
+                'http://localhost:8080'
+            );
         });
 
-        it('generates https URL with server: "https" option', async function() {
+        it('generates https URL with server: "https" option', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -192,17 +200,19 @@ describe('path-util getContentBase()', function() {
             config.setPublicPath('/');
             config.addEntry('main', './main');
             config.enableSingleRuntimeChunk();
-            config.configureDevServerOptions(options => {
+            config.configureDevServerOptions((options) => {
                 options.server = 'https';
             });
 
             // Run config generator to set devServerFinalIsHttps
             await configGenerator(config);
 
-            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe('https://localhost:8080');
+            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe(
+                'https://localhost:8080'
+            );
         });
 
-        it('generates https URL with server: { type: "https" } option', async function() {
+        it('generates https URL with server: { type: "https" } option', async function () {
             const config = createConfig();
             config.runtimeConfig.useDevServer = true;
             config.runtimeConfig.devServerHost = 'localhost';
@@ -211,14 +221,16 @@ describe('path-util getContentBase()', function() {
             config.setPublicPath('/');
             config.addEntry('main', './main');
             config.enableSingleRuntimeChunk();
-            config.configureDevServerOptions(options => {
+            config.configureDevServerOptions((options) => {
                 options.server = { type: 'https' };
             });
 
             // Run config generator to set devServerFinalIsHttps
             await configGenerator(config);
 
-            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe('https://localhost:8080');
+            expect(pathUtil.calculateDevServerUrl(config.runtimeConfig)).toBe(
+                'https://localhost:8080'
+            );
         });
     });
 });

--- a/test/config/validator.js
+++ b/test/config/validator.js
@@ -8,10 +8,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import validator from '../../lib/config/validator.js';
 import logger from '../../lib/logger.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,10 +22,10 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('The validator function', function() {
+describe('The validator function', function () {
     function CustomPlugin1() {}
 
-    it('throws an error if there are no entries', function() {
+    it('throws an error if there are no entries', function () {
         const config = createConfig();
         config.publicPath = '/';
         config.outputPath = '/tmp';
@@ -34,7 +35,7 @@ describe('The validator function', function() {
         }).toThrow('No entries found!');
     });
 
-    it('should accept use with copyFiles() only', function() {
+    it('should accept use with copyFiles() only', function () {
         const config = createConfig();
         config.setOutputPath('/tmp');
         config.setPublicPath('/tmp');
@@ -47,7 +48,7 @@ describe('The validator function', function() {
         expect(Object.keys(config.copyFilesConfigs).length).toBe(1);
     });
 
-    it('should accept use with addPlugin() only', function() {
+    it('should accept use with addPlugin() only', function () {
         const config = createConfig();
         config.setOutputPath('/tmp');
         config.setPublicPath('/tmp');
@@ -58,7 +59,7 @@ describe('The validator function', function() {
         }).not.throw();
     });
 
-    it('throws an error if there is no output path', function() {
+    it('throws an error if there is no output path', function () {
         const config = createConfig();
         config.publicPath = '/';
         config.addEntry('main', './main');
@@ -68,7 +69,7 @@ describe('The validator function', function() {
         }).toThrow('Missing output path');
     });
 
-    it('throws an error if there is no public path', function() {
+    it('throws an error if there is no public path', function () {
         const config = createConfig();
         config.outputPath = '/tmp';
         config.addEntry('main', './main');
@@ -78,7 +79,7 @@ describe('The validator function', function() {
         }).toThrow('Missing public path');
     });
 
-    it('cannot use versioning with webpack-dev-server', function() {
+    it('cannot use versioning with webpack-dev-server', function () {
         const config = createConfig();
         config.outputPath = '/tmp/public/build';
         config.setPublicPath('/build');
@@ -88,10 +89,10 @@ describe('The validator function', function() {
 
         expect(() => {
             validator(config);
-        }).toThrow('Don\'t enable versioning with the dev-server');
+        }).toThrow("Don't enable versioning with the dev-server");
     });
 
-    it('warning with dev-server and absolute publicPath', function() {
+    it('warning with dev-server and absolute publicPath', function () {
         const config = createConfig();
         config.outputPath = '/tmp/public/build';
         config.setPublicPath('https://absoluteurl.com/build');
@@ -104,10 +105,12 @@ describe('The validator function', function() {
         validator(config);
 
         expect(logger.getMessages().warning).toHaveLength(1);
-        expect(logger.getMessages().warning[0]).to.include('Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues');
+        expect(logger.getMessages().warning[0]).to.include(
+            'Passing an absolute URL to setPublicPath() *and* using the dev-server can cause issues'
+        );
     });
 
-    it('warning with addCacheGroup() and core cache group name', function() {
+    it('warning with addCacheGroup() and core cache group name', function () {
         const config = createConfig();
         config.outputPath = '/tmp/public/build';
         config.setPublicPath('/build');
@@ -121,6 +124,8 @@ describe('The validator function', function() {
         validator(config);
 
         expect(logger.getMessages().warning).toHaveLength(1);
-        expect(logger.getMessages().warning[0]).to.include('Passing "defaultVendors" to addCacheGroup() is not recommended');
+        expect(logger.getMessages().warning[0]).to.include(
+            'Passing "defaultVendors" to addCacheGroup() is not recommended'
+        );
     });
 });

--- a/test/friendly-errors/formatters/missing-css-file.js
+++ b/test/friendly-errors/formatters/missing-css-file.js
@@ -8,20 +8,20 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import formatter from '../../../lib/friendly-errors/formatters/missing-css-file.js';
 
-describe('formatters/missing-css-file', function() {
-
-    describe('test format()', function() {
-        it('works with no errors', function() {
+describe('formatters/missing-css-file', function () {
+    describe('test format()', function () {
+        it('works with no errors', function () {
             const actualErrors = formatter([]);
             expect(actualErrors).to.be.empty;
         });
 
-        it('filters errors that dont have the correct type', function() {
+        it('filters errors that dont have the correct type', function () {
             const errors = [
                 { type: 'missing-css-file', file: 'some-file.sass', ref: '../images/foo.png' },
-                { type: 'other-type', file: 'other-type.sass' }
+                { type: 'other-type', file: 'other-type.sass' },
             ];
 
             const actualErrors = formatter(errors);
@@ -29,16 +29,20 @@ describe('formatters/missing-css-file', function() {
             expect(JSON.stringify(actualErrors)).not.toContain('other-type.sass');
         });
 
-        it('formats the error correctly', function() {
+        it('formats the error correctly', function () {
             const error = {
                 type: 'missing-css-file',
                 file: '/some/file.css',
-                ref: '../images/foo.png'
+                ref: '../images/foo.png',
             };
 
             const actualErrors = formatter([error]);
-            expect(JSON.stringify(actualErrors)).toContain('\\"/some/file.css\\" contains a reference to the file \\"../images/foo.png\\"');
-            expect(JSON.stringify(actualErrors)).toContain('This file can not be found, please check it for typos or update it if the file got moved.');
+            expect(JSON.stringify(actualErrors)).toContain(
+                '\\"/some/file.css\\" contains a reference to the file \\"../images/foo.png\\"'
+            );
+            expect(JSON.stringify(actualErrors)).toContain(
+                'This file can not be found, please check it for typos or update it if the file got moved.'
+            );
             // all needed packages will be present when running tests
             expect(JSON.stringify(actualErrors)).not.toContain('yarn add');
         });

--- a/test/friendly-errors/formatters/missing-loader.js
+++ b/test/friendly-errors/formatters/missing-loader.js
@@ -8,20 +8,20 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import formatter from '../../../lib/friendly-errors/formatters/missing-loader.js';
 
-describe('formatters/missing-loader', function() {
-
-    describe('test format()', function() {
-        it('works with no errors', function() {
+describe('formatters/missing-loader', function () {
+    describe('test format()', function () {
+        it('works with no errors', function () {
             const actualErrors = formatter([]);
             expect(actualErrors).to.be.empty;
         });
 
-        it('errors without loader-not-enabled type are filtered', function() {
+        it('errors without loader-not-enabled type are filtered', function () {
             const errors = [
                 { type: 'loader-not-enabled', file: 'not-enabled.sass' },
-                { type: 'other-type', file: 'other-type.sass' }
+                { type: 'other-type', file: 'other-type.sass' },
             ];
 
             const actualErrors = formatter(errors);
@@ -29,11 +29,11 @@ describe('formatters/missing-loader', function() {
             expect(JSON.stringify(actualErrors)).not.toContain('other-type.sass');
         });
 
-        it('error is formatted correctly', function() {
+        it('error is formatted correctly', function () {
             const error = {
                 type: 'loader-not-enabled',
                 file: '/some/file.sass',
-                loaderName: 'sass'
+                loaderName: 'sass',
             };
 
             const actualErrors = formatter([error]);
@@ -43,31 +43,35 @@ describe('formatters/missing-loader', function() {
             expect(JSON.stringify(actualErrors)).not.toContain('yarn add');
         });
 
-        it('error is formatted correctly without loaderName', function() {
+        it('error is formatted correctly without loaderName', function () {
             const error = {
                 type: 'loader-not-enabled',
-                file: '/some/file.jpg'
+                file: '/some/file.jpg',
             };
 
             const actualErrors = formatter([error]);
             expect(JSON.stringify(actualErrors)).toContain('To load \\"/some/file.jpg\\"');
-            expect(JSON.stringify(actualErrors)).toContain('You may need to install and configure a special loader');
+            expect(JSON.stringify(actualErrors)).toContain(
+                'You may need to install and configure a special loader'
+            );
         });
 
-        it('vue loader error includes original message & origin', function() {
+        it('vue loader error includes original message & origin', function () {
             const error = {
                 message: 'I am a message from vue-loader',
                 isVueLoader: true,
                 loaderName: 'sass',
                 origin: 'Some stacktrace info from origin',
                 type: 'loader-not-enabled',
-                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss'
+                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss',
             };
 
             const actualErrors = formatter([error]);
             expect(JSON.stringify(actualErrors)).toContain('I am a message from vue-loader');
             expect(JSON.stringify(actualErrors)).toContain('Some stacktrace info from origin');
-            expect(JSON.stringify(actualErrors)).not.toContain('/path/to/project/node_modules/vue-loader');
+            expect(JSON.stringify(actualErrors)).not.toContain(
+                '/path/to/project/node_modules/vue-loader'
+            );
         });
     });
 });

--- a/test/friendly-errors/transformers/missing-css-file.js
+++ b/test/friendly-errors/transformers/missing-css-file.js
@@ -8,44 +8,47 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import transform from '../../../lib/friendly-errors/transformers/missing-css-file.js';
 
-describe('transform/missing-css-file', function() {
-
-    describe('test transform', function() {
-        it('Error not with "ModuleNotFoundError" name is ignored', function() {
+describe('transform/missing-css-file', function () {
+    describe('test transform', function () {
+        it('Error not with "ModuleNotFoundError" name is ignored', function () {
             const startError = {
                 name: 'OtherParseError',
                 message: 'You may need an appropriate loader',
-                file: '/path/to/file.sass'
+                file: '/path/to/file.sass',
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError).toEqual(startError);
         });
 
-        it('Error not containing "Module not found: Error: Can\'t resolve" is ignored', function() {
+        it('Error not containing "Module not found: Error: Can\'t resolve" is ignored', function () {
             const startError = {
                 name: 'ModuleNotFoundError',
                 message: 'Some other message',
-                file: '/path/to/file.sass'
+                file: '/path/to/file.sass',
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError).toEqual(startError);
         });
 
-        it('Matching error is properly transformed', function() {
+        it('Matching error is properly transformed', function () {
             const startError = {
                 name: 'ModuleNotFoundError',
-                message: 'Module build failed: ModuleNotFoundError: Module not found: Error: Can\'t resolve \'./../images/symfony_logo.png2\' in \'/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css\'',
-                file: '/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css'
+                message:
+                    "Module build failed: ModuleNotFoundError: Module not found: Error: Can't resolve './../images/symfony_logo.png2' in '/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css'",
+                file: '/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css',
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError.ref).toEqual('./../images/symfony_logo.png2');
             expect(actualError.type).toEqual('missing-css-file');
-            expect(actualError.file).toEqual('/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css');
+            expect(actualError.file).toEqual(
+                '/Users/weaverryan/Sites/os/webpack-encore/tmp_project_playing/css'
+            );
         });
     });
 });

--- a/test/friendly-errors/transformers/missing-loader.js
+++ b/test/friendly-errors/transformers/missing-loader.js
@@ -8,8 +8,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import transformFactory from '../../../lib/friendly-errors/transformers/missing-loader.js';
+
 import RuntimeConfig from '../../../lib/config/RuntimeConfig.js';
+import transformFactory from '../../../lib/friendly-errors/transformers/missing-loader.js';
 import WebpackConfig from '../../../lib/WebpackConfig.js';
 
 const runtimeConfig = new RuntimeConfig();
@@ -17,48 +18,47 @@ runtimeConfig.context = import.meta.dirname;
 runtimeConfig.babelRcFileExists = false;
 const transform = transformFactory(new WebpackConfig(runtimeConfig));
 
-describe('transform/missing-loader', function() {
-
-    describe('test transform', function() {
-        it('Error not with "ModuleParseError" name is ignored', function() {
+describe('transform/missing-loader', function () {
+    describe('test transform', function () {
+        it('Error not with "ModuleParseError" name is ignored', function () {
             const startError = {
                 name: 'OtherParseError',
                 message: 'You may need an appropriate loader',
-                file: '/path/to/file.sass'
+                file: '/path/to/file.sass',
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError).toEqual(startError);
         });
 
-        it('Error not containing "appropriate loader" is ignored', function() {
+        it('Error not containing "appropriate loader" is ignored', function () {
             const startError = {
                 name: 'ModuleParseError',
                 message: 'Some other message',
-                file: '/path/to/file.sass'
+                file: '/path/to/file.sass',
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError).toEqual(startError);
         });
 
-        it('Error with unsupported file extension is ignored', function() {
+        it('Error with unsupported file extension is ignored', function () {
             const startError = {
                 name: 'ModuleParseError',
                 message: 'You may need an appropriate loader',
                 file: '/path/to/file.jpg',
-                isVueLoader: false
+                isVueLoader: false,
             };
             const actualError = transform(Object.assign({}, startError));
 
             expect(actualError).toEqual(startError);
         });
 
-        it('Matching error is properly transformed', function() {
+        it('Matching error is properly transformed', function () {
             const startError = {
                 name: 'ModuleParseError',
                 message: 'You may need an appropriate loader',
-                file: '/path/to/file.sass'
+                file: '/path/to/file.sass',
             };
             const actualError = transform(Object.assign({}, startError));
 
@@ -67,11 +67,11 @@ describe('transform/missing-loader', function() {
             expect(actualError.loaderName).toEqual('sass');
         });
 
-        it('Typescript error is properly transformed', function() {
+        it('Typescript error is properly transformed', function () {
             const startError = {
                 name: 'ModuleParseError',
                 message: 'You may need an appropriate loader',
-                file: '/path/to/file.ts'
+                file: '/path/to/file.ts',
             };
             const actualError = transform(Object.assign({}, startError));
 
@@ -80,11 +80,12 @@ describe('transform/missing-loader', function() {
             expect(actualError.loaderName).toEqual('typescript');
         });
 
-        it('vue-loader15 is handled correctly', function() {
+        it('vue-loader15 is handled correctly', function () {
             const startError = {
                 name: 'ModuleParseError',
-                message: 'Module parse failed: Unexpected character \'#\' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;',
-                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss'
+                message:
+                    "Module parse failed: Unexpected character '#' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;",
+                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss',
             };
             const actualError = transform(Object.assign({}, startError));
 
@@ -94,11 +95,12 @@ describe('transform/missing-loader', function() {
             expect(actualError.isVueLoader).toBe(true);
         });
 
-        it('vue-loader16 is handled correctly', function() {
+        it('vue-loader16 is handled correctly', function () {
             const startError = {
                 name: 'ModuleParseError',
-                message: 'Module parse failed: Unexpected character \'#\' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;',
-                file: '/path/to/project/node_modules/vue-loader/dist??ref--4-0!./vuejs/App.vue?vue&type=style&index=1&lang=scss'
+                message:
+                    "Module parse failed: Unexpected character '#' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;",
+                file: '/path/to/project/node_modules/vue-loader/dist??ref--4-0!./vuejs/App.vue?vue&type=style&index=1&lang=scss',
             };
             const actualError = transform(Object.assign({}, startError));
 
@@ -108,11 +110,12 @@ describe('transform/missing-loader', function() {
             expect(actualError.isVueLoader).toBe(true);
         });
 
-        it('vue-loader is handled correctly, more options after lang=', function() {
+        it('vue-loader is handled correctly, more options after lang=', function () {
             const startError = {
                 name: 'ModuleParseError',
-                message: 'Module parse failed: Unexpected character \'#\' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;',
-                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss&foo=bar'
+                message:
+                    "Module parse failed: Unexpected character '#' (35:0)\nYou may need an appropriate loader to handle this file type.\n| \n| \n| #app {\n|   display: flex;\n|   color: #2c3e90;",
+                file: '/path/to/project/node_modules/vue-loader/lib??vue-loader-options!./vuejs/App.vue?vue&type=style&index=1&lang=scss&foo=bar',
             };
             const actualError = transform(Object.assign({}, startError));
 

--- a/test/functional.js
+++ b/test/functional.js
@@ -7,20 +7,23 @@
  * file that was distributed with this source code.
  */
 
-import { afterAll, beforeAll, chai, describe, expect, it } from 'vitest';
-import { fileURLToPath } from 'url';
-import path from 'path';
-import * as testSetup from './helpers/setup.js';
-import fs from 'fs-extra';
-import getVueVersion from '../lib/utils/get-vue-version.js';
-import packageHelper from '../lib/package-helper.js';
-import semver from 'semver';
-import puppeteer from 'puppeteer';
 import { createRequire } from 'module';
-import { assertWarning } from './helpers/logger-assert.js';
-import packageJson from '../package.json' with { type: 'json' };
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const isLowestDependencies = packageJson.config && packageJson.config['lowest-dependencies'] === true;
+import fs from 'fs-extra';
+import puppeteer from 'puppeteer';
+import semver from 'semver';
+import { afterAll, beforeAll, chai, describe, expect, it } from 'vitest';
+
+import packageHelper from '../lib/package-helper.js';
+import getVueVersion from '../lib/utils/get-vue-version.js';
+import packageJson from '../package.json' with { type: 'json' };
+import { assertWarning } from './helpers/logger-assert.js';
+import * as testSetup from './helpers/setup.js';
+
+const isLowestDependencies =
+    packageJson.config && packageJson.config['lowest-dependencies'] === true;
 const chunkVueJs = isLowestDependencies
     ? 'vendors-node_modules_pnpm_vue_3_2_14_node_modules_vue_dist_vue_runtime_esm-bundler_js.js'
     : 'vendors-node_modules_pnpm_vue_3_5_32_typescript_5_9_3_node_modules_vue_dist_vue_runtime_esm-b-4f542a.js';
@@ -44,12 +47,7 @@ function createWebpackConfig(outputDirName = '', command, argv = {}) {
 function createStaticCachedWebpackConfig(outputDirName = '', testName, command, argv = {}) {
     // We need a static named test dir for the cache to work
     let testAppDir = testSetup.createTestAppDir(null, testName + '/test');
-    const webpackConfig = testSetup.createWebpackConfig(
-        testAppDir,
-        outputDirName,
-        command,
-        argv,
-    );
+    const webpackConfig = testSetup.createWebpackConfig(testAppDir, outputDirName, command, argv);
 
     webpackConfig.enableSingleRuntimeChunk();
     webpackConfig.enableBuildCache({ config: [import.meta.filename] }, (cache) => {
@@ -98,18 +96,18 @@ function getIntegrityData(config) {
     return entrypointsData.integrity;
 }
 
-describe('Functional tests using webpack', function() {
+describe('Functional tests using webpack', function () {
     /** @type {import('puppeteer').Browser} */
     let browser;
 
     // being functional tests, these can take quite long
 
-    beforeAll(async function() {
+    beforeAll(async function () {
         try {
             browser = await puppeteer.launch({
                 headless: 'new',
                 timeout: 14000,
-                args: ['--no-sandbox', '--disable-setuid-sandbox']
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
             });
         } catch (err) {
             console.log('Unable to launch Puppeteer');
@@ -118,13 +116,12 @@ describe('Functional tests using webpack', function() {
         }
     });
 
-    afterAll(async function() {
+    afterAll(async function () {
         await browser.close();
     });
 
-    describe('Basic scenarios.', function() {
-
-        it('Builds a few simple entries file + manifest.json', async function() {
+    describe('Basic scenarios.', function () {
+        it('Builds a few simple entries file + manifest.json', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', './js/no_require');
             config.addStyleEntry('font', './css/roboto_font.css');
@@ -135,35 +132,25 @@ describe('Functional tests using webpack', function() {
             // should have a main.js file
             // should have a manifest.json with public/main.js
 
-            expect(config.outputPath).to.be.a.directory().with.deep.files([
-                'runtime.js',
-                'main.js',
-                'font.css',
-                'bg.css',
-                'fonts/Roboto.e1dcc0db.woff2',
-                'images/symfony_logo.91beba37.png',
-                'manifest.json',
-                'entrypoints.json'
-            ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.deep.files([
+                    'runtime.js',
+                    'main.js',
+                    'font.css',
+                    'bg.css',
+                    'fonts/Roboto.e1dcc0db.woff2',
+                    'images/symfony_logo.91beba37.png',
+                    'manifest.json',
+                    'entrypoints.json',
+                ]);
 
             // check that main.js has the correct contents
-            webpackAssert.assertOutputFileContains(
-                'main.js',
-                'i am the no_require.js file'
-            );
+            webpackAssert.assertOutputFileContains('main.js', 'i am the no_require.js file');
             // check that main.js has the webpack bootstrap
-            webpackAssert.assertOutputFileContains(
-                'runtime.js',
-                '__webpack_require__'
-            );
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
-            webpackAssert.assertManifestPath(
-                'build/font.css',
-                '/build/font.css'
-            );
+            webpackAssert.assertOutputFileContains('runtime.js', '__webpack_require__');
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
+            webpackAssert.assertManifestPath('build/font.css', '/build/font.css');
             webpackAssert.assertManifestPath(
                 'build/fonts/Roboto.woff2',
                 '/build/fonts/Roboto.e1dcc0db.woff2'
@@ -176,21 +163,21 @@ describe('Functional tests using webpack', function() {
             webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                 entrypoints: {
                     main: {
-                        js: ['/build/runtime.js', '/build/main.js']
+                        js: ['/build/runtime.js', '/build/main.js'],
                     },
                     font: {
                         js: ['/build/runtime.js'],
-                        css: ['/build/font.css']
+                        css: ['/build/font.css'],
                     },
                     bg: {
                         js: ['/build/runtime.js'],
-                        css: ['/build/bg.css']
-                    }
-                }
+                        css: ['/build/bg.css'],
+                    },
+                },
             });
         });
 
-        it('Check manifest.json with node_module includes', async function() {
+        it('Check manifest.json with node_module includes', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', './js/import_node_modules_image');
             config.setPublicPath('/build');
@@ -207,7 +194,7 @@ describe('Functional tests using webpack', function() {
             });
         });
 
-        it('Use "all" splitChunks & look at entrypoints.json', async function() {
+        it('Use "all" splitChunks & look at entrypoints.json', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -225,24 +212,24 @@ describe('Functional tests using webpack', function() {
                             '/build/runtime.js',
                             '/build/' + chunkVueJs,
                             '/build/css_roboto_font_css.js',
-                            '/build/main.js'
+                            '/build/main.js',
                         ],
-                        css: ['/build/css_roboto_font_css.css']
+                        css: ['/build/css_roboto_font_css.css'],
                     },
                     other: {
                         js: [
                             '/build/runtime.js',
                             '/build/' + chunkVueJs,
                             '/build/css_roboto_font_css.js',
-                            '/build/other.js'
+                            '/build/other.js',
                         ],
-                        css: ['/build/css_roboto_font_css.css']
-                    }
-                }
+                        css: ['/build/css_roboto_font_css.css'],
+                    },
+                },
             });
         });
 
-        it('Disable the runtime chunk', async function() {
+        it('Disable the runtime chunk', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', './js/no_require');
             config.disableSingleRuntimeChunk();
@@ -251,14 +238,12 @@ describe('Functional tests using webpack', function() {
             await testSetup.runWebpack(config);
 
             // no runtime.js
-            expect(config.outputPath).to.be.a.directory().with.deep.files([
-                'main.js',
-                'manifest.json',
-                'entrypoints.json'
-            ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.deep.files(['main.js', 'manifest.json', 'entrypoints.json']);
         });
 
-        it('setPublicPath with CDN loads assets from the CDN', async function() {
+        it('setPublicPath with CDN loads assets from the CDN', async function () {
             const config = createWebpackConfig('public/assets', 'dev');
             config.addEntry('main', './js/code_splitting');
             config.addStyleEntry('font', './css/roboto_font.css');
@@ -268,7 +253,8 @@ describe('Functional tests using webpack', function() {
             config.setManifestKeyPrefix('assets');
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'js_no_require_js-css_h1_style_css.css',
                     'js_no_require_js-css_h1_style_css.js',
@@ -277,7 +263,7 @@ describe('Functional tests using webpack', function() {
                     'font.css',
                     'bg.css',
                     'manifest.json',
-                    'entrypoints.json'
+                    'entrypoints.json',
                 ]);
 
             // check that the publicPath is set correctly
@@ -306,7 +292,7 @@ describe('Functional tests using webpack', function() {
                 [
                     // purposely load this NOT from the CDN
                     'assets/runtime.js',
-                    'assets/main.js'
+                    'assets/main.js',
                 ],
                 ({ loadedResources }) => {
                     webpackAssert.assertResourcesLoadedCorrectly(loadedResources, [
@@ -317,14 +303,14 @@ describe('Functional tests using webpack', function() {
                         // we did this to check that the internally-loaded assets
                         // use the CDN, even if the entry point does not
                         'http://127.0.0.1:8080/assets/runtime.js',
-                        'http://127.0.0.1:8080/assets/main.js'
+                        'http://127.0.0.1:8080/assets/main.js',
                     ]);
                 }
             );
         });
     });
 
-    it('The devServer config loads successfully', async function() {
+    it('The devServer config loads successfully', async function () {
         const config = createWebpackConfig('public/assets', 'dev-server', {
             port: '8090',
             host: '127.0.0.1',
@@ -347,17 +333,14 @@ describe('Functional tests using webpack', function() {
             'http://127.0.0.1:8090/assets/images/symfony_logo.91beba37.png'
         );
         // manifest file has CDN in value
-        webpackAssert.assertManifestPath(
-            'assets/main.js',
-            'http://127.0.0.1:8090/assets/main.js'
-        );
+        webpackAssert.assertManifestPath('assets/main.js', 'http://127.0.0.1:8090/assets/main.js');
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'public'),
             [
                 convertToManifestPath('assets/runtime.js', config),
-                convertToManifestPath('assets/main.js', config)
+                convertToManifestPath('assets/main.js', config),
             ],
             ({ loadedResources }) => {
                 webpackAssert.assertResourcesLoadedCorrectly(loadedResources, [
@@ -370,17 +353,14 @@ describe('Functional tests using webpack', function() {
         );
     });
 
-    it('Deploying to a subdirectory is no problem', async function() {
+    it('Deploying to a subdirectory is no problem', async function () {
         const config = createWebpackConfig('subdirectory/build', 'dev');
         config.addEntry('main', './js/code_splitting');
         config.setPublicPath('/subdirectory/build');
         config.setManifestKeyPrefix('build');
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertManifestPath(
-            'build/main.js',
-            '/subdirectory/build/main.js'
-        );
+        webpackAssert.assertManifestPath('build/main.js', '/subdirectory/build/main.js');
 
         await testSetup.requestTestPage(
             browser,
@@ -388,7 +368,7 @@ describe('Functional tests using webpack', function() {
             path.join(config.getContext(), ''),
             [
                 convertToManifestPath('build/runtime.js', config),
-                convertToManifestPath('build/main.js', config)
+                convertToManifestPath('build/main.js', config),
             ],
             ({ loadedResources }) => {
                 webpackAssert.assertResourcesLoadedCorrectly(loadedResources, [
@@ -397,62 +377,56 @@ describe('Functional tests using webpack', function() {
                     'http://127.0.0.1:8080/subdirectory/build/js_no_require_js-css_h1_style_css.js',
                     'http://127.0.0.1:8080/subdirectory/build/js_no_require_js-css_h1_style_css.css',
                 ]);
-            });
+            }
+        );
     });
 
-    it('Empty manifestKeyPrefix is allowed', async function() {
+    it('Empty manifestKeyPrefix is allowed', async function () {
         const config = createWebpackConfig('build', 'dev');
         config.addEntry('main', './js/code_splitting');
         config.setPublicPath('/build');
         config.setManifestKeyPrefix('');
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertManifestPath(
-            'main.js',
-            '/build/main.js'
-        );
+        webpackAssert.assertManifestPath('main.js', '/build/main.js');
     });
 
-    it('.mjs files are supported natively', async function() {
+    it('.mjs files are supported natively', async function () {
         const config = createWebpackConfig('web/build', 'dev');
         config.addEntry('main', './js/hello_world');
         config.setPublicPath('/build');
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that main.js has the correct contents
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'Hello World!'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'Hello World!');
     });
 
-    describe('addStyleEntry .js files are removed', function() {
-        it('Without versioning', async function() {
+    describe('addStyleEntry .js files are removed', function () {
+        it('Without versioning', async function () {
             const config = createWebpackConfig('web', 'dev');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/');
             config.addStyleEntry('styles', './css/h1_style.css');
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 // public.js should not exist
-                .with.files(['main.js', 'styles.css', 'manifest.json', 'entrypoints.json', 'runtime.js']);
+                .with.files([
+                    'main.js',
+                    'styles.css',
+                    'manifest.json',
+                    'entrypoints.json',
+                    'runtime.js',
+                ]);
 
-            webpackAssert.assertOutputFileContains(
-                'styles.css',
-                'font-size: 50px;'
-            );
-            webpackAssert.assertManifestPathDoesNotExist(
-                'styles.js'
-            );
-            webpackAssert.assertManifestPath(
-                'styles.css',
-                '/styles.css'
-            );
+            webpackAssert.assertOutputFileContains('styles.css', 'font-size: 50px;');
+            webpackAssert.assertManifestPathDoesNotExist('styles.js');
+            webpackAssert.assertManifestPath('styles.css', '/styles.css');
         });
     });
 
-    it('With default versioning', async function() {
+    it('With default versioning', async function () {
         const config = createWebpackConfig('web', 'dev');
         config.addEntry('main', './js/no_require');
         config.setPublicPath('/');
@@ -468,20 +442,12 @@ describe('Functional tests using webpack', function() {
             'runtime.[hash:8].js',
         ]);
 
-        webpackAssert.assertOutputFileContains(
-            'styles.[hash:8].css',
-            'font-size: 50px;'
-        );
-        webpackAssert.assertManifestPathDoesNotExist(
-            'styles.js'
-        );
-        webpackAssert.assertManifestPath(
-            'styles.css',
-            '/styles.[hash:8].css'
-        );
+        webpackAssert.assertOutputFileContains('styles.[hash:8].css', 'font-size: 50px;');
+        webpackAssert.assertManifestPathDoesNotExist('styles.js');
+        webpackAssert.assertManifestPath('styles.css', '/styles.[hash:8].css');
     });
 
-    it('With query string versioning', async function() {
+    it('With query string versioning', async function () {
         const config = createWebpackConfig('web', 'dev');
         config.addEntry('main', './js/no_require');
         config.setPublicPath('/');
@@ -489,27 +455,26 @@ describe('Functional tests using webpack', function() {
         config.enableVersioning(true);
         config.configureFilenames({
             js: '[name].js?[contenthash:16]',
-            css: '[name].css?[contenthash:16]'
+            css: '[name].css?[contenthash:16]',
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory()
-            .with.files(['main.js', 'styles.css', 'manifest.json', 'entrypoints.json', 'runtime.js']);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.files([
+                'main.js',
+                'styles.css',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
-        webpackAssert.assertOutputFileContains(
-            'styles.css',
-            'font-size: 50px;'
-        );
-        webpackAssert.assertManifestPathDoesNotExist(
-            'styles.js'
-        );
-        webpackAssert.assertManifestPath(
-            'styles.css',
-            '/styles.css?[hash:16]'
-        );
+        webpackAssert.assertOutputFileContains('styles.css', 'font-size: 50px;');
+        webpackAssert.assertManifestPathDoesNotExist('styles.js');
+        webpackAssert.assertManifestPath('styles.css', '/styles.css?[hash:16]');
     });
 
-    it('With source maps in production mode', async function() {
+    it('With source maps in production mode', async function () {
         const config = createWebpackConfig('web', 'production');
         config.addEntry('main', './js/arrow_function');
         config.setPublicPath('/');
@@ -517,30 +482,25 @@ describe('Functional tests using webpack', function() {
         config.enableSourceMaps(true);
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory()
-            .with.files([
-                'main.js',
-                'main.js.map',
-                'styles.css',
-                'styles.css.map',
-                'manifest.json',
-                'entrypoints.json',
-                'runtime.js',
-                'runtime.js.map',
+        expect(config.outputPath).to.be.a.directory().with.files([
+            'main.js',
+            'main.js.map',
+            'styles.css',
+            'styles.css.map',
+            'manifest.json',
+            'entrypoints.json',
+            'runtime.js',
+            'runtime.js.map',
             // no styles.js
             // no styles.js.map
-            ]);
+        ]);
 
-        webpackAssert.assertManifestPathDoesNotExist(
-            'styles.js'
-        );
+        webpackAssert.assertManifestPathDoesNotExist('styles.js');
 
-        webpackAssert.assertManifestPathDoesNotExist(
-            'styles.js.map'
-        );
+        webpackAssert.assertManifestPathDoesNotExist('styles.js.map');
     });
 
-    it('enableVersioning applies to js, css & manifest', async function() {
+    it('enableVersioning applies to js, css & manifest', async function () {
         const config = createWebpackConfig('web/build', 'dev');
         config.addEntry('main', './js/code_splitting');
         config.setPublicPath('/build');
@@ -561,10 +521,9 @@ describe('Functional tests using webpack', function() {
             'runtime.[hash:8].js',
         ]);
 
-        expect(path.join(config.outputPath, 'images')).to.be.a.directory()
-            .with.files([
-                'symfony_logo.91beba37.png'
-            ]);
+        expect(path.join(config.outputPath, 'images'))
+            .to.be.a.directory()
+            .with.files(['symfony_logo.91beba37.png']);
 
         webpackAssert.assertOutputFileContains(
             'bg.[hash:8].css',
@@ -572,73 +531,52 @@ describe('Functional tests using webpack', function() {
         );
     });
 
-    it('font and image files are copied correctly', async function() {
+    it('font and image files are copied correctly', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addStyleEntry('bg', './css/background_image.scss');
         config.addStyleEntry('font', './css/roboto_font.css');
-        config.enableSassLoader(options => {
+        config.enableSassLoader((options) => {
             // Use sass-loader instead of node-sass
             options.implementation = require('sass');
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory()
-            .with.files([
-                'bg.css',
-                'font.css',
-                'manifest.json',
-                'entrypoints.json',
-                'runtime.js',
-            ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.files(['bg.css', 'font.css', 'manifest.json', 'entrypoints.json', 'runtime.js']);
 
-        expect(path.join(config.outputPath, 'images')).to.be.a.directory()
-            .with.files([
-                'symfony_logo.91beba37.png'
-            ]);
+        expect(path.join(config.outputPath, 'images'))
+            .to.be.a.directory()
+            .with.files(['symfony_logo.91beba37.png']);
 
-        expect(path.join(config.outputPath, 'fonts')).to.be.a.directory()
-            .with.files([
-                'Roboto.e1dcc0db.woff2'
-            ]);
+        expect(path.join(config.outputPath, 'fonts'))
+            .to.be.a.directory()
+            .with.files(['Roboto.e1dcc0db.woff2']);
 
-        webpackAssert.assertOutputFileContains(
-            'bg.css',
-            '/build/images/symfony_logo.91beba37.png'
-        );
+        webpackAssert.assertOutputFileContains('bg.css', '/build/images/symfony_logo.91beba37.png');
 
-        webpackAssert.assertOutputFileContains(
-            'font.css',
-            '/build/fonts/Roboto.e1dcc0db.woff2'
-        );
+        webpackAssert.assertOutputFileContains('font.css', '/build/fonts/Roboto.e1dcc0db.woff2');
     });
 
-    it('two fonts or images with the same filename should not output a single file', async function() {
+    it('two fonts or images with the same filename should not output a single file', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addStyleEntry('styles', './css/same_filename.css');
         config.enableSassLoader();
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory()
-            .with.files([
-                'styles.css',
-                'manifest.json',
-                'entrypoints.json',
-                'runtime.js',
-            ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.files(['styles.css', 'manifest.json', 'entrypoints.json', 'runtime.js']);
 
-        expect(path.join(config.outputPath, 'images')).to.be.a.directory()
-            .with.files([
-                'symfony_logo.91beba37.png',
-                'symfony_logo.f880ba14.png'
-            ]);
+        expect(path.join(config.outputPath, 'images'))
+            .to.be.a.directory()
+            .with.files(['symfony_logo.91beba37.png', 'symfony_logo.f880ba14.png']);
 
-        expect(path.join(config.outputPath, 'fonts')).to.be.a.directory()
-            .with.files([
-                'Roboto.e1dcc0db.woff2',
-                'Roboto.2779fd7b.woff2'
-            ]);
+        expect(path.join(config.outputPath, 'fonts'))
+            .to.be.a.directory()
+            .with.files(['Roboto.e1dcc0db.woff2', 'Roboto.2779fd7b.woff2']);
 
         webpackAssert.assertOutputFileContains(
             'styles.css',
@@ -650,18 +588,12 @@ describe('Functional tests using webpack', function() {
             '/build/images/symfony_logo.f880ba14.png'
         );
 
-        webpackAssert.assertOutputFileContains(
-            'styles.css',
-            '/build/fonts/Roboto.e1dcc0db.woff2'
-        );
+        webpackAssert.assertOutputFileContains('styles.css', '/build/fonts/Roboto.e1dcc0db.woff2');
 
-        webpackAssert.assertOutputFileContains(
-            'styles.css',
-            '/build/fonts/Roboto.2779fd7b.woff2'
-        );
+        webpackAssert.assertOutputFileContains('styles.css', '/build/fonts/Roboto.2779fd7b.woff2');
     });
 
-    it('enableSourceMaps() adds to .js, css & scss', async function() {
+    it('enableSourceMaps() adds to .js, css & scss', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/no_require');
@@ -671,18 +603,12 @@ describe('Functional tests using webpack', function() {
         config.enableSourceMaps();
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertOutputFileHasSourcemap(
-            'main.js'
-        );
-        webpackAssert.assertOutputFileHasSourcemap(
-            'bg.css'
-        );
-        webpackAssert.assertOutputFileHasSourcemap(
-            'font.css'
-        );
+        webpackAssert.assertOutputFileHasSourcemap('main.js');
+        webpackAssert.assertOutputFileHasSourcemap('bg.css');
+        webpackAssert.assertOutputFileHasSourcemap('font.css');
     });
 
-    it('Without enableSourceMaps(), there are no sourcemaps', async function() {
+    it('Without enableSourceMaps(), there are no sourcemaps', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/no_require');
@@ -691,18 +617,12 @@ describe('Functional tests using webpack', function() {
         config.enableSassLoader();
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'main.js'
-        );
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'bg.css'
-        );
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'font.css'
-        );
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('main.js');
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('bg.css');
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('font.css');
     });
 
-    it('Without enableSourceMaps(), there are no sourcemaps in production', async function() {
+    it('Without enableSourceMaps(), there are no sourcemaps in production', async function () {
         const config = createWebpackConfig('www/build', 'production');
         config.setPublicPath('/build');
         config.addEntry('main', './js/no_require');
@@ -711,18 +631,12 @@ describe('Functional tests using webpack', function() {
         config.enableSassLoader();
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'main.js'
-        );
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'font.css'
-        );
-        webpackAssert.assertOutputFileDoesNotHaveSourcemap(
-            'bg.css'
-        );
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('main.js');
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('font.css');
+        webpackAssert.assertOutputFileDoesNotHaveSourcemap('bg.css');
     });
 
-    it('Code splitting a scss file works', async function() {
+    it('Code splitting a scss file works', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         // loads sass_features.scss via require.ensure
@@ -731,10 +645,7 @@ describe('Functional tests using webpack', function() {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // make sure sass is parsed
-        webpackAssert.assertOutputFileContains(
-            'css_sass_features_scss.css',
-            'color: #333'
-        );
+        webpackAssert.assertOutputFileContains('css_sass_features_scss.css', 'color: #333');
         // and imported files are loaded correctly
         webpackAssert.assertOutputFileContains(
             'css_sass_features_scss.css',
@@ -742,8 +653,8 @@ describe('Functional tests using webpack', function() {
         );
     });
 
-    describe('addCacheGroup()', function() {
-        it('addCacheGroup() to extract a vendor into its own chunk', async function() {
+    describe('addCacheGroup()', function () {
+        it('addCacheGroup() to extract a vendor into its own chunk', async function () {
             const config = createWebpackConfig('www/build', 'dev');
             config.setPublicPath('/build');
             config.enableVueLoader();
@@ -755,7 +666,7 @@ describe('Functional tests using webpack', function() {
 
             // Move Vue.js code into its own chunk
             config.addCacheGroup('vuejs', {
-                test: /[\\/]node_modules[\\/]@vue[\\/]/
+                test: /[\\/]node_modules[\\/]@vue[\\/]/,
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
@@ -796,32 +707,30 @@ describe('Functional tests using webpack', function() {
                 entrypoints: {
                     page1: {
                         js: ['/build/runtime.js', '/build/vuejs.js', '/build/page1.js'],
-                        css: ['/build/page1.css']
+                        css: ['/build/page1.css'],
                     },
                     page2: {
-                        js: ['/build/runtime.js', '/build/page2.js']
-                    }
-                }
+                        js: ['/build/runtime.js', '/build/page2.js'],
+                    },
+                },
             });
 
             // Check if Vue.js code is still executed properly
             await testSetup.requestTestPage(
                 browser,
                 path.join(config.getContext(), 'www'),
-                [
-                    'build/runtime.js',
-                    'build/page1.js',
-                    'build/vuejs.js',
-                ],
-                async({ page }) => {
-                    const bodyText = await page.evaluate(() => document.querySelector('#app').textContent);
+                ['build/runtime.js', 'build/page1.js', 'build/vuejs.js'],
+                async ({ page }) => {
+                    const bodyText = await page.evaluate(
+                        () => document.querySelector('#app').textContent
+                    );
                     expect(bodyText).to.contains('Welcome to Your Vue.js App');
                 }
             );
         });
     });
 
-    it('addCacheGroup() with node_modules', async function() {
+    it('addCacheGroup() with node_modules', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.enableVueLoader();
@@ -833,10 +742,7 @@ describe('Functional tests using webpack', function() {
 
         // Move both vue.js and preact code into their own chunk
         config.addCacheGroup('common', {
-            node_modules: [
-                '@vue',
-                'preact'
-            ]
+            node_modules: ['@vue', 'preact'],
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
@@ -877,30 +783,28 @@ describe('Functional tests using webpack', function() {
             entrypoints: {
                 page1: {
                     js: ['/build/runtime.js', '/build/common.js', '/build/page1.js'],
-                    css: ['/build/page1.css']
+                    css: ['/build/page1.css'],
                 },
                 page2: {
-                    js: ['/build/runtime.js', '/build/common.js', '/build/page2.js']
-                }
-            }
+                    js: ['/build/runtime.js', '/build/common.js', '/build/page2.js'],
+                },
+            },
         });
 
         // Check if Preact code is still executed properly
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/page2.js',
-                'build/common.js',
-            ],
-            async({ page }) => {
-                expect(await page.evaluate(() => document.querySelector('#app').textContent)).to.contains('This is a React component!');
+            ['build/runtime.js', 'build/page2.js', 'build/common.js'],
+            async ({ page }) => {
+                expect(
+                    await page.evaluate(() => document.querySelector('#app').textContent)
+                ).to.contains('This is a React component!');
             }
         );
     });
 
-    it('addCacheGroup() with versioning enabled', async function() {
+    it('addCacheGroup() with versioning enabled', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.enableVersioning();
@@ -913,9 +817,10 @@ describe('Functional tests using webpack', function() {
 
         // Move Vue.js code into its own chunk
         config.addCacheGroup('vuejs', {
-            test: getVueVersion(config) === 2 ?
-                /[\\/]node_modules[\\/]vue[\\/]/ :
-                /[\\/]node_modules[\\/]@vue[\\/]/
+            test:
+                getVueVersion(config) === 2
+                    ? /[\\/]node_modules[\\/]vue[\\/]/
+                    : /[\\/]node_modules[\\/]@vue[\\/]/,
         });
 
         await testSetup.runWebpack(config);
@@ -928,14 +833,16 @@ describe('Functional tests using webpack', function() {
                 convertToManifestPath('build/page1.js', config),
                 convertToManifestPath('build/vuejs.js', config),
             ],
-            async({ page }) => {
-                const bodyText = await page.evaluate(() => document.querySelector('#app').textContent);
+            async ({ page }) => {
+                const bodyText = await page.evaluate(
+                    () => document.querySelector('#app').textContent
+                );
                 expect(bodyText).to.contains('Welcome to Your Vue.js App');
             }
         );
     });
 
-    it('addCacheGroup() with source maps enabled', async function() {
+    it('addCacheGroup() with source maps enabled', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.enableSourceMaps();
@@ -948,9 +855,10 @@ describe('Functional tests using webpack', function() {
 
         // Move Vue.js code into its own chunk
         config.addCacheGroup('vuejs', {
-            test: getVueVersion(config) === 2 ?
-                /[\\/]node_modules[\\/]vue[\\/]/ :
-                /[\\/]node_modules[\\/]@vue[\\/]/
+            test:
+                getVueVersion(config) === 2
+                    ? /[\\/]node_modules[\\/]vue[\\/]/
+                    : /[\\/]node_modules[\\/]@vue[\\/]/,
         });
 
         await testSetup.runWebpack(config);
@@ -958,19 +866,17 @@ describe('Functional tests using webpack', function() {
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/page1.js',
-                'build/vuejs.js',
-            ],
-            async({ page }) => {
-                const bodyText = await page.evaluate(() => document.querySelector('#app').textContent);
+            ['build/runtime.js', 'build/page1.js', 'build/vuejs.js'],
+            async ({ page }) => {
+                const bodyText = await page.evaluate(
+                    () => document.querySelector('#app').textContent
+                );
                 expect(bodyText).to.contains('Welcome to Your Vue.js App');
             }
         );
     });
 
-    it('in production mode, code is uglified', async function() {
+    it('in production mode, code is uglified', async function () {
         const config = createWebpackConfig('www/build', 'production');
         config.setPublicPath('/build');
         config.addEntry('main', ['./js/no_require']);
@@ -978,23 +884,14 @@ describe('Functional tests using webpack', function() {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // the comment should not live in the file
-        webpackAssert.assertOutputFileDoesNotContain(
-            'main.js',
-            '// comments in no_require.js'
-        );
+        webpackAssert.assertOutputFileDoesNotContain('main.js', '// comments in no_require.js');
         // check for any webpack-added comments
-        webpackAssert.assertOutputFileDoesNotContain(
-            'main.js',
-            '/*!'
-        );
+        webpackAssert.assertOutputFileDoesNotContain('main.js', '/*!');
         // extra spaces should not live in the CSS file
-        webpackAssert.assertOutputFileDoesNotContain(
-            'styles.css',
-            '    font-size: 50px;'
-        );
+        webpackAssert.assertOutputFileDoesNotContain('styles.css', '    font-size: 50px;');
     });
 
-    it('PostCSS works when enabled', async function() {
+    it('PostCSS works when enabled', async function () {
         const appDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -1022,21 +919,15 @@ module.exports = {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that the autoprefixer did its work!
-        webpackAssert.assertOutputFileContains(
-            'styles.css',
-            '-webkit-backdrop-filter'
-        );
+        webpackAssert.assertOutputFileContains('styles.css', '-webkit-backdrop-filter');
 
         // check that the .postcss file was also processed
         // correctly (it also @import the autoprefixer_test.css
         // file)
-        webpackAssert.assertOutputFileContains(
-            'postcss.css',
-            '-webkit-backdrop-filter'
-        );
+        webpackAssert.assertOutputFileContains('postcss.css', '-webkit-backdrop-filter');
     });
 
-    it('PostCSS works when enabled (ESM config)', async function() {
+    it('PostCSS works when enabled (ESM config)', async function () {
         const appDir = testSetup.createTestAppDir();
 
         // Enable ESM so that postcss.config.js is treated as an ES module
@@ -1069,18 +960,12 @@ export default {
         config.enablePostCssLoader();
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        webpackAssert.assertOutputFileContains(
-            'styles.css',
-            '-webkit-backdrop-filter'
-        );
+        webpackAssert.assertOutputFileContains('styles.css', '-webkit-backdrop-filter');
 
-        webpackAssert.assertOutputFileContains(
-            'postcss.css',
-            '-webkit-backdrop-filter'
-        );
+        webpackAssert.assertOutputFileContains('postcss.css', '-webkit-backdrop-filter');
     });
 
-    it('less processes when enabled', async function() {
+    it('less processes when enabled', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addStyleEntry('styles', ['./css/h2_styles.less']);
@@ -1095,7 +980,7 @@ export default {
         );
     });
 
-    it('stylus processes when enabled', async function() {
+    it('stylus processes when enabled', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addStyleEntry('styles', ['./css/h2_styles.styl']);
@@ -1110,20 +995,17 @@ export default {
         );
     });
 
-    it('Babel is executed on .js files', async function() {
+    it('Babel is executed on .js files', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/class-syntax');
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that babel transformed the class
-        webpackAssert.assertOutputFileDoesNotContain(
-            'main.js',
-            'class A {}'
-        );
+        webpackAssert.assertOutputFileDoesNotContain('main.js', 'class A {}');
     });
 
-    it('Babel can be configured via .babelrc', async function() {
+    it('Babel can be configured via .babelrc', async function () {
         // create the .babelrc file first, so we see it
         const appDir = testSetup.createTestAppDir();
 
@@ -1156,7 +1038,7 @@ export default {
         );
     });
 
-    it('Babel can be configured via babel.config.js (ESM)', async function() {
+    it('Babel can be configured via babel.config.js (ESM)', async function () {
         const appDir = testSetup.createTestAppDir();
 
         // Enable ESM so that babel.config.js is treated as an ES module
@@ -1187,16 +1069,13 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // chrome 52 supports class, so it's not transpiled
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'class A {}'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'class A {}');
     });
 
-    it('Babel can be configured via package.json browserlist', async function() {
+    it('Babel can be configured via package.json browserlist', async function () {
         const cwd = process.cwd();
 
-        afterAll(function() {
+        afterAll(function () {
             process.chdir(cwd);
         });
 
@@ -1237,7 +1116,7 @@ export default {
         );
     });
 
-    it('Babel adds polyfills correctly', async function() {
+    it('Babel adds polyfills correctly', async function () {
         const cwd = process.cwd();
         const appDir = testSetup.createTestAppDir();
         process.chdir(appDir);
@@ -1263,30 +1142,25 @@ export default {
         for (const scriptName of ['commonjs.js', 'ecmascript.js']) {
             // Check that the polyfills are included correctly
             // in both files.
-            webpackAssert.assertOutputFileContains(
-                scriptName,
-                'Array.prototype.flat'
-            );
+            webpackAssert.assertOutputFileContains(scriptName, 'Array.prototype.flat');
 
             // Test that the generated scripts work fine
             await testSetup.requestTestPage(
                 browser,
                 path.join(config.getContext(), 'www'),
-                [
-                    'build/runtime.js',
-                    `build/${scriptName}`,
-                ],
-                async({ page }) => {
-                    expect(await page.evaluate(() => document.body.textContent)).to.contains('[1,2,3,4]');
+                ['build/runtime.js', `build/${scriptName}`],
+                async ({ page }) => {
+                    expect(await page.evaluate(() => document.body.textContent)).to.contains(
+                        '[1,2,3,4]'
+                    );
                 }
             );
         }
 
         process.chdir(cwd);
-
     });
 
-    it('When enabled, react JSX is transformed!', async function() {
+    it('When enabled, react JSX is transformed!', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/CoolReactComponent.jsx');
@@ -1294,13 +1168,10 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that babel transformed the JSX
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'React.createElement'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'React.createElement');
     });
 
-    it('When enabled, preact JSX is transformed without preact-compat!', async function() {
+    it('When enabled, preact JSX is transformed without preact-compat!', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/CoolReactComponent.jsx');
@@ -1308,13 +1179,10 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that babel transformed the JSX
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'var hiGuys = h('
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'var hiGuys = h(');
     });
 
-    it('When enabled, svelte is transformed', async function() {
+    it('When enabled, svelte is transformed', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/hello_world.svelte');
@@ -1322,13 +1190,10 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that babel transformed the svelte files
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'SvelteComponent'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'SvelteComponent');
     });
 
-    it('When enabled, preact JSX is transformed with preact-compat!', async function() {
+    it('When enabled, preact JSX is transformed with preact-compat!', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/CoolReactComponent.jsx');
@@ -1336,51 +1201,44 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that babel transformed the JSX
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'React.createElement'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'React.createElement');
     });
 
-    it('When configured, TypeScript is compiled!', async function() {
+    it('When configured, TypeScript is compiled!', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', ['./js/index.ts']);
-        const testCallback = () => {
-        };
+        const testCallback = () => {};
         config.enableTypeScriptLoader(testCallback);
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // check that ts-loader transformed the ts file
         webpackAssert.assertOutputFileContains(
             'main.js',
-            'document.getElementById(\'app\').innerHTML ='
+            "document.getElementById('app').innerHTML ="
         );
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert that the ts module rendered
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your TypeScript App');
             }
         );
     });
 
-    it('TypeScript is compiled and type checking is done in a separate process!', async function() {
+    it('TypeScript is compiled and type checking is done in a separate process!', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', ['./js/render.ts', './js/index.ts']);
         config.enableTypeScriptLoader();
         // test should fail if `config.typescript.configFile` is not set up properly
-        config.enableForkedTypeScriptTypesChecking((config) => {
-
-        });
+        config.enableForkedTypeScriptTypesChecking((config) => {});
 
         try {
             await testSetup.runWebpack(config);
@@ -1392,7 +1250,7 @@ export default {
         }
     });
 
-    it('TypeScript can be compiled by Babel', async function() {
+    it('TypeScript can be compiled by Babel', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', ['./js/render.ts', './js/index.ts']);
@@ -1402,48 +1260,45 @@ export default {
         // check that babel-loader transformed the ts file
         webpackAssert.assertOutputFileContains(
             'main.js',
-            'document.getElementById(\'app\').innerHTML =',
+            "document.getElementById('app').innerHTML ="
         );
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js',
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert that the ts module rendered
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your TypeScript App');
-            },
+            }
         );
     });
 
-    it('When configured, Handlebars is compiled', async function() {
+    it('When configured, Handlebars is compiled', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', ['./js/handlebars.js']);
-        const testCallback = () => {
-        };
+        const testCallback = () => {};
         config.enableHandlebarsLoader(testCallback);
 
         await testSetup.runWebpack(config);
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your Handlebars App');
             }
         );
     });
 
-    it('The output directory is cleaned between builds', async function() {
+    it('The output directory is cleaned between builds', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/no_require');
@@ -1453,15 +1308,11 @@ export default {
 
         const { webpackAssert } = await testSetup.runWebpack(config);
         // make sure the file was cleaned up!
-        webpackAssert.assertOutputFileDoesNotExist(
-            'file.txt'
-        );
-        webpackAssert.assertOutputFileDoesNotExist(
-            'deeper/other.txt'
-        );
+        webpackAssert.assertOutputFileDoesNotExist('file.txt');
+        webpackAssert.assertOutputFileDoesNotExist('deeper/other.txt');
     });
 
-    it('Vue.js is compiled correctly', async function() {
+    it('Vue.js is compiled correctly', async function () {
         const appDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -1481,52 +1332,55 @@ module.exports = {
         config.enableVueLoader();
         config.enableSassLoader();
         config.enableLessLoader();
-        config.configureBabel(function(config) {
+        config.configureBabel(function (config) {
             config.presets = [
-                ['@babel/preset-env', {
-                    'targets': {
-                        'chrome': 52
-                    }
-                }]
+                [
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            chrome: 52,
+                        },
+                    },
+                ],
             ];
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'images/logo.26bd867d.png',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'images/logo.26bd867d.png',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         // test that our custom babel config is used
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'class TestClassSyntax'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'class TestClassSyntax');
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert that the vue.js app rendered
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your Vue.js App');
 
                 // make sure the styles are not inlined
-                const styleElementsCount = await page.evaluate(() => document.querySelectorAll('style').length);
+                const styleElementsCount = await page.evaluate(
+                    () => document.querySelectorAll('style').length
+                );
                 expect(styleElementsCount).toBe(0);
             }
         );
     });
 
-    it('Vue.js is compiled correctly using TypeScript', async function() {
+    it('Vue.js is compiled correctly using TypeScript', async function () {
         const appDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -1547,52 +1401,55 @@ module.exports = {
         config.enableSassLoader();
         config.enableLessLoader();
         config.enableTypeScriptLoader();
-        config.configureBabel(function(config) {
+        config.configureBabel(function (config) {
             config.presets = [
-                ['@babel/preset-env', {
-                    'targets': {
-                        'chrome': 52
-                    }
-                }]
+                [
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            chrome: 52,
+                        },
+                    },
+                ],
             ];
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'images/logo.26bd867d.png',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'images/logo.26bd867d.png',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         // test that our custom babel config is used
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'class TestClassSyntax'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'class TestClassSyntax');
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert that the vue.js app rendered
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your Vue.js App');
 
                 // make sure the styles are not inlined
-                const styleElementsCount = await page.evaluate(() => document.querySelectorAll('style').length);
+                const styleElementsCount = await page.evaluate(
+                    () => document.querySelectorAll('style').length
+                );
                 expect(styleElementsCount).toBe(0);
             }
         );
     });
 
-    it('Vue.js supports CSS/Sass/Less/Stylus/PostCSS modules', async function() {
+    it('Vue.js supports CSS/Sass/Less/Stylus/PostCSS modules', async function () {
         const appDir = testSetup.createTestAppDir();
         const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
         config.enableSingleRuntimeChunk();
@@ -1602,7 +1459,7 @@ module.exports = {
         config.enableSassLoader();
         config.enableLessLoader();
         config.enableStylusLoader();
-        config.configureCssLoader(options => {
+        config.configureCssLoader((options) => {
             // Until https://github.com/vuejs/vue-loader/pull/1909 is merged,
             // Vue users should configure the css-loader modules
             // to keep the previous default behavior from css-loader v6
@@ -1631,19 +1488,18 @@ module.exports = {
         );
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         const expectClassDeclaration = (className) => {
-            webpackAssert.assertOutputFileContains(
-                'main.css',
-                `.${className} {`
-            );
+            webpackAssert.assertOutputFileContains('main.css', `.${className} {`);
         };
 
         expectClassDeclaration('red'); // Standard CSS
@@ -1661,12 +1517,11 @@ module.exports = {
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
-                const divClassArray = await page.evaluate(() => Array.from(document.body.querySelector('#app > div').classList.values()));
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
+                const divClassArray = await page.evaluate(() =>
+                    Array.from(document.body.querySelector('#app > div').classList.values())
+                );
 
                 expect(divClassArray.includes('red')).toBe(true); // Standard CSS
                 expect(divClassArray.includes('large')).toBe(true); // Standard SCSS
@@ -1683,7 +1538,7 @@ module.exports = {
         );
     });
 
-    it('React supports CSS/Sass/Less/Stylus modules', async function() {
+    it('React supports CSS/Sass/Less/Stylus modules', async function () {
         const appDir = testSetup.createTestAppDir();
         const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
         config.enableSingleRuntimeChunk();
@@ -1693,7 +1548,7 @@ module.exports = {
         config.enableSassLoader();
         config.enableLessLoader();
         config.enableStylusLoader();
-        config.configureCssLoader(options => {
+        config.configureCssLoader((options) => {
             // Remove hashes from local ident names
             // since they are not always the same.
             if (options.modules) {
@@ -1714,19 +1569,18 @@ module.exports = {
         );
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         const expectClassDeclaration = (className) => {
-            webpackAssert.assertOutputFileContains(
-                'main.css',
-                `.${className} {`
-            );
+            webpackAssert.assertOutputFileContains('main.css', `.${className} {`);
         };
 
         expectClassDeclaration('red'); // Standard CSS
@@ -1742,12 +1596,11 @@ module.exports = {
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
-                const divClassArray = await page.evaluate(() => Array.from(document.body.querySelector('#app > div').classList.values()));
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
+                const divClassArray = await page.evaluate(() =>
+                    Array.from(document.body.querySelector('#app > div').classList.values())
+                );
 
                 expect(divClassArray.includes('red')).toBe(true); // Standard CSS
                 expect(divClassArray.includes('large')).toBe(true); // Standard SCSS
@@ -1762,7 +1615,7 @@ module.exports = {
         );
     });
 
-    it('Preact supports CSS/Sass/Less/Stylus modules', async function() {
+    it('Preact supports CSS/Sass/Less/Stylus modules', async function () {
         const appDir = testSetup.createTestAppDir();
         const config = testSetup.createWebpackConfig(appDir, 'www/build', 'dev');
         config.enableSingleRuntimeChunk();
@@ -1772,7 +1625,7 @@ module.exports = {
         config.enableSassLoader();
         config.enableLessLoader();
         config.enableStylusLoader();
-        config.configureCssLoader(options => {
+        config.configureCssLoader((options) => {
             // Remove hashes from local ident names
             // since they are not always the same.
             if (options.modules) {
@@ -1793,19 +1646,18 @@ module.exports = {
         );
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         const expectClassDeclaration = (className) => {
-            webpackAssert.assertOutputFileContains(
-                'main.css',
-                `.${className} {`
-            );
+            webpackAssert.assertOutputFileContains('main.css', `.${className} {`);
         };
 
         expectClassDeclaration('red'); // Standard CSS
@@ -1821,12 +1673,11 @@ module.exports = {
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
-                const divClassArray = await page.evaluate(() => Array.from(document.body.querySelector('#app > div').classList.values()));
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
+                const divClassArray = await page.evaluate(() =>
+                    Array.from(document.body.querySelector('#app > div').classList.values())
+                );
 
                 expect(divClassArray.includes('red')).toBe(true); // Standard CSS
                 expect(divClassArray.includes('large')).toBe(true); // Standard SCSS
@@ -1841,7 +1692,7 @@ module.exports = {
         );
     });
 
-    it('Vue.js error when using non-activated loaders', async function() {
+    it('Vue.js error when using non-activated loaders', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', `./vuejs/main_v${getVueVersion(config)}`);
@@ -1852,7 +1703,7 @@ module.exports = {
         expect(output).toContain('To load Sass files');
     });
 
-    it('Vue.js is compiled correctly with JSX support', async function() {
+    it('Vue.js is compiled correctly with JSX support', async function () {
         const appDir = testSetup.createTestAppDir();
 
         fs.writeFileSync(
@@ -1870,42 +1721,39 @@ module.exports = {
         config.enableSingleRuntimeChunk();
         config.setPublicPath('/build');
         config.addEntry('main', `./vuejs-jsx/main_v${getVueVersion(config)}`);
-        config.enableVueLoader(() => {
-        }, {
+        config.enableVueLoader(() => {}, {
             useJsx: true,
             version: getVueVersion(config),
         });
         config.enableSassLoader();
         config.enableLessLoader();
-        config.configureBabel(function(config) {
+        config.configureBabel(function (config) {
             // throw new Error(JSON.stringify(config));
-            expect(config.presets[0][0]).toBe(fileURLToPath(import.meta.resolve('@babel/preset-env')));
+            expect(config.presets[0][0]).toBe(
+                fileURLToPath(import.meta.resolve('@babel/preset-env'))
+            );
             config.presets[0][1].targets = {
-                chrome: 109
+                chrome: 109,
             };
         });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'images/logo.26bd867d.png',
-            'manifest.json',
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'images/logo.26bd867d.png',
+                'manifest.json',
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         // test that our custom babel config is used
-        webpackAssert.assertOutputFileContains(
-            'main.js',
-            'class TestClassSyntax'
-        );
+        webpackAssert.assertOutputFileContains('main.js', 'class TestClassSyntax');
 
         // test that global styles are working correctly
-        webpackAssert.assertOutputFileContains(
-            'main.css',
-            '#app {'
-        );
+        webpackAssert.assertOutputFileContains('main.css', '#app {');
 
         // test that CSS Modules (for scoped styles) is used
         webpackAssert.assertOutputFileContains(
@@ -1916,23 +1764,24 @@ module.exports = {
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert that the vue.js app rendered
-                const h1Text = await page.evaluate(() => document.querySelector('#app h1').textContent);
+                const h1Text = await page.evaluate(
+                    () => document.querySelector('#app h1').textContent
+                );
                 expect(h1Text).to.contains('Welcome to Your Vue.js App');
 
                 // make sure the styles are not inlined
-                const styleElementsCount = await page.evaluate(() => document.querySelectorAll('style').length);
+                const styleElementsCount = await page.evaluate(
+                    () => document.querySelectorAll('style').length
+                );
                 expect(styleElementsCount).toBe(0);
             }
         );
     });
 
-    it('configureImageRule() allows configuring maxSize for inlining', async function() {
+    it('configureImageRule() allows configuring maxSize for inlining', async function () {
         const config = createWebpackConfig('web/build', 'dev');
         config.setPublicPath('/build');
         config.addStyleEntry('url-loader', './css/url-loader.css');
@@ -1941,26 +1790,16 @@ module.exports = {
         config.configureFontRule({ type: 'asset', maxSize: 102400 });
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory()
-            .with.files([
-                'url-loader.css',
-                'manifest.json',
-                'entrypoints.json',
-                'runtime.js'
-            ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.files(['url-loader.css', 'manifest.json', 'entrypoints.json', 'runtime.js']);
 
-        webpackAssert.assertOutputFileContains(
-            'url-loader.css',
-            'url(data:font/woff2;base64,'
-        );
+        webpackAssert.assertOutputFileContains('url-loader.css', 'url(data:font/woff2;base64,');
 
-        webpackAssert.assertOutputFileContains(
-            'url-loader.css',
-            'url(data:image/png;base64,'
-        );
+        webpackAssert.assertOutputFileContains('url-loader.css', 'url(data:image/png;base64,');
     });
 
-    it('Code splitting with dynamic import', async function() {
+    it('Code splitting with dynamic import', async function () {
         const config = createWebpackConfig('www/build', 'dev');
         config.setPublicPath('/build');
         config.addEntry('main', './js/code_splitting_dynamic_import');
@@ -1969,24 +1808,23 @@ module.exports = {
         // check for the code-split file
         webpackAssert.assertOutputFileContains(
             'js_print_to_app_export_js.js',
-            'document.getElementById(\'app\').innerHTML ='
+            "document.getElementById('app').innerHTML ="
         );
 
         await testSetup.requestTestPage(
             browser,
             path.join(config.getContext(), 'www'),
-            [
-                'build/runtime.js',
-                'build/main.js'
-            ],
-            async({ page }) => {
+            ['build/runtime.js', 'build/main.js'],
+            async ({ page }) => {
                 // assert the async module was loaded and works
-                expect(await page.evaluate(() => document.querySelector('#app').textContent)).to.contains('Welcome to Encore!');
+                expect(
+                    await page.evaluate(() => document.querySelector('#app').textContent)
+                ).to.contains('Welcome to Encore!');
             }
         );
     });
 
-    it('Symfony - Stimulus standard app is built correctly', async function({ skip }) {
+    it('Symfony - Stimulus standard app is built correctly', async function ({ skip }) {
         const appDir = testSetup.createTestAppDir();
 
         const version = packageHelper.getPackageVersion('@symfony/stimulus-bridge');
@@ -2001,21 +1839,25 @@ module.exports = {
         config.enableSingleRuntimeChunk();
         config.setPublicPath('/build');
         config.addEntry('main', './stimulus/assets/app.js');
-        config.enableStimulusBridge(import.meta.dirname + '/../fixtures/stimulus/assets/controllers.json');
+        config.enableStimulusBridge(
+            import.meta.dirname + '/../fixtures/stimulus/assets/controllers.json'
+        );
 
         const chunkStimulusBridgeMock = isLowestDependencies
             ? 'node_modules_pnpm_symfony_mock-module_file_fixtures_stimulus_mock-module_node_modules_symfony-99479d.js'
             : 'node_modules_symfony_mock-module_dist_controller_js.js';
 
         const { webpackAssert } = await testSetup.runWebpack(config);
-        expect(config.outputPath).to.be.a.directory().with.deep.files([
-            'main.js',
-            'main.css',
-            'manifest.json',
-            chunkStimulusBridgeMock,
-            'entrypoints.json',
-            'runtime.js',
-        ]);
+        expect(config.outputPath)
+            .to.be.a.directory()
+            .with.deep.files([
+                'main.js',
+                'main.css',
+                'manifest.json',
+                chunkStimulusBridgeMock,
+                'entrypoints.json',
+                'runtime.js',
+            ]);
 
         // test controllers and style are shipped
         webpackAssert.assertOutputFileContains('main.js', 'app-controller');
@@ -2023,49 +1865,45 @@ module.exports = {
         webpackAssert.assertOutputFileContains('main.css', 'body {}');
     });
 
-    describe('copyFiles() allows to copy files and folders', function() {
-        it('Single file copy', async function() {
+    describe('copyFiles() allows to copy files and folders', function () {
+        it('Single file copy', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.copyFiles({
                 from: './images',
                 pattern: /symfony_logo\.png/,
-                includeSubdirectories: false
+                includeSubdirectories: false,
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'entrypoints.json',
                     'runtime.js',
                     'main.js',
                     'manifest.json',
-                    'symfony_logo.png'
+                    'symfony_logo.png',
                 ]);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
-            webpackAssert.assertManifestPath(
-                'build/symfony_logo.png',
-                '/build/symfony_logo.png'
-            );
+            webpackAssert.assertManifestPath('build/symfony_logo.png', '/build/symfony_logo.png');
         });
 
-        it('Folder copy without subdirectories', async function() {
+        it('Folder copy without subdirectories', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.copyFiles({
                 from: './images',
-                includeSubdirectories: false
+                includeSubdirectories: false,
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'entrypoints.json',
                     'runtime.js',
@@ -2075,15 +1913,9 @@ module.exports = {
                     'symfony_logo_alt.png',
                 ]);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
-            webpackAssert.assertManifestPath(
-                'build/symfony_logo.png',
-                '/build/symfony_logo.png'
-            );
+            webpackAssert.assertManifestPath('build/symfony_logo.png', '/build/symfony_logo.png');
 
             webpackAssert.assertManifestPath(
                 'build/symfony_logo_alt.png',
@@ -2091,40 +1923,33 @@ module.exports = {
             );
         });
 
-        it('Multiple copies', async function() {
+        it('Multiple copies', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
-            config.copyFiles([{
-                from: './images',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }, {
-                from: './fonts',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }]);
+            config.copyFiles([
+                {
+                    from: './images',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+                {
+                    from: './fonts',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+            ]);
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'entrypoints.json',
-                    'runtime.js',
-                    'main.js',
-                    'manifest.json'
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['entrypoints.json', 'runtime.js', 'main.js', 'manifest.json']);
 
-            expect(path.join(config.outputPath, 'assets')).to.be.a.directory()
-                .with.files([
-                    'symfony_logo.png',
-                    'symfony_logo_alt.png',
-                    'Roboto.woff2',
-                ]);
+            expect(path.join(config.outputPath, 'assets'))
+                .to.be.a.directory()
+                .with.files(['symfony_logo.png', 'symfony_logo_alt.png', 'Roboto.woff2']);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
             webpackAssert.assertManifestPath(
                 'build/assets/symfony_logo.png',
@@ -2142,40 +1967,30 @@ module.exports = {
             );
         });
 
-        it('Copy folder and subdirectories with versioning enabled to the specified location', async function() {
+        it('Copy folder and subdirectories with versioning enabled to the specified location', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.copyFiles({
                 from: './images',
                 to: 'images/[path][name].[hash:8].[ext]',
-                includeSubdirectories: true
+                includeSubdirectories: true,
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'entrypoints.json',
-                    'runtime.js',
-                    'main.js',
-                    'manifest.json',
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['entrypoints.json', 'runtime.js', 'main.js', 'manifest.json']);
 
-            expect(path.join(config.outputPath, 'images')).to.be.a.directory()
-                .with.files([
-                    'symfony_logo.91beba37.png',
-                    'symfony_logo_alt.f880ba14.png',
-                ]);
+            expect(path.join(config.outputPath, 'images'))
+                .to.be.a.directory()
+                .with.files(['symfony_logo.91beba37.png', 'symfony_logo_alt.f880ba14.png']);
 
-            expect(path.join(config.outputPath, 'images', 'same_filename')).to.be.a.directory()
-                .with.files([
-                    'symfony_logo.f880ba14.png',
-                ]);
+            expect(path.join(config.outputPath, 'images', 'same_filename'))
+                .to.be.a.directory()
+                .with.files(['symfony_logo.f880ba14.png']);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
             webpackAssert.assertManifestPath(
                 'build/images/symfony_logo.png',
@@ -2193,18 +2008,19 @@ module.exports = {
             );
         });
 
-        it('Filter files using the given pattern', async function() {
+        it('Filter files using the given pattern', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.copyFiles({
                 from: './images',
                 pattern: /_alt/,
-                includeSubdirectories: false
+                includeSubdirectories: false,
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'entrypoints.json',
                     'runtime.js',
@@ -2213,34 +2029,32 @@ module.exports = {
                     'symfony_logo_alt.png',
                 ]);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
             webpackAssert.assertManifestPath(
                 'build/symfony_logo_alt.png',
                 '/build/symfony_logo_alt.png'
             );
 
-            webpackAssert.assertManifestPathDoesNotExist(
-                'build/symfony_logo.png'
-            );
+            webpackAssert.assertManifestPathDoesNotExist('build/symfony_logo.png');
         });
 
-        it('Copy with versioning enabled', async function() {
+        it('Copy with versioning enabled', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.enableVersioning(true);
-            config.copyFiles([{
-                from: './images',
-                includeSubdirectories: false
-            }, {
-                from: './fonts',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }]);
+            config.copyFiles([
+                {
+                    from: './images',
+                    includeSubdirectories: false,
+                },
+                {
+                    from: './fonts',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+            ]);
 
             const { webpackAssert } = await testSetup.runWebpack(config);
             webpackAssert.assertDirectoryContents([
@@ -2252,15 +2066,11 @@ module.exports = {
                 'symfony_logo_alt.[hash:8].png',
             ]);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.[hash:8].js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.[hash:8].js');
 
-            expect(path.join(config.outputPath, 'assets')).to.be.a.directory()
-                .with.files([
-                    'Roboto.woff2',
-                ]);
+            expect(path.join(config.outputPath, 'assets'))
+                .to.be.a.directory()
+                .with.files(['Roboto.woff2']);
 
             webpackAssert.assertManifestPath(
                 'build/symfony_logo.png',
@@ -2278,41 +2088,46 @@ module.exports = {
             );
         });
 
-        it('Do not try to copy files from an invalid path', async function() {
+        it('Do not try to copy files from an invalid path', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
-            config.copyFiles([{
-                from: './images',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }, {
-                from: './foo',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }, {
-                from: './fonts',
-                to: 'assets/[path][name].[ext]',
-                includeSubdirectories: false
-            }, {
-                from: './images/symfony_logo.png',
-                includeSubdirectories: true
-            }]);
+            config.copyFiles([
+                {
+                    from: './images',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+                {
+                    from: './foo',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+                {
+                    from: './fonts',
+                    to: 'assets/[path][name].[ext]',
+                    includeSubdirectories: false,
+                },
+                {
+                    from: './images/symfony_logo.png',
+                    includeSubdirectories: true,
+                },
+            ]);
 
             await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'entrypoints.json',
-                    'runtime.js',
-                    'main.js',
-                    'manifest.json'
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['entrypoints.json', 'runtime.js', 'main.js', 'manifest.json']);
 
-            assertWarning('should be set to an existing directory but "./foo" does not seem to exist');
-            assertWarning('should be set to an existing directory but "./images/symfony_logo.png" seems to be a file');
+            assertWarning(
+                'should be set to an existing directory but "./foo" does not seem to exist'
+            );
+            assertWarning(
+                'should be set to an existing directory but "./images/symfony_logo.png" seems to be a file'
+            );
         });
 
-        it('Copy with a custom context', async function() {
+        it('Copy with a custom context', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
@@ -2324,29 +2139,19 @@ module.exports = {
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'entrypoints.json',
-                    'runtime.js',
-                    'main.js',
-                    'manifest.json',
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['entrypoints.json', 'runtime.js', 'main.js', 'manifest.json']);
 
-            expect(path.join(config.outputPath, 'images')).to.be.a.directory()
-                .with.files([
-                    'symfony_logo.91beba37.png',
-                    'symfony_logo_alt.f880ba14.png',
-                ]);
+            expect(path.join(config.outputPath, 'images'))
+                .to.be.a.directory()
+                .with.files(['symfony_logo.91beba37.png', 'symfony_logo_alt.f880ba14.png']);
 
-            expect(path.join(config.outputPath, 'images', 'same_filename')).to.be.a.directory()
-                .with.files([
-                    'symfony_logo.f880ba14.png',
-                ]);
+            expect(path.join(config.outputPath, 'images', 'same_filename'))
+                .to.be.a.directory()
+                .with.files(['symfony_logo.f880ba14.png']);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
 
             webpackAssert.assertManifestPath(
                 'build/images/symfony_logo.png',
@@ -2364,7 +2169,7 @@ module.exports = {
             );
         });
 
-        it('Copy files without processing them', async function() {
+        it('Copy files without processing them', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
@@ -2375,7 +2180,7 @@ module.exports = {
             // handled by `Encore.copyFiles()`.
             // We disable it for this test since our CSS file will
             // not be valid and can't be handled by this plugin.
-            config.configureCssMinimizerPlugin(options => {
+            config.configureCssMinimizerPlugin((options) => {
                 options.include = /^$/;
             });
 
@@ -2384,12 +2189,13 @@ module.exports = {
             // handled by `Encore.copyFiles()`.
             // We disable it for this test since our JS file will
             // not be valid and can't be handled by this plugin.
-            config.configureTerserPlugin(options => {
+            config.configureTerserPlugin((options) => {
                 options.include = /^$/;
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'entrypoints.json',
                     'runtime.js',
@@ -2409,7 +2215,7 @@ module.exports = {
             }
         });
 
-        it('Do not copy files excluded by a RegExp', async function() {
+        it('Do not copy files excluded by a RegExp', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
@@ -2426,7 +2232,7 @@ module.exports = {
             config.copyFiles({
                 from: './copy',
                 to: './[path][name].[ext]',
-                pattern: /\.(?!(css|js)$)([^.]+$)/
+                pattern: /\.(?!(css|js)$)([^.]+$)/,
             });
 
             // By default the css-minimizer-webpack-plugin will
@@ -2434,7 +2240,7 @@ module.exports = {
             // handled by `Encore.copyFiles()`.
             // We disable it for this test since our CSS file will
             // not be valid and can't be handled by this plugin.
-            config.configureCssMinimizerPlugin(options => {
+            config.configureCssMinimizerPlugin((options) => {
                 options.include = /^$/;
             });
 
@@ -2443,7 +2249,7 @@ module.exports = {
             // handled by `Encore.copyFiles()`.
             // We disable it for this test since our JS file will
             // not be valid and can't be handled by this plugin.
-            config.configureTerserPlugin(options => {
+            config.configureTerserPlugin((options) => {
                 options.include = /^$/;
             });
 
@@ -2464,17 +2270,17 @@ module.exports = {
             ]);
         });
 
-        it('Does not prevent from setting the map option of the manifest plugin', async function() {
+        it('Does not prevent from setting the map option of the manifest plugin', async function () {
             const config = createWebpackConfig('www/build', 'production');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
             config.copyFiles({
                 from: './images',
                 pattern: /symfony_logo\.png/,
-                includeSubdirectories: false
+                includeSubdirectories: false,
             });
 
-            config.configureManifestPlugin(options => {
+            config.configureManifestPlugin((options) => {
                 options.map = (file) => {
                     return Object.assign({}, file, {
                         name: `${file.name}.test`,
@@ -2483,19 +2289,17 @@ module.exports = {
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
+            expect(config.outputPath)
+                .to.be.a.directory()
                 .with.files([
                     'entrypoints.json',
                     'runtime.js',
                     'main.js',
                     'manifest.json',
-                    'symfony_logo.png'
+                    'symfony_logo.png',
                 ]);
 
-            webpackAssert.assertManifestPath(
-                'build/main.js.test',
-                '/build/main.js'
-            );
+            webpackAssert.assertManifestPath('build/main.js.test', '/build/main.js');
 
             webpackAssert.assertManifestPath(
                 'build/symfony_logo.png.test',
@@ -2504,8 +2308,8 @@ module.exports = {
         });
     });
 
-    describe('entrypoints.json & splitChunks()', function() {
-        it('Use "all" splitChunks & look at entrypoints.json', async function() {
+    describe('entrypoints.json & splitChunks()', function () {
+        it('Use "all" splitChunks & look at entrypoints.json', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2524,27 +2328,27 @@ module.exports = {
                             '/build/runtime.js',
                             '/build/' + chunkVueJs,
                             '/build/css_roboto_font_css.js',
-                            '/build/main.js'
+                            '/build/main.js',
                         ],
-                        css: ['/build/css_roboto_font_css.css']
+                        css: ['/build/css_roboto_font_css.css'],
                     },
                     other: {
                         js: [
                             '/build/runtime.js',
                             '/build/' + chunkVueJs,
                             '/build/css_roboto_font_css.js',
-                            '/build/other.js'
+                            '/build/other.js',
                         ],
-                        css: ['/build/css_roboto_font_css.css']
-                    }
-                }
+                        css: ['/build/css_roboto_font_css.css'],
+                    },
+                },
             });
 
             // make split chunks are correct in manifest
             webpackAssert.assertManifestKeyExists('build/' + chunkVueJs);
         });
 
-        it('Custom public path does affect entrypoints.json but does not affect manifest.json', async function() {
+        it('Custom public path does affect entrypoints.json but does not affect manifest.json', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2563,27 +2367,27 @@ module.exports = {
                             'http://localhost:8080/build/runtime.js',
                             'http://localhost:8080/build/' + chunkVueJs,
                             'http://localhost:8080/build/css_roboto_font_css.js',
-                            'http://localhost:8080/build/main.js'
+                            'http://localhost:8080/build/main.js',
                         ],
-                        css: ['http://localhost:8080/build/css_roboto_font_css.css']
+                        css: ['http://localhost:8080/build/css_roboto_font_css.css'],
                     },
                     other: {
                         js: [
                             'http://localhost:8080/build/runtime.js',
                             'http://localhost:8080/build/' + chunkVueJs,
                             'http://localhost:8080/build/css_roboto_font_css.js',
-                            'http://localhost:8080/build/other.js'
+                            'http://localhost:8080/build/other.js',
                         ],
-                        css: ['http://localhost:8080/build/css_roboto_font_css.css']
-                    }
-                }
+                        css: ['http://localhost:8080/build/css_roboto_font_css.css'],
+                    },
+                },
             });
 
             // make split chunks are correct in manifest
             webpackAssert.assertManifestKeyExists('custom_prefix/' + chunkVueJs);
         });
 
-        it('Subdirectory public path affects entrypoints.json but does not affect manifest.json', async function() {
+        it('Subdirectory public path affects entrypoints.json but does not affect manifest.json', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2602,27 +2406,27 @@ module.exports = {
                             '/subdirectory/build/runtime.js',
                             '/subdirectory/build/' + chunkVueJs,
                             '/subdirectory/build/css_roboto_font_css.js',
-                            '/subdirectory/build/main.js'
+                            '/subdirectory/build/main.js',
                         ],
-                        css: ['/subdirectory/build/css_roboto_font_css.css']
+                        css: ['/subdirectory/build/css_roboto_font_css.css'],
                     },
                     other: {
                         js: [
                             '/subdirectory/build/runtime.js',
                             '/subdirectory/build/' + chunkVueJs,
                             '/subdirectory/build/css_roboto_font_css.js',
-                            '/subdirectory/build/other.js'
+                            '/subdirectory/build/other.js',
                         ],
-                        css: ['/subdirectory/build/css_roboto_font_css.css']
-                    }
-                }
+                        css: ['/subdirectory/build/css_roboto_font_css.css'],
+                    },
+                },
             });
 
             // make split chunks are correct in manifest
             webpackAssert.assertManifestKeyExists('custom_prefix/' + chunkVueJs);
         });
 
-        it('Use splitChunks in production mode', async function() {
+        it('Use splitChunks in production mode', async function () {
             const config = createWebpackConfig('web/build', 'production');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2651,7 +2455,7 @@ module.exports = {
             });
         });
 
-        it('Use splitEntryChunks() with code splitting', async function() {
+        it('Use splitEntryChunks() with code splitting', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./js/code_splitting', 'vue']);
             config.addEntry('other', ['./js/no_require', 'vue']);
@@ -2665,12 +2469,17 @@ module.exports = {
             webpackAssert.assertOutputJsonFileMatches('entrypoints.json', {
                 entrypoints: {
                     main: {
-                        js: ['/build/runtime.js', '/build/' + chunkVueJs, '/build/main.js']
+                        js: ['/build/runtime.js', '/build/' + chunkVueJs, '/build/main.js'],
                     },
                     other: {
-                        js: ['/build/runtime.js', '/build/' + chunkVueJs, '/build/js_no_require_js.js', '/build/other.js']
-                    }
-                }
+                        js: [
+                            '/build/runtime.js',
+                            '/build/' + chunkVueJs,
+                            '/build/js_no_require_js.js',
+                            '/build/other.js',
+                        ],
+                    },
+                },
             });
 
             // make split chunks are correct in manifest
@@ -2678,9 +2487,9 @@ module.exports = {
             webpackAssert.assertManifestKeyExists('build/js_no_require_js.js');
         });
 
-        it('Make sure chunkIds do not change between builds', async function() {
+        it('Make sure chunkIds do not change between builds', async function () {
             // https://github.com/symfony/webpack-encore/issues/461
-            const createSimilarConfig = function(includeExtraEntry) {
+            const createSimilarConfig = function (includeExtraEntry) {
                 const config = createWebpackConfig('web/build', 'production');
                 config.addEntry('main1', './js/code_splitting');
                 if (includeExtraEntry) {
@@ -2700,11 +2509,14 @@ module.exports = {
             const main3Contents = readOutputFileContents('main3.js', configA);
             const finalMain3Contents = readOutputFileContents('main3.js', configB);
 
-            expect(finalMain3Contents, 'Contents after first compile do not match after second compile.').toEqual(main3Contents);
+            expect(
+                finalMain3Contents,
+                'Contents after first compile do not match after second compile.'
+            ).toEqual(main3Contents);
         });
 
-        it('Do not change contents or filenames when more modules require the same split contents', async function() {
-            const createSimilarConfig = function(includeExtraEntry) {
+        it('Do not change contents or filenames when more modules require the same split contents', async function () {
+            const createSimilarConfig = function (includeExtraEntry) {
                 const config = createWebpackConfig('web/build', 'production');
                 config.addEntry('main1', ['./js/code_splitting', 'preact']);
                 config.addEntry('main3', ['./js/no_require', 'preact']);
@@ -2721,16 +2533,18 @@ module.exports = {
                 return config;
             };
 
-            const getSplitVendorJsPath = function(config) {
+            const getSplitVendorJsPath = function (config) {
                 const entrypointData = getEntrypointData(config, 'main3');
 
-                const splitFiles = entrypointData.js.filter(filename => {
+                const splitFiles = entrypointData.js.filter((filename) => {
                     return filename !== '/build/runtime.js' && filename !== '/build/main3.js';
                 });
 
                 // sanity check
                 if (splitFiles.length !== 1) {
-                    throw new Error(`Unexpected number (${splitFiles.length}) of split files for main3 entry`);
+                    throw new Error(
+                        `Unexpected number (${splitFiles.length}) of split files for main3 entry`
+                    );
                 }
 
                 return splitFiles[0];
@@ -2747,7 +2561,9 @@ module.exports = {
             // make sure that the filename of the split vendor file didn't change,
             // even though an additional entry is now sharing its contents
             if (finalVendorPath !== vendorPath) {
-                throw new Error(`Vendor filename changed! Before ${vendorPath} and after ${finalVendorPath}.`);
+                throw new Error(
+                    `Vendor filename changed! Before ${vendorPath} and after ${finalVendorPath}.`
+                );
             }
 
             // make sure that, internally, the split chunk name did not change,
@@ -2756,18 +2572,20 @@ module.exports = {
             const finalMain3Contents = readOutputFileContents('main3.js', configB);
 
             if (finalMain3Contents !== main3Contents) {
-                throw new Error(`Contents after first compile do not match after second compile: \n\n ${main3Contents} \n\n versus \n\n ${finalMain3Contents} \n`);
+                throw new Error(
+                    `Contents after first compile do not match after second compile: \n\n ${main3Contents} \n\n versus \n\n ${finalMain3Contents} \n`
+                );
             }
         });
     });
 
-    describe('Package entrypoint imports', function() {
-        it('Import via "sass" package property', async function() {
+    describe('Package entrypoint imports', function () {
+        it('Import via "sass" package property', async function () {
             const config = createWebpackConfig('web/build', 'dev');
 
             config.setPublicPath('/build');
             config.addAliases({
-                lib: path.resolve('./lib')
+                lib: path.resolve('./lib'),
             });
             config.enableSassLoader();
             config.addStyleEntry('sass', './css/sass_package_import.scss');
@@ -2778,12 +2596,12 @@ module.exports = {
             await testSetup.runWebpack(config);
         });
 
-        it('Import via "style" package property', async function() {
+        it('Import via "style" package property', async function () {
             const config = createWebpackConfig('web/build', 'dev');
 
             config.setPublicPath('/build');
             config.addAliases({
-                lib: path.resolve('./lib')
+                lib: path.resolve('./lib'),
             });
             config.addStyleEntry('style', './css/style_package_import.css');
 
@@ -2794,29 +2612,22 @@ module.exports = {
         });
     });
 
-    describe('CSS extraction', function() {
-        it('With CSS extraction enabled', async function() {
+    describe('CSS extraction', function () {
+        it('With CSS extraction enabled', async function () {
             const config = createWebpackConfig('build', 'dev');
             config.setPublicPath('/build');
             config.disableSingleRuntimeChunk();
             config.addEntry('main', './js/css_import');
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'manifest.json',
-                    'entrypoints.json',
-                    'main.js',
-                    'main.css',
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['manifest.json', 'entrypoints.json', 'main.js', 'main.css']);
 
-            webpackAssert.assertOutputFileContains(
-                'main.css',
-                'font-size: 50px;'
-            );
+            webpackAssert.assertOutputFileContains('main.css', 'font-size: 50px;');
         });
 
-        it('With CSS extraction disabled', async function() {
+        it('With CSS extraction disabled', async function () {
             const config = createWebpackConfig('build', 'dev');
             config.setPublicPath('/build');
             config.disableSingleRuntimeChunk();
@@ -2824,20 +2635,14 @@ module.exports = {
             config.disableCssExtraction();
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'manifest.json',
-                    'entrypoints.json',
-                    'main.js'
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['manifest.json', 'entrypoints.json', 'main.js']);
 
-            webpackAssert.assertOutputFileContains(
-                'main.js',
-                'font-size: 50px;'
-            );
+            webpackAssert.assertOutputFileContains('main.js', 'font-size: 50px;');
         });
 
-        it('With CSS extraction disabled and with options callback of the StyleLoader', async function() {
+        it('With CSS extraction disabled and with options callback of the StyleLoader', async function () {
             const config = createWebpackConfig('build', 'dev');
             config.setPublicPath('/build');
             config.disableSingleRuntimeChunk();
@@ -2848,22 +2653,16 @@ module.exports = {
             });
 
             const { webpackAssert } = await testSetup.runWebpack(config);
-            expect(config.outputPath).to.be.a.directory()
-                .with.files([
-                    'manifest.json',
-                    'entrypoints.json',
-                    'main.js'
-                ]);
+            expect(config.outputPath)
+                .to.be.a.directory()
+                .with.files(['manifest.json', 'entrypoints.json', 'main.js']);
 
-            webpackAssert.assertOutputFileContains(
-                'main.js',
-                'TESTING_ATTRIBUTES'
-            );
+            webpackAssert.assertOutputFileContains('main.js', 'TESTING_ATTRIBUTES');
         });
     });
 
-    describe('enableIntegrityHashes() adds hashes to the entrypoints.json file', function() {
-        it('Using default algorithm', async function() {
+    describe('enableIntegrityHashes() adds hashes to the entrypoints.json file', function () {
+        it('Using default algorithm', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2891,7 +2690,7 @@ module.exports = {
             });
         });
 
-        it('Using another algorithm and a different public path', async function() {
+        it('Using another algorithm and a different public path', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2919,7 +2718,7 @@ module.exports = {
             });
         });
 
-        it('Using multiple algorithms', async function() {
+        it('Using multiple algorithms', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', ['./css/roboto_font.css', './js/no_require', 'vue']);
             config.addEntry('other', ['./css/roboto_font.css', 'vue']);
@@ -2948,7 +2747,7 @@ module.exports = {
             });
         });
 
-        it('With query string versioning', async function() {
+        it('With query string versioning', async function () {
             const config = createWebpackConfig('web/build', 'dev');
             config.addEntry('main', './js/no_require');
             config.setPublicPath('/build');
@@ -2956,19 +2755,21 @@ module.exports = {
             config.enableVersioning(true);
             config.configureFilenames({
                 js: '[name].js?v=[contenthash:16]',
-                css: '[name].css?v=[contenthash:16]'
+                css: '[name].css?v=[contenthash:16]',
             });
             config.enableIntegrityHashes();
 
             await testSetup.runWebpack(config);
             const integrityData = getIntegrityData(config);
-            const expectedFilesWithHashes = Object.keys(integrityData).filter(file => {
+            const expectedFilesWithHashes = Object.keys(integrityData).filter((file) => {
                 if (!/\?v=[a-z0-9]{16}$/.test(file)) {
                     return false;
                 }
-                return file.startsWith('/build/runtime.js?v=')
-                    || file.startsWith('/build/main.js?v=')
-                    || file.startsWith('/build/styles.css?v=');
+                return (
+                    file.startsWith('/build/runtime.js?v=') ||
+                    file.startsWith('/build/main.js?v=') ||
+                    file.startsWith('/build/styles.css?v=')
+                );
             });
 
             expectedFilesWithHashes.forEach((file) => {
@@ -2978,56 +2779,64 @@ module.exports = {
         });
     });
 
-    describe.each([
-        [1],
-        [2]
-    ])('Functional persistent cache tests using webpack (%d/2)', { timeout: 10000 }, function() {
-        describe('Basic scenarios.', function() {
-            it('Persistent caching does not cause problems', async function() {
-                const config = createStaticCachedWebpackConfig('www/build', 'basic_cache', 'dev');
-                config.setPublicPath('/build');
-                config.addEntry('main', './js/code_splitting');
+    describe.each([[1], [2]])(
+        'Functional persistent cache tests using webpack (%d/2)',
+        { timeout: 10000 },
+        function () {
+            describe('Basic scenarios.', function () {
+                it('Persistent caching does not cause problems', async function () {
+                    const config = createStaticCachedWebpackConfig(
+                        'www/build',
+                        'basic_cache',
+                        'dev'
+                    );
+                    config.setPublicPath('/build');
+                    config.addEntry('main', './js/code_splitting');
 
-                const { webpackAssert } = await testSetup.runWebpack(config);
-                // sanity check
-                webpackAssert.assertManifestPath(
-                    'build/main.js',
-                    '/build/main.js',
-                );
+                    const { webpackAssert } = await testSetup.runWebpack(config);
+                    // sanity check
+                    webpackAssert.assertManifestPath('build/main.js', '/build/main.js');
+                });
             });
-        });
 
-        describe('copyFiles() allows to copy files and folders', function() {
-            it('Persistent caching does not cause problems', async function() {
-                const config = createStaticCachedWebpackConfig('www/build', 'copy_files_cache', 'production');
-                config.addEntry('main', './js/no_require');
-                config.setPublicPath('/build');
-                config.enableVersioning(true);
-                config.copyFiles([{
-                    from: './images',
-                    includeSubdirectories: false,
-                }]);
+            describe('copyFiles() allows to copy files and folders', function () {
+                it('Persistent caching does not cause problems', async function () {
+                    const config = createStaticCachedWebpackConfig(
+                        'www/build',
+                        'copy_files_cache',
+                        'production'
+                    );
+                    config.addEntry('main', './js/no_require');
+                    config.setPublicPath('/build');
+                    config.enableVersioning(true);
+                    config.copyFiles([
+                        {
+                            from: './images',
+                            includeSubdirectories: false,
+                        },
+                    ]);
 
-                const { webpackAssert } = await testSetup.runWebpack(config);
-                webpackAssert.assertDirectoryContents([
-                    'entrypoints.json',
-                    'runtime.[hash:8].js',
-                    'main.[hash:8].js',
-                    'manifest.json',
-                    'symfony_logo.[hash:8].png',
-                    'symfony_logo_alt.[hash:8].png',
-                ]);
+                    const { webpackAssert } = await testSetup.runWebpack(config);
+                    webpackAssert.assertDirectoryContents([
+                        'entrypoints.json',
+                        'runtime.[hash:8].js',
+                        'main.[hash:8].js',
+                        'manifest.json',
+                        'symfony_logo.[hash:8].png',
+                        'symfony_logo_alt.[hash:8].png',
+                    ]);
 
-                webpackAssert.assertManifestPath(
-                    'build/symfony_logo.png',
-                    '/build/symfony_logo.91beba37.png',
-                );
+                    webpackAssert.assertManifestPath(
+                        'build/symfony_logo.png',
+                        '/build/symfony_logo.91beba37.png'
+                    );
 
-                webpackAssert.assertManifestPath(
-                    'build/symfony_logo_alt.png',
-                    '/build/symfony_logo_alt.f880ba14.png',
-                );
+                    webpackAssert.assertManifestPath(
+                        'build/symfony_logo_alt.png',
+                        '/build/symfony_logo_alt.f880ba14.png'
+                    );
+                });
             });
-        });
-    });
+        }
+    );
 });

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -7,18 +7,20 @@
  * file that was distributed with this source code.
  */
 
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
+
 import { expect } from 'vitest';
+
 import regexEscaper from '../../lib/utils/regexp-escaper.js';
 
-const loadManifest = function(webpackConfig) {
+const loadManifest = function (webpackConfig) {
     return JSON.parse(
         fs.readFileSync(path.join(webpackConfig.outputPath, 'manifest.json'), 'utf8')
     );
 };
 
-const readOutputFile = function(webpackConfig, filePath) {
+const readOutputFile = function (webpackConfig, filePath) {
     const fullPath = path.join(webpackConfig.outputPath, filePath);
 
     if (!fs.existsSync(fullPath)) {
@@ -28,7 +30,7 @@ const readOutputFile = function(webpackConfig, filePath) {
     return fs.readFileSync(fullPath, 'utf8');
 };
 
-const getMatchedFilename = function(targetDirectory, filenameRegex) {
+const getMatchedFilename = function (targetDirectory, filenameRegex) {
     const actualFiles = fs.readdirSync(targetDirectory);
     let foundFile = false;
     actualFiles.forEach((actualFile) => {
@@ -51,7 +53,7 @@ const getMatchedFilename = function(targetDirectory, filenameRegex) {
  * @param {string} filename Filename with possible [hash:8] wildcard
  * @returns {RegExp}
  */
-const convertFilenameToMatcher = function(filename) {
+const convertFilenameToMatcher = function (filename) {
     const hashMatch = filename.match(/\[hash:(\d+)\]/);
 
     if (hashMatch === null) {
@@ -61,8 +63,7 @@ const convertFilenameToMatcher = function(filename) {
     const [hashString, hashLength] = hashMatch;
 
     return new RegExp(
-        regexEscaper(filename)
-            .replace(regexEscaper(hashString), `([a-z0-9_-]){${hashLength}}`)
+        regexEscaper(filename).replace(regexEscaper(hashString), `([a-z0-9_-]){${hashLength}}`)
     );
 };
 
@@ -88,7 +89,9 @@ export class Assert {
 
         const actualContents = fs.readFileSync(fullPath, 'utf8');
         if (!actualContents.includes(expectedContents)) {
-            throw new Error(`Expected contents "${expectedContents}" not found in file ${fullPath}`);
+            throw new Error(
+                `Expected contents "${expectedContents}" not found in file ${fullPath}`
+            );
         }
     }
 
@@ -109,7 +112,9 @@ export class Assert {
 
         const actualContents = fs.readFileSync(fullPath, 'utf8');
         if (actualContents.includes(expectedContents)) {
-            throw new Error(`Contents "${expectedContents}" *were* found in file ${fullPath}, but should not have been.`);
+            throw new Error(
+                `Contents "${expectedContents}" *were* found in file ${fullPath}, but should not have been.`
+            );
         }
     }
 
@@ -151,7 +156,9 @@ export class Assert {
         const expectedRegex = convertFilenameToMatcher(expectedDestinationPath);
 
         if (!manifestData[sourcePath].match(expectedRegex)) {
-            throw new Error(`source path ${sourcePath} expected to match pattern ${expectedDestinationPath}, was actually ${manifestData[sourcePath]}`);
+            throw new Error(
+                `source path ${sourcePath} expected to match pattern ${expectedDestinationPath}, was actually ${manifestData[sourcePath]}`
+            );
         }
     }
 
@@ -167,7 +174,9 @@ export class Assert {
         const manifestData = loadManifest(this.webpackConfig);
 
         if (manifestData[sourcePath]) {
-            throw new Error(`Source ${sourcePath} key WAS found in manifest, but should not be there!`);
+            throw new Error(
+                `Source ${sourcePath} key WAS found in manifest, but should not be there!`
+            );
         }
     }
 
@@ -262,12 +271,16 @@ export class Assert {
             }
 
             if (!matchIsFound) {
-                throw new Error(`File "${foundFile}" was found in directory but was not expected. Expected patterns where ${expectedFiles.join(', ')}`);
+                throw new Error(
+                    `File "${foundFile}" was found in directory but was not expected. Expected patterns where ${expectedFiles.join(', ')}`
+                );
             }
         });
 
         if (Object.keys(expectedFileStrings).length > 0) {
-            throw new Error(`Files ${Object.keys(expectedFileStrings).join(', ')} were expected to be found in the directory but were not. Actual files: ${actualFiles.join(', ')}`);
+            throw new Error(
+                `Files ${Object.keys(expectedFileStrings).join(', ')} were expected to be found in the directory but were not. Actual files: ${actualFiles.join(', ')}`
+            );
         }
     }
 }

--- a/test/helpers/logger-assert.js
+++ b/test/helpers/logger-assert.js
@@ -17,11 +17,13 @@ export function assertWarning(expectedMessage) {
 
 function assertLogMessage(messages, description, expectedMessage) {
     if (messages.length === 0) {
-        throw new Error(`Found zero log ${description}s. And so, expected "${description} ${expectedMessage}" was not logged.`);
+        throw new Error(
+            `Found zero log ${description}s. And so, expected "${description} ${expectedMessage}" was not logged.`
+        );
     }
 
     let isFound = false;
-    messages.forEach(function(message, index) {
+    messages.forEach(function (message, index) {
         if (!isFound && message.includes(expectedMessage)) {
             isFound = true;
             // remove from the array now that it is found
@@ -30,6 +32,8 @@ function assertLogMessage(messages, description, expectedMessage) {
     });
 
     if (!isFound) {
-        throw new Error(`Did not find any log ${description}s matching ${expectedMessage}. Found: ${messages.join('\n')}`);
+        throw new Error(
+            `Did not find any log ${description}s matching ${expectedMessage}. Found: ${messages.join('\n')}`
+        );
     }
 }

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -8,13 +8,15 @@
  */
 
 import path from 'path';
-import WebpackConfig from '../../lib/WebpackConfig.js';
-import parseRuntime from '../../lib/config/parse-runtime.js';
-import webpack from 'webpack';
+
 import fs from 'fs-extra';
 import httpServer from 'http-server';
+import webpack from 'webpack';
+
 import configGenerator from '../../lib/config-generator.js';
+import parseRuntime from '../../lib/config/parse-runtime.js';
 import validator from '../../lib/config/validator.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 import { Assert } from './assert.js';
 
 const tmpDir = path.join(import.meta.dirname, '../', '../', 'test_tmp');
@@ -23,7 +25,10 @@ const testFixturesDir = path.join(import.meta.dirname, '../', '../', 'fixtures')
 let servers = [];
 
 export function createTestAppDir(rootDir = null, subDir = null) {
-    const testAppDir = path.join(rootDir ? rootDir : tmpDir, subDir ? subDir : Math.random().toString(36).substring(7));
+    const testAppDir = path.join(
+        rootDir ? rootDir : tmpDir,
+        subDir ? subDir : Math.random().toString(36).substring(7)
+    );
 
     // copy the fixtures into this new directory
     fs.copySync(testFixturesDir, testAppDir);
@@ -34,10 +39,7 @@ export function createTestAppDir(rootDir = null, subDir = null) {
     // webpack to treat them as strict ESM (requiring fully-specified
     // imports, disabling require.ensure, etc.).
     if (!fs.existsSync(path.join(testAppDir, 'package.json'))) {
-        fs.writeFileSync(
-            path.join(testAppDir, 'package.json'),
-            JSON.stringify({ private: true })
-        );
+        fs.writeFileSync(path.join(testAppDir, 'package.json'), JSON.stringify({ private: true }));
     }
 
     return testAppDir;
@@ -53,10 +55,7 @@ export function createTestAppDir(rootDir = null, subDir = null) {
 export function createWebpackConfig(testAppDir, outputDirName = '', command, argv = {}) {
     argv._ = [command];
     argv.context = testAppDir;
-    const runtimeConfig = parseRuntime(
-        argv,
-        testAppDir
-    );
+    const runtimeConfig = parseRuntime(argv, testAppDir);
 
     const config = new WebpackConfig(runtimeConfig);
 
@@ -126,7 +125,7 @@ export async function runWebpack(webpackConfig, { allowCompilationError = false 
                 resolve({
                     webpackAssert: new Assert(webpackConfig),
                     stats,
-                    output: stdOutContents.join('\n')
+                    output: stdOutContents.join('\n'),
                 });
             });
         });
@@ -145,15 +144,12 @@ export function touchFileInOutputDir(filename, webpackConfig) {
     const fullPath = path.join(webpackConfig.outputPath, filename);
     fs.ensureDirSync(path.dirname(fullPath));
 
-    fs.writeFileSync(
-        fullPath,
-        ''
-    );
+    fs.writeFileSync(fullPath, '');
 }
 
 function startHttpServer(port, webRoot) {
     var server = httpServer.createServer({
-        root: webRoot
+        root: webRoot,
     });
 
     server.listen(port, '0.0.0.0');
@@ -200,10 +196,7 @@ export async function requestTestPage(browser, webRootDir, scriptSrcs, callback)
 `;
 
     // write the testing.html file
-    fs.writeFileSync(
-        path.join(webRootDir, 'testing.html'),
-        testHtml
-    );
+    fs.writeFileSync(path.join(webRootDir, 'testing.html'), testHtml);
 
     // start the main local server
     startHttpServer('8080', webRootDir);
@@ -220,7 +213,9 @@ export async function requestTestPage(browser, webRootDir, scriptSrcs, callback)
     });
 
     page.on('requestfailed', (request) => {
-        throw new Error(`Error "${request.failure().errorText}" when requesting resource "${request.url()}".`);
+        throw new Error(
+            `Error "${request.failure().errorText}" when requesting resource "${request.url()}".`
+        );
     });
 
     page.on('response', (response) => {

--- a/test/index.js
+++ b/test/index.js
@@ -7,500 +7,419 @@
  * file that was distributed with this source code.
  */
 
+import path from 'path';
+
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 import api from '../index.js';
-import path from 'path';
 
-describe('Public API', function() {
-    beforeEach(function() {
+describe('Public API', function () {
+    beforeEach(function () {
         process.chdir(path.join(import.meta.dirname, '..'));
         api.configureRuntimeEnvironment('dev', {}, false);
     });
 
-    describe('setOutputPath', function() {
-
-        it('must return the API object', function() {
+    describe('setOutputPath', function () {
+        it('must return the API object', function () {
             const returnedValue = api.setOutputPath('/');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('setPublicPath', function() {
-
-        it('must return the API object', function() {
+    describe('setPublicPath', function () {
+        it('must return the API object', function () {
             const returnedValue = api.setPublicPath('/');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('setManifestKeyPrefix', function() {
-
-        it('must return the API object', function() {
+    describe('setManifestKeyPrefix', function () {
+        it('must return the API object', function () {
             const returnedValue = api.setManifestKeyPrefix('/build');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addEntry', function() {
-
-        it('must return the API object', function() {
+    describe('addEntry', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addEntry('entry', 'main.js');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addStyleEntry', function() {
-
-        it('must return the API object', function() {
+    describe('addStyleEntry', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addStyleEntry('styleEntry', 'main.css');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addPlugin', function() {
-
-        it('must return the API object', function() {
+    describe('addPlugin', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addPlugin(null);
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addLoader', function() {
-
-        it('must return the API object', function() {
+    describe('addLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addLoader(null);
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addRule', function() {
-
-        it('must return the API object', function() {
+    describe('addRule', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addRule(null);
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addAliases', function() {
-
-        it('must return the API object', function() {
+    describe('addAliases', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addAliases({});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addExternals', function() {
-
-        it('must return the API object', function() {
+    describe('addExternals', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addExternals({});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableVersioning', function() {
-
-        it('must return the API object', function() {
+    describe('enableVersioning', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableVersioning();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableSourceMaps', function() {
-
-        it('must return the API object', function() {
+    describe('enableSourceMaps', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableSourceMaps();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('addCacheGroup', function() {
-
-        it('must return the API object', function() {
+    describe('addCacheGroup', function () {
+        it('must return the API object', function () {
             const returnedValue = api.addCacheGroup('sharedEntry', {
-                test: /vendor\.js/
+                test: /vendor\.js/,
             });
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('copyFiles', function() {
-
-        it('must return the API object', function() {
+    describe('copyFiles', function () {
+        it('must return the API object', function () {
             const returnedValue = api.copyFiles({ from: './foo' });
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableSingleRuntimeChunk', function() {
-
-        it('must return the API object', function() {
+    describe('enableSingleRuntimeChunk', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableSingleRuntimeChunk();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('disableSingleRuntimeChunk', function() {
-
-        it('must return the API object', function() {
+    describe('disableSingleRuntimeChunk', function () {
+        it('must return the API object', function () {
             const returnedValue = api.disableSingleRuntimeChunk();
             expect(returnedValue).toBe(api);
         });
-
     });
-    describe('splitEntryChunks', function() {
-
-        it('must return the API object', function() {
+    describe('splitEntryChunks', function () {
+        it('must return the API object', function () {
             const returnedValue = api.splitEntryChunks();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureSplitChunks', function() {
-
-        it('must return the API object', function() {
+    describe('configureSplitChunks', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureSplitChunks(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('autoProvideVariables', function() {
-
-        it('must return the API object', function() {
+    describe('autoProvideVariables', function () {
+        it('must return the API object', function () {
             const returnedValue = api.autoProvideVariables({});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('autoProvidejQuery', function() {
-
-        it('must return the API object', function() {
+    describe('autoProvidejQuery', function () {
+        it('must return the API object', function () {
             const returnedValue = api.autoProvidejQuery();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enablePostCssLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enablePostCssLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enablePostCssLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableSassLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableSassLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableSassLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableLessLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableLessLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableLessLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableStylusLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableStylusLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableStylusLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureBabel', function() {
-
-        it('must return the API object', function() {
+    describe('configureBabel', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureBabel(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureBabelPresetEnv', function() {
-
-        it('must return the API object', function() {
+    describe('configureBabelPresetEnv', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureBabelPresetEnv(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableReactPreset', function() {
-
-        it('must return the API object', function() {
+    describe('enableReactPreset', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableReactPreset();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableSvelte', function() {
-
-        it('must return the API object', function() {
+    describe('enableSvelte', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableSvelte();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enablePreactPreset', function() {
-
-        it('must return the API object', function() {
+    describe('enablePreactPreset', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enablePreactPreset();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableTypeScriptLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableTypeScriptLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableTypeScriptLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableForkedTypeScriptTypesChecking', function() {
-
-        it('must return the API object', function() {
+    describe('enableForkedTypeScriptTypesChecking', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableForkedTypeScriptTypesChecking();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableVueLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableVueLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableVueLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableBuildNotifications', function() {
-
-        it('must return the API object', function() {
+    describe('enableBuildNotifications', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableBuildNotifications();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableHandlebarsLoader', function() {
-
-        it('must return the API object', function() {
+    describe('enableHandlebarsLoader', function () {
+        it('must return the API object', function () {
             const returnedValue = api.enableHandlebarsLoader();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('disableCssExtraction', function() {
-
-        it('must return the API object', function() {
+    describe('disableCssExtraction', function () {
+        it('must return the API object', function () {
             const returnedValue = api.disableCssExtraction();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureFilenames', function() {
-
-        it('must return the API object', function() {
+    describe('configureFilenames', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureFilenames({});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureImageRule', function() {
-
-        it('must return the API object', function() {
+    describe('configureImageRule', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureImageRule();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureFontRule', function() {
-
-        it('must return the API object', function() {
+    describe('configureFontRule', function () {
+        it('must return the API object', function () {
             const returnedValue = api.configureFontRule();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('cleanupOutputBeforeBuild', function() {
-
-        it('must return the API object', function() {
+    describe('cleanupOutputBeforeBuild', function () {
+        it('must return the API object', function () {
             const returnedValue = api.cleanupOutputBeforeBuild();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureRuntimeEnvironment', function() {
-
-        it('should return the API object', function() {
+    describe('configureRuntimeEnvironment', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureRuntimeEnvironment('dev');
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureDefinePlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureDefinePlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureDefinePlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureFriendlyErrorsPlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureFriendlyErrorsPlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureFriendlyErrorsPlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureManifestPlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureManifestPlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureManifestPlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureTerserPlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureTerserPlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureTerserPlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('configureCssMinimizerPlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureCssMinimizerPlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureCssMinimizerPlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableStimulusBridge', function() {
-
-        it('should return the API object', function() {
-            const returnedValue = api.enableStimulusBridge(path.resolve(import.meta.dirname, '../', 'package.json'));
+    describe('enableStimulusBridge', function () {
+        it('should return the API object', function () {
+            const returnedValue = api.enableStimulusBridge(
+                path.resolve(import.meta.dirname, '../', 'package.json')
+            );
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableBuildCache', function() {
-
-        it('should return the API object', function() {
+    describe('enableBuildCache', function () {
+        it('should return the API object', function () {
             const returnedValue = api.enableBuildCache({ config: [import.meta.filename] });
             expect(returnedValue).toBe(api);
         });
-
     });
-    describe('configureMiniCssExtractPlugin', function() {
-
-        it('should return the API object', function() {
+    describe('configureMiniCssExtractPlugin', function () {
+        it('should return the API object', function () {
             const returnedValue = api.configureMiniCssExtractPlugin(() => {});
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('enableIntegrityHashes', function() {
-
-        it('should return the API object', function() {
+    describe('enableIntegrityHashes', function () {
+        it('should return the API object', function () {
             const returnedValue = api.enableIntegrityHashes();
             expect(returnedValue).toBe(api);
         });
-
     });
 
-    describe('when', function() {
-        it('should call or not callbacks depending of the conditions', function() {
+    describe('when', function () {
+        it('should call or not callbacks depending of the conditions', function () {
             api.configureRuntimeEnvironment('dev', {}, false);
 
             const spy = vi.fn();
-            api
-                .when((Encore) => Encore.isDev(), (Encore) => spy('is dev'))
-                .when((Encore) => Encore.isProduction(), (Encore) => spy('is production'))
+            api.when(
+                (Encore) => Encore.isDev(),
+                (Encore) => spy('is dev')
+            )
+                .when(
+                    (Encore) => Encore.isProduction(),
+                    (Encore) => spy('is production')
+                )
                 .when(true, (Encore) => spy('true'));
-            expect(spy.mock.calls.some(call => call[0] === 'is dev'), 'callback for "is dev" should be called').toBe(true);
-            expect(spy.mock.calls.some(call => call[0] === 'is production'), 'callback for "is production" should NOT be called').toBe(false);
-            expect(spy.mock.calls.some(call => call[0] === 'true'), 'callback for "true" should be called').toBe(true);
+            expect(
+                spy.mock.calls.some((call) => call[0] === 'is dev'),
+                'callback for "is dev" should be called'
+            ).toBe(true);
+            expect(
+                spy.mock.calls.some((call) => call[0] === 'is production'),
+                'callback for "is production" should NOT be called'
+            ).toBe(false);
+            expect(
+                spy.mock.calls.some((call) => call[0] === 'true'),
+                'callback for "true" should be called'
+            ).toBe(true);
         });
     });
 
-    describe('isRuntimeEnvironmentConfigured', function() {
-
-        it('should return true if the runtime environment has been configured', function() {
+    describe('isRuntimeEnvironmentConfigured', function () {
+        it('should return true if the runtime environment has been configured', function () {
             const returnedValue = api.isRuntimeEnvironmentConfigured();
             expect(returnedValue).toBe(true);
         });
 
-        it('should return false if the runtime environment has not been configured', function() {
+        it('should return false if the runtime environment has not been configured', function () {
             api.clearRuntimeEnvironment();
 
             const returnedValue = api.isRuntimeEnvironmentConfigured();
             expect(returnedValue).toBe(false);
         });
-
     });
 
-    describe('Runtime environment proxy', function() {
-        beforeEach(function() {
+    describe('Runtime environment proxy', function () {
+        beforeEach(function () {
             api.clearRuntimeEnvironment();
         });
 
-        it('safe methods should be callable even if the runtime environment has not been configured', function() {
+        it('safe methods should be callable even if the runtime environment has not been configured', function () {
             expect(() => api.clearRuntimeEnvironment()).to.not.throw();
         });
 
-        it('unsafe methods should NOT be callable if the runtime environment has not been configured', function() {
-            expect(() => api.setOutputPath('/')).toThrow('Encore.setOutputPath() cannot be called yet');
+        it('unsafe methods should NOT be callable if the runtime environment has not been configured', function () {
+            expect(() => api.setOutputPath('/')).toThrow(
+                'Encore.setOutputPath() cannot be called yet'
+            );
         });
     });
 });

--- a/test/loaders/babel.js
+++ b/test/loaders/babel.js
@@ -7,11 +7,13 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'url';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
+import { describe, it, expect } from 'vitest';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import babelLoader from '../../lib/loaders/babel.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,11 +23,11 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/babel', function() {
-    it('getLoaders() basic usage', async function() {
+describe('loaders/babel', function () {
+    it('getLoaders() basic usage', async function () {
         const config = createConfig();
         config.runtimeConfig.babelRcFileExists = false;
-        config.configureBabel(function(config) {
+        config.configureBabel(function (config) {
             config.foo = 'bar';
         });
 
@@ -37,7 +39,7 @@ describe('loaders/babel', function() {
         expect(actualLoaders[0].options.foo).toBe('bar');
     });
 
-    it('getLoaders() when .babelrc IS present', async function() {
+    it('getLoaders() when .babelrc IS present', async function () {
         const config = createConfig();
         config.runtimeConfig.babelRcFileExists = true;
 
@@ -49,7 +51,7 @@ describe('loaders/babel', function() {
         });
     });
 
-    it('getLoaders() for production', async function() {
+    it('getLoaders() for production', async function () {
         const config = createConfig();
         config.runtimeConfig.babelRcFileExists = true;
         config.runtimeConfig.environment = 'production';
@@ -62,11 +64,11 @@ describe('loaders/babel', function() {
         });
     });
 
-    it('getLoaders() with react', async function() {
+    it('getLoaders() with react', async function () {
         const config = createConfig();
         config.enableReactPreset();
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.presets.push('foo');
         });
 
@@ -87,19 +89,19 @@ describe('loaders/babel', function() {
             fileURLToPath(import.meta.resolve('@babel/preset-react')),
             {
                 runtime: 'automatic',
-            }
+            },
         ]);
         // foo is also still there, not overridden
         expect(actualLoaders[0].options.presets[2]).toBe('foo');
     });
 
-    it('getLoaders() with react and callback', async function() {
+    it('getLoaders() with react and callback', async function () {
         const config = createConfig();
         config.enableReactPreset((options) => {
             options.development = !config.isProduction();
         });
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.presets.push('foo');
         });
 
@@ -121,33 +123,36 @@ describe('loaders/babel', function() {
             {
                 runtime: 'automatic',
                 development: true,
-            }
+            },
         ]);
         // foo is also still there, not overridden
         expect(actualLoaders[0].options.presets[2]).toBe('foo');
     });
 
-    it('getLoaders() with preact', async function() {
+    it('getLoaders() with preact', async function () {
         const config = createConfig();
         config.enablePreactPreset();
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.plugins.push('foo');
         });
 
         const actualLoaders = await babelLoader.getLoaders(config);
 
         expect(actualLoaders[0].options.plugins).to.deep.include.members([
-            [fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx')), { pragma: 'h' }],
-            'foo'
+            [
+                fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx')),
+                { pragma: 'h' },
+            ],
+            'foo',
         ]);
     });
 
-    it('getLoaders() with preact and preact-compat', async function() {
+    it('getLoaders() with preact and preact-compat', async function () {
         const config = createConfig();
         config.enablePreactPreset({ preactCompat: true });
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.plugins.push('foo');
         });
 
@@ -155,15 +160,15 @@ describe('loaders/babel', function() {
 
         expect(actualLoaders[0].options.plugins).to.deep.include.members([
             [fileURLToPath(import.meta.resolve('@babel/plugin-transform-react-jsx'))],
-            'foo'
+            'foo',
         ]);
     });
 
-    it('getLoaders() with a callback that returns an object', async function() {
+    it('getLoaders() with a callback that returns an object', async function () {
         const config = createConfig();
         config.enablePreactPreset({ preactCompat: true });
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.plugins.push('foo');
 
             // This should override the original config
@@ -171,17 +176,17 @@ describe('loaders/babel', function() {
         });
 
         const actualLoaders = await babelLoader.getLoaders(config);
-        expect(actualLoaders[0].options).toEqual({ 'foo': true });
+        expect(actualLoaders[0].options).toEqual({ foo: true });
     });
 
-    it('getLoaders() with Vue and JSX support', async function() {
+    it('getLoaders() with Vue and JSX support', async function () {
         const config = createConfig();
         config.enableVueLoader(() => {}, {
             version: 3,
             useJsx: true,
         });
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.plugins.push('foo');
         });
 
@@ -189,19 +194,19 @@ describe('loaders/babel', function() {
 
         expect(actualLoaders[0].options.plugins).to.deep.include.members([
             fileURLToPath(import.meta.resolve('@vue/babel-plugin-jsx')),
-            'foo'
+            'foo',
         ]);
     });
 
-    it('getLoaders() with configured babel env preset', async function() {
+    it('getLoaders() with configured babel env preset', async function () {
         const config = createConfig();
         config.runtimeConfig.babelRcFileExists = false;
 
-        config.configureBabel(function(config) {
+        config.configureBabel(function (config) {
             config.corejs = null;
         });
 
-        config.configureBabelPresetEnv(function(config) {
+        config.configureBabelPresetEnv(function (config) {
             config.corejs = 3;
             config.include = ['bar'];
         });
@@ -213,34 +218,36 @@ describe('loaders/babel', function() {
         expect(actualLoaders[0].options.presets[0][1].include).to.have.members(['bar']);
     });
 
-    it('getLoaders() with TypeScript', async function() {
+    it('getLoaders() with TypeScript', async function () {
         const config = createConfig();
         const presetTypeScriptOptions = { isTSX: true };
 
         config.enableBabelTypeScriptPreset(presetTypeScriptOptions);
 
-        config.configureBabel(function(babelConfig) {
+        config.configureBabel(function (babelConfig) {
             babelConfig.plugins.push('foo');
         });
 
         const actualLoaders = await babelLoader.getLoaders(config);
 
-        expect(actualLoaders[0].options.presets[0][0]).toBe(fileURLToPath(import.meta.resolve('@babel/preset-env')));
-        expect(actualLoaders[0].options.presets[1][0]).toBe(fileURLToPath(import.meta.resolve('@babel/preset-typescript')));
+        expect(actualLoaders[0].options.presets[0][0]).toBe(
+            fileURLToPath(import.meta.resolve('@babel/preset-env'))
+        );
+        expect(actualLoaders[0].options.presets[1][0]).toBe(
+            fileURLToPath(import.meta.resolve('@babel/preset-typescript'))
+        );
         expect(actualLoaders[0].options.presets[1][1]).toBe(presetTypeScriptOptions);
-        expect(actualLoaders[0].options.plugins).to.deep.include.members([
-            'foo'
-        ]);
+        expect(actualLoaders[0].options.plugins).to.deep.include.members(['foo']);
     });
 
-    it('getTest() base behavior', function() {
+    it('getTest() base behavior', function () {
         const config = createConfig();
 
         const actualTest = babelLoader.getTest(config);
         expect(actualTest.toString()).to.equals(/\.(m?jsx?)$/.toString());
     });
 
-    it('getTest() with TypeScript', function() {
+    it('getTest() with TypeScript', function () {
         const config = createConfig();
         config.enableBabelTypeScriptPreset();
 

--- a/test/loaders/css-extract.js
+++ b/test/loaders/css-extract.js
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
  */
 
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import cssExtractLoader from '../../lib/loaders/css-extract.js';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,8 +22,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/css-extract', function() {
-    it('prependLoaders() basic usage', function() {
+describe('loaders/css-extract', function () {
+    it('prependLoaders() basic usage', function () {
         const config = createConfig();
 
         const loaders = cssExtractLoader.prependLoaders(config, ['foo']);
@@ -31,7 +32,7 @@ describe('loaders/css-extract', function() {
         expect(loaders[0].loader).toBe(MiniCssExtractPlugin.loader);
     });
 
-    it('prependLoaders() with CSS extraction disabled', function() {
+    it('prependLoaders() with CSS extraction disabled', function () {
         const config = createConfig();
         config.disableCssExtraction();
         config.enableSourceMaps(true);
@@ -42,9 +43,9 @@ describe('loaders/css-extract', function() {
         expect(loaders[0].loader).toContain('style-loader');
     });
 
-    it('prependLoaders() options callback', function() {
+    it('prependLoaders() options callback', function () {
         const config = createConfig();
-        config.configureMiniCssExtractPlugin(options => {
+        config.configureMiniCssExtractPlugin((options) => {
             options.ignoreOrder = true;
         });
 

--- a/test/loaders/css.js
+++ b/test/loaders/css.js
@@ -8,9 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import cssLoader from '../../lib/loaders/css.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -20,8 +21,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/css', function() {
-    it('getLoaders() basic usage', function() {
+describe('loaders/css', function () {
+    it('getLoaders() basic usage', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
@@ -31,7 +32,7 @@ describe('loaders/css', function() {
         expect(actualLoaders[0].options.modules).toBe(false);
     });
 
-    it('getLoaders() for production', function() {
+    it('getLoaders() for production', function () {
         const config = createConfig();
         config.enableSourceMaps(false);
         config.runtimeConfig.environment = 'production';
@@ -42,10 +43,10 @@ describe('loaders/css', function() {
         expect(actualLoaders[0].options.modules).toBe(false);
     });
 
-    it('getLoaders() with options callback', function() {
+    it('getLoaders() with options callback', function () {
         const config = createConfig();
 
-        config.configureCssLoader(function(options) {
+        config.configureCssLoader(function (options) {
             options.foo = true;
             options.url = false;
         });
@@ -57,10 +58,10 @@ describe('loaders/css', function() {
         expect(actualLoaders[0].options.modules).toBe(false);
     });
 
-    it('getLoaders() with CSS modules enabled', function() {
+    it('getLoaders() with CSS modules enabled', function () {
         const config = createConfig();
 
-        config.configureCssLoader(function(options) {
+        config.configureCssLoader(function (options) {
             options.foo = true;
             options.url = false;
         });
@@ -74,8 +75,8 @@ describe('loaders/css', function() {
         });
     });
 
-    describe('getLoaders() with PostCSS', function() {
-        it('without options callback', function() {
+    describe('getLoaders() with PostCSS', function () {
+        it('without options callback', function () {
             const config = createConfig();
             config.enableSourceMaps();
             config.enablePostCssLoader();
@@ -86,12 +87,12 @@ describe('loaders/css', function() {
             expect(actualLoaders[1].options.sourceMap).toBe(true);
         });
 
-        it('with options callback', function() {
+        it('with options callback', function () {
             const config = createConfig();
             config.enableSourceMaps();
             config.enablePostCssLoader((options) => {
                 options.config = {
-                    path: 'config/postcss.config.js'
+                    path: 'config/postcss.config.js',
                 };
             });
 
@@ -102,12 +103,12 @@ describe('loaders/css', function() {
             expect(actualLoaders[1].options.config.path).toBe('config/postcss.config.js');
         });
 
-        it('with options callback that returns an object', function() {
+        it('with options callback that returns an object', function () {
             const config = createConfig();
             config.enableSourceMaps(true);
             config.enablePostCssLoader((options) => {
                 options.config = {
-                    path: 'config/postcss.config.js'
+                    path: 'config/postcss.config.js',
                 };
 
                 // This should override the original config

--- a/test/loaders/handlebars.js
+++ b/test/loaders/handlebars.js
@@ -8,9 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import handlebarsLoader from '../../lib/loaders/handlebars.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -20,8 +21,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/handlebars', function() {
-    it('getLoaders() basic usage', function() {
+describe('loaders/handlebars', function () {
+    it('getLoaders() basic usage', function () {
         const config = createConfig();
         config.enableHandlebarsLoader();
 
@@ -30,7 +31,7 @@ describe('loaders/handlebars', function() {
         expect(actualLoaders[0].options).to.be.empty;
     });
 
-    it('getLoaders() with options callback', function() {
+    it('getLoaders() with options callback', function () {
         const config = createConfig();
         config.enableHandlebarsLoader((options) => {
             options.debug = true;
@@ -41,7 +42,7 @@ describe('loaders/handlebars', function() {
         expect(actualLoaders[0].options.debug).toBe(true);
     });
 
-    it('getLoaders() with options callback that returns an object', function() {
+    it('getLoaders() with options callback that returns an object', function () {
         const config = createConfig();
         config.enableHandlebarsLoader((options) => {
             options.debug = true;

--- a/test/loaders/less.js
+++ b/test/loaders/less.js
@@ -8,11 +8,11 @@
  */
 
 import { vi, describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
-import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
-import lessLoader from '../../lib/loaders/less.js';
-import cssLoader from '../../lib/loaders/css.js';
 
+import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
+import cssLoader from '../../lib/loaders/css.js';
+import lessLoader from '../../lib/loaders/less.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -22,14 +22,13 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/less', function() {
-    it('getLoaders() basic usage', function() {
+describe('loaders/less', function () {
+    it('getLoaders() basic usage', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = lessLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(1);
@@ -37,15 +36,14 @@ describe('loaders/less', function() {
         expect(cssLoaderStub.mock.calls[0][1]).toBe(false);
     });
 
-    it('getLoaders() with options callback', function() {
+    it('getLoaders() with options callback', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableLessLoader(function(lessOptions) {
+        config.enableLessLoader(function (lessOptions) {
             lessOptions.custom_option = 'foo';
             lessOptions.other_option = true;
         });
@@ -54,20 +52,18 @@ describe('loaders/less', function() {
         expect(actualLoaders[0].options).toEqual({
             sourceMap: true,
             custom_option: 'foo',
-            other_option: true
+            other_option: true,
         });
-
     });
 
-    it('getLoaders() with a callback that returns an object', function() {
+    it('getLoaders() with a callback that returns an object', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableLessLoader(function(lessOptions) {
+        config.enableLessLoader(function (lessOptions) {
             lessOptions.custom_option = 'foo';
 
             // This should override the original config
@@ -76,16 +72,14 @@ describe('loaders/less', function() {
 
         const actualLoaders = lessLoader.getLoaders(config);
         expect(actualLoaders[0].options).toEqual({ foo: true });
-
     });
 
-    it('getLoaders() with CSS modules enabled', function() {
+    it('getLoaders() with CSS modules enabled', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = lessLoader.getLoaders(config, true);
         expect(actualLoaders).toHaveLength(1);

--- a/test/loaders/sass.js
+++ b/test/loaders/sass.js
@@ -8,11 +8,11 @@
  */
 
 import { vi, describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
-import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
-import sassLoader from '../../lib/loaders/sass.js';
-import cssLoader from '../../lib/loaders/css.js';
 
+import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
+import cssLoader from '../../lib/loaders/css.js';
+import sassLoader from '../../lib/loaders/sass.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -22,14 +22,13 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/sass', function() {
-    it('getLoaders() basic usage', function() {
+describe('loaders/sass', function () {
+    it('getLoaders() basic usage', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = sassLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(2);
@@ -41,13 +40,12 @@ describe('loaders/sass', function() {
         expect(cssLoaderStub.mock.calls[0][1]).toBe(false);
     });
 
-    it('getLoaders() with resolve-url-loader but not sourcemaps', function() {
+    it('getLoaders() with resolve-url-loader but not sourcemaps', function () {
         const config = createConfig();
         config.enableSourceMaps(false);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = sassLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(2);
@@ -59,17 +57,16 @@ describe('loaders/sass', function() {
         expect(actualLoaders[1].options.sourceMap).toBe(true);
     });
 
-    it('getLoaders() with resolve-url-loader options', function() {
+    it('getLoaders() with resolve-url-loader options', function () {
         const config = createConfig();
         config.enableSassLoader(() => {}, {
             resolveUrlLoaderOptions: {
-                removeCR: true
-            }
+                removeCR: true,
+            },
         });
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = sassLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(2);
@@ -77,7 +74,7 @@ describe('loaders/sass', function() {
         expect(actualLoaders[0].options.removeCR).toBe(true);
     });
 
-    it('getLoaders() without resolve-url-loader', function() {
+    it('getLoaders() without resolve-url-loader', function () {
         const config = createConfig();
         config.enableSassLoader(() => {}, {
             resolveUrlLoader: false,
@@ -85,8 +82,7 @@ describe('loaders/sass', function() {
         config.enableSourceMaps(false);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = sassLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(1);
@@ -94,14 +90,13 @@ describe('loaders/sass', function() {
         expect(actualLoaders[0].options.sourceMap).toBe(false);
     });
 
-    it('getLoaders() with options callback', function() {
+    it('getLoaders() with options callback', function () {
         const config = createConfig();
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableSassLoader(function(options) {
+        config.enableSassLoader(function (options) {
             options.sassOptions.custom_option = 'baz';
             options.sassOptions.other_option = true;
         });
@@ -113,20 +108,18 @@ describe('loaders/sass', function() {
             sassOptions: {
                 outputStyle: 'expanded',
                 custom_option: 'baz',
-                other_option: true
-            }
+                other_option: true,
+            },
         });
-
     });
 
-    it('getLoaders() with a callback that returns an object', function() {
+    it('getLoaders() with a callback that returns an object', function () {
         const config = createConfig();
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableSassLoader(function(options) {
+        config.enableSassLoader(function (options) {
             options.custom_option = 'baz';
 
             // This should override the original config
@@ -136,13 +129,12 @@ describe('loaders/sass', function() {
         expect(actualLoaders[1].options).toEqual({ foo: true });
     });
 
-    it('getLoaders() with CSS modules enabled', function() {
+    it('getLoaders() with CSS modules enabled', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = sassLoader.getLoaders(config, true);
         expect(actualLoaders).toHaveLength(2);

--- a/test/loaders/stylus.js
+++ b/test/loaders/stylus.js
@@ -8,11 +8,11 @@
  */
 
 import { vi, describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
-import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
-import stylusLoader from '../../lib/loaders/stylus.js';
-import cssLoader from '../../lib/loaders/css.js';
 
+import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
+import cssLoader from '../../lib/loaders/css.js';
+import stylusLoader from '../../lib/loaders/stylus.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -22,14 +22,13 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/stylus', function() {
-    it('getLoaders() basic usage', function() {
+describe('loaders/stylus', function () {
+    it('getLoaders() basic usage', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = stylusLoader.getLoaders(config);
         expect(actualLoaders).toHaveLength(1);
@@ -37,15 +36,14 @@ describe('loaders/stylus', function() {
         expect(cssLoaderStub.mock.calls[0][1]).toBe(false);
     });
 
-    it('getLoaders() with options callback', function() {
+    it('getLoaders() with options callback', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableStylusLoader(function(stylusOptions) {
+        config.enableStylusLoader(function (stylusOptions) {
             stylusOptions.custom_option = 'foo';
             stylusOptions.other_option = true;
         });
@@ -54,20 +52,18 @@ describe('loaders/stylus', function() {
         expect(actualLoaders[0].options).toEqual({
             sourceMap: true,
             custom_option: 'foo',
-            other_option: true
+            other_option: true,
         });
-
     });
 
-    it('getLoaders() with a callback that returns an object', function() {
+    it('getLoaders() with a callback that returns an object', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
-        config.enableStylusLoader(function(stylusOptions) {
+        config.enableStylusLoader(function (stylusOptions) {
             stylusOptions.custom_option = 'foo';
 
             // This should override the original config
@@ -78,13 +74,12 @@ describe('loaders/stylus', function() {
         expect(actualLoaders[0].options).toEqual({ foo: true });
     });
 
-    it('getLoaders() with CSS modules enabled', function() {
+    it('getLoaders() with CSS modules enabled', function () {
         const config = createConfig();
         config.enableSourceMaps(true);
 
         // make the cssLoader return nothing
-        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders')
-            .mockImplementation(() => []);
+        const cssLoaderStub = vi.spyOn(cssLoader, 'getLoaders').mockImplementation(() => []);
 
         const actualLoaders = stylusLoader.getLoaders(config, true);
         expect(actualLoaders).toHaveLength(1);

--- a/test/loaders/typescript.js
+++ b/test/loaders/typescript.js
@@ -8,9 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import tsLoader from '../../lib/loaders/typescript.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -20,10 +21,10 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/typescript', function() {
-    it('getLoaders() basic usage', async function() {
+describe('loaders/typescript', function () {
+    it('getLoaders() basic usage', async function () {
         const config = createConfig();
-        config.enableTypeScriptLoader(function(config) {
+        config.enableTypeScriptLoader(function (config) {
             config.foo = 'bar';
         });
 
@@ -33,9 +34,9 @@ describe('loaders/typescript', function() {
         expect(actualLoaders[1].options.foo).toBe('bar');
     });
 
-    it('getLoaders() check defaults configuration values', async function() {
+    it('getLoaders() check defaults configuration values', async function () {
         const config = createConfig();
-        config.enableTypeScriptLoader(function(config) {
+        config.enableTypeScriptLoader(function (config) {
             config.foo = 'bar';
         });
 
@@ -46,9 +47,9 @@ describe('loaders/typescript', function() {
         expect(actualLoaders[1].options.silent).toBe(true);
     });
 
-    it('getLoaders() with a callback that returns an object', async function() {
+    it('getLoaders() with a callback that returns an object', async function () {
         const config = createConfig();
-        config.enableTypeScriptLoader(function(config) {
+        config.enableTypeScriptLoader(function (config) {
             config.foo = false;
 
             // This should override the original config

--- a/test/loaders/vue.js
+++ b/test/loaders/vue.js
@@ -8,9 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import vueLoader from '../../lib/loaders/vue.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -20,8 +21,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('loaders/vue', function() {
-    it('getLoaders() with extra options', function() {
+describe('loaders/vue', function () {
+    it('getLoaders() with extra options', function () {
         const config = createConfig();
         config.enableVueLoader((options) => {
             options.postLoaders = { foo: 'foo-loader' };
@@ -33,7 +34,7 @@ describe('loaders/vue', function() {
         expect(actualLoaders[0].options.postLoaders.foo).toBe('foo-loader');
     });
 
-    it('getLoaders() with a callback that returns an object', function() {
+    it('getLoaders() with a callback that returns an object', function () {
         const config = createConfig();
         config.enableVueLoader((options) => {
             options.postLoaders = { foo: 'foo-loader' };

--- a/test/logger.js
+++ b/test/logger.js
@@ -8,27 +8,22 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
 import context from '../lib/context.js';
 context.runtimeConfig = {};
 import logger from '../lib/logger.js';
 
-describe('logger', function() {
-    beforeEach(function() {
+describe('logger', function () {
+    beforeEach(function () {
         logger.reset();
     });
 
-    afterEach(function() {
+    afterEach(function () {
         logger.reset();
     });
 
-    it('Smoke test for log methods', function() {
-
-        const methods = [
-            'debug',
-            'recommendation',
-            'warning',
-            'deprecation',
-        ];
+    it('Smoke test for log methods', function () {
+        const methods = ['debug', 'recommendation', 'warning', 'deprecation'];
         const testString = 'TEST MESSAGE';
         const expectedMessages = {
             debug: [testString],
@@ -50,7 +45,7 @@ describe('logger', function() {
         expect(actualMessages).toEqual(expectedMessages);
     });
 
-    it('test reset()', function() {
+    it('test reset()', function () {
         logger.debug('DEBUG!');
         logger.reset();
 

--- a/test/package-helper.js
+++ b/test/package-helper.js
@@ -7,76 +7,92 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect, afterAll } from 'vitest';
-import packageHelper from '../lib/package-helper.js';
+import fs from 'fs';
 import path from 'path';
 import process from 'process';
-import fs from 'fs';
-import stripAnsi from 'strip-ansi';
 
-describe('package-helper', function() {
+import stripAnsi from 'strip-ansi';
+import { describe, it, expect, afterAll } from 'vitest';
+
+import packageHelper from '../lib/package-helper.js';
+
+describe('package-helper', function () {
     const baseCwd = process.cwd();
 
-    describe('recommended install command is based on the existing lock files', function() {
-        afterAll(function() {
+    describe('recommended install command is based on the existing lock files', function () {
+        afterAll(function () {
             process.chdir(baseCwd);
         });
 
-        it('missing packages without any lock file', function() {
-            process.chdir(path.join(import.meta.dirname , '../fixtures/package-helper/empty'));
+        it('missing packages without any lock file', function () {
+            process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/empty'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('npm install foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with package-lock.json only', function() {
+        it('missing packages with package-lock.json only', function () {
             process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/npm'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('npm install foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with yarn.lock only', function() {
+        it('missing packages with yarn.lock only', function () {
             process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/yarn'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('yarn add foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with pnpm-lock.yaml only', function() {
+        it('missing packages with pnpm-lock.yaml only', function () {
             process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/pnpm'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('pnpm add foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with both package-lock.json and yarn.lock', function() {
+        it('missing packages with both package-lock.json and yarn.lock', function () {
             process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/yarn-npm'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('yarn add foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with package-lock.json, yarn.lock and pnpm-lock.yaml', function() {
-            process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/pnpm-yarn-npm'));
+        it('missing packages with package-lock.json, yarn.lock and pnpm-lock.yaml', function () {
+            process.chdir(
+                path.join(import.meta.dirname, '../fixtures/package-helper/pnpm-yarn-npm')
+            );
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'webpack' }, { name: 'bar' }
+                { name: 'foo' },
+                { name: 'webpack' },
+                { name: 'bar' },
             ]);
             expect(packageRecommendations.installCommand).toContain('pnpm add foo bar');
             expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar');
         });
 
-        it('missing packages with alternative packages', function() {
+        it('missing packages with alternative packages', function () {
             process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/yarn'));
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
                 { name: 'foo' },
@@ -85,98 +101,106 @@ describe('package-helper', function() {
                 [{ name: 'quux' }, { name: 'webpack' }],
             ]);
             expect(packageRecommendations.installCommand).toContain('yarn add foo bar qux');
-            expect(stripAnsi(packageRecommendations.message)).toContain('foo & bar (or baz) & qux (or corge or grault)');
+            expect(stripAnsi(packageRecommendations.message)).toContain(
+                'foo & bar (or baz) & qux (or corge or grault)'
+            );
         });
     });
 
-    describe('check messaging on install commands', function() {
-        it('Make sure the major version is included in the install command', function() {
+    describe('check messaging on install commands', function () {
+        it('Make sure the major version is included in the install command', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
-                { name: 'foo' }, { name: 'bar', version: '^3.0' }
+                { name: 'foo' },
+                { name: 'bar', version: '^3.0' },
             ]);
 
             expect(packageRecommendations.installCommand).toContain('pnpm add foo bar@^3.0');
         });
 
-        it('Recommends correct install on 0 version', function() {
+        it('Recommends correct install on 0 version', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
                 { name: 'foo', version: '^0.1.0' },
-                { name: 'bar' }
+                { name: 'bar' },
             ]);
 
             expect(packageRecommendations.installCommand).toContain('pnpm add foo@^0.1.0 bar');
         });
 
-        it('Recommends correct install with a more complex constraint', function() {
+        it('Recommends correct install with a more complex constraint', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
                 { name: 'foo', version: '^7.0||^8.0' },
-                { name: 'bar' }
+                { name: 'bar' },
             ]);
 
             expect(packageRecommendations.installCommand).toContain('pnpm add foo@^8.0 bar');
         });
 
-        it('Recommends correct install with a more complex constraint (spaces around ||)', function() {
+        it('Recommends correct install with a more complex constraint (spaces around ||)', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
                 { name: 'foo', version: '^7.0 || ^8.0' },
-                { name: 'bar' }
+                { name: 'bar' },
             ]);
 
             expect(packageRecommendations.installCommand).toContain('pnpm add foo@^8.0 bar');
         });
 
-        it('Recommends correct install with alternative packages', function() {
+        it('Recommends correct install with alternative packages', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([
                 { name: 'foo', version: '^7.0 || ^8.0' },
                 [{ name: 'bar' }, { name: 'baz' }],
-                [{ name: 'qux', version: '^1.0' }, { name: 'quux', version: '^2.0' }]
+                [
+                    { name: 'qux', version: '^1.0' },
+                    { name: 'quux', version: '^2.0' },
+                ],
             ]);
 
-            expect(packageRecommendations.installCommand).toContain('pnpm add foo@^8.0 bar qux@^1.0');
+            expect(packageRecommendations.installCommand).toContain(
+                'pnpm add foo@^8.0 bar qux@^1.0'
+            );
         });
     });
 
-    describe('The getInvalidPackageVersionRecommendations correctly checks installed versions', function() {
-        it('Check package that *is* the correct version', function() {
+    describe('The getInvalidPackageVersionRecommendations correctly checks installed versions', function () {
+        it('Check package that *is* the correct version', function () {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
                 { name: '@hotwired/stimulus', version: '^3.0.0' },
-                { name: 'preact', version: '^8.2.0 || ^10.0.0' }
+                { name: 'preact', version: '^8.2.0 || ^10.0.0' },
             ]);
 
             expect(versionProblems).to.be.empty;
         });
 
-        it('Check package with a version too low', function() {
+        it('Check package with a version too low', function () {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
                 { name: '@hotwired/stimulus', version: '^4.0.0' },
-                { name: 'preact', version: '9.0.0' }
+                { name: 'preact', version: '9.0.0' },
             ]);
 
             expect(versionProblems).to.have.length(2);
             expect(versionProblems[0]).toContain('is too old');
         });
 
-        it('Check package with a version too new', function() {
+        it('Check package with a version too new', function () {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
                 { name: '@hotwired/stimulus', version: '^2.0' },
-                { name: 'preact', version: '8.1.0' }
+                { name: 'preact', version: '8.1.0' },
             ]);
 
             expect(versionProblems).to.have.length(2);
             expect(versionProblems[0]).toContain('is too new');
         });
 
-        it('Missing "version" key is ok', function() {
+        it('Missing "version" key is ok', function () {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
                 { name: 'sass-loader', version: '^6.9.9' },
-                { name: 'preact' }
+                { name: 'preact' },
             ]);
 
             // just sass-loader
             expect(versionProblems).to.have.length(1);
         });
 
-        it('Beta version is ok', function() {
+        it('Beta version is ok', function () {
             const versionProblems = packageHelper.getInvalidPackageVersionRecommendations([
                 { name: 'vue', version: '^3.0.0-beta.5' },
             ]);
@@ -185,12 +209,12 @@ describe('package-helper', function() {
         });
     });
 
-    describe('addPackagesVersionConstraint', function() {
-        it('Lookup a version constraint', function() {
+    describe('addPackagesVersionConstraint', function () {
+        it('Lookup a version constraint', function () {
             const inputPackages = [
                 { name: 'sass-loader', enforce_version: 7 },
                 { name: 'node-sass' },
-                { name: 'vue', version: '^2' }
+                { name: 'vue', version: '^2' },
             ];
 
             const packageInfo = JSON.parse(
@@ -200,7 +224,7 @@ describe('package-helper', function() {
             const expectedPackages = [
                 { name: 'sass-loader', version: packageInfo.devDependencies['sass-loader'] },
                 { name: 'node-sass' },
-                { name: 'vue', version: '^2' }
+                { name: 'vue', version: '^2' },
             ];
 
             const actualPackages = packageHelper.addPackagesVersionConstraint(inputPackages);

--- a/test/plugins/define.js
+++ b/test/plugins/define.js
@@ -9,9 +9,10 @@
 
 import { describe, it, expect } from 'vitest';
 import webpack from 'webpack';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import definePluginUtil from '../../lib/plugins/define.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig(environment = 'production') {
     const runtimeConfig = new RuntimeConfig();
@@ -22,28 +23,32 @@ function createConfig(environment = 'production') {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/define', function() {
-    it('dev environment', function() {
+describe('plugins/define', function () {
+    it('dev environment', function () {
         const config = createConfig('dev');
         const plugins = [];
 
         definePluginUtil(plugins, config);
         expect(plugins.length).toBe(1);
         expect(plugins[0].plugin).toBeInstanceOf(webpack.DefinePlugin);
-        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(JSON.stringify('development'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(
+            JSON.stringify('development')
+        );
     });
 
-    it('production environment with default settings', function() {
+    it('production environment with default settings', function () {
         const config = createConfig();
         const plugins = [];
 
         definePluginUtil(plugins, config);
         expect(plugins.length).toBe(1);
         expect(plugins[0].plugin).toBeInstanceOf(webpack.DefinePlugin);
-        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(JSON.stringify('production'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(
+            JSON.stringify('production')
+        );
     });
 
-    it('production environment with options callback', function() {
+    it('production environment with options callback', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -61,10 +66,12 @@ describe('plugins/define', function() {
         expect(plugins[0].plugin.definitions['process.env.bar']).toBe(true);
 
         // Doesn't remove default definitions
-        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(JSON.stringify('production'));
+        expect(plugins[0].plugin.definitions['process.env.NODE_ENV']).toBe(
+            JSON.stringify('production')
+        );
     });
 
-    it('production environment with options callback that returns an object', function() {
+    it('production environment with options callback that returns an object', function () {
         const config = createConfig();
         const plugins = [];
 

--- a/test/plugins/forked-ts-types.js
+++ b/test/plugins/forked-ts-types.js
@@ -7,12 +7,13 @@
  * file that was distributed with this source code.
  */
 
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import { describe, it, expect } from 'vitest';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import tsLoader from '../../lib/loaders/typescript.js';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import tsTypeChecker from '../../lib/plugins/forked-ts-types.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -22,8 +23,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/forkedtypecheck', function() {
-    it('getPlugins() basic usage', async function() {
+describe('plugins/forkedtypecheck', function () {
+    it('getPlugins() basic usage', async function () {
         const config = createConfig();
         config.enableTypeScriptLoader();
         config.enableForkedTypeScriptTypesChecking();
@@ -38,10 +39,10 @@ describe('plugins/forkedtypecheck', function() {
         expect(actualLoaders[1].options.transpileOnly).toBe(true);
     });
 
-    it('getPlugins() with options callback', function() {
+    it('getPlugins() with options callback', function () {
         const config = createConfig();
         config.enableTypeScriptLoader();
-        config.enableForkedTypeScriptTypesChecking(function(options) {
+        config.enableForkedTypeScriptTypesChecking(function (options) {
             options.async = true;
         });
 
@@ -52,10 +53,10 @@ describe('plugins/forkedtypecheck', function() {
         expect(config.plugins[0].plugin.options.async).toBe(true);
     });
 
-    it('getPlugins() with options callback that returns an object', function() {
+    it('getPlugins() with options callback that returns an object', function () {
         const config = createConfig();
         config.enableTypeScriptLoader();
-        config.enableForkedTypeScriptTypesChecking(function(options) {
+        config.enableForkedTypeScriptTypesChecking(function (options) {
             options.silent = true;
 
             // This should override the original config

--- a/test/plugins/friendly-errors.js
+++ b/test/plugins/friendly-errors.js
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect } from 'vitest';
 import FriendlyErrorsWebpackPlugin from '@kocal/friendly-errors-webpack-plugin';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+import { describe, it, expect } from 'vitest';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import friendlyErrorsPluginUtil from '../../lib/plugins/friendly-errors.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,8 +22,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/friendly-errors', function() {
-    it('with default settings', function() {
+describe('plugins/friendly-errors', function () {
+    it('with default settings', function () {
         const config = createConfig();
 
         const plugin = friendlyErrorsPluginUtil(config);
@@ -32,7 +33,7 @@ describe('plugins/friendly-errors', function() {
         expect(plugin.transformers.length).toBe(6);
     });
 
-    it('with options callback', function() {
+    it('with options callback', function () {
         const config = createConfig();
 
         config.configureFriendlyErrorsPlugin((options) => {
@@ -47,7 +48,7 @@ describe('plugins/friendly-errors', function() {
         expect(plugin.transformers.length).toBe(6);
     });
 
-    it('with options callback that returns an object', function() {
+    it('with options callback that returns an object', function () {
         const config = createConfig();
 
         config.configureFriendlyErrorsPlugin((options) => {

--- a/test/plugins/manifest.js
+++ b/test/plugins/manifest.js
@@ -9,9 +9,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import manifestPluginUtil from '../../lib/plugins/manifest.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -23,8 +24,8 @@ function createConfig() {
     return config;
 }
 
-describe('plugins/manifest', function() {
-    it('default settings', function() {
+describe('plugins/manifest', function () {
+    it('default settings', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -34,7 +35,7 @@ describe('plugins/manifest', function() {
         expect(plugins[0].plugin.options.fileName).toBe('manifest.json');
     });
 
-    it('with options callback', function() {
+    it('with options callback', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -50,7 +51,7 @@ describe('plugins/manifest', function() {
         expect(plugins[0].plugin.options.fileName).toBe('bar');
     });
 
-    it('with options callback that returns an object', function() {
+    it('with options callback that returns an object', function () {
         const config = createConfig();
         const plugins = [];
 

--- a/test/plugins/mini-css-extract.js
+++ b/test/plugins/mini-css-extract.js
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect } from 'vitest';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+import { describe, it, expect } from 'vitest';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import miniCssExtractPluginUtil from '../../lib/plugins/mini-css-extract.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,8 +22,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/mini-css-extract', function() {
-    it('with default settings and versioning disabled', function() {
+describe('plugins/mini-css-extract', function () {
+    it('with default settings and versioning disabled', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -32,7 +33,7 @@ describe('plugins/mini-css-extract', function() {
         expect(plugins[0].plugin.options.filename).toBe('[name].css');
     });
 
-    it('with default settings and versioning enabled', function() {
+    it('with default settings and versioning enabled', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -44,7 +45,7 @@ describe('plugins/mini-css-extract', function() {
         expect(plugins[0].plugin.options.filename).toBe('[name].[contenthash:8].css');
     });
 
-    it('with CSS extraction disabled', function() {
+    it('with CSS extraction disabled', function () {
         const config = createConfig();
         const plugins = [];
 
@@ -54,13 +55,13 @@ describe('plugins/mini-css-extract', function() {
         expect(plugins.length).toBe(0);
     });
 
-    it('with options callback', function() {
+    it('with options callback', function () {
         const config = createConfig();
         const plugins = [];
 
         config.configureMiniCssExtractPlugin(
             () => {},
-            options => {
+            (options) => {
                 options.filename = '[name].css';
             }
         );

--- a/test/plugins/notifier.js
+++ b/test/plugins/notifier.js
@@ -9,9 +9,10 @@
 
 import { describe, it, expect } from 'vitest';
 import WebpackNotifier from 'webpack-notifier';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import notifierPluginUtil from '../../lib/plugins/notifier.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig() {
     const runtimeConfig = new RuntimeConfig();
@@ -21,8 +22,8 @@ function createConfig() {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/notifier', function() {
-    it('disabled by default', async function() {
+describe('plugins/notifier', function () {
+    it('disabled by default', async function () {
         const config = createConfig();
         const plugins = [];
 
@@ -30,7 +31,7 @@ describe('plugins/notifier', function() {
         expect(plugins.length).toBe(0);
     });
 
-    it('explicitly disabled', async function() {
+    it('explicitly disabled', async function () {
         const config = createConfig();
         const plugins = [];
 
@@ -40,7 +41,7 @@ describe('plugins/notifier', function() {
         expect(plugins.length).toBe(0);
     });
 
-    it('enabled with default settings', async function() {
+    it('enabled with default settings', async function () {
         const config = createConfig();
         const plugins = [];
 
@@ -52,7 +53,7 @@ describe('plugins/notifier', function() {
         expect(plugins[0].plugin.options.title).toBe('Webpack Encore');
     });
 
-    it('enabled with options callback', async function() {
+    it('enabled with options callback', async function () {
         const config = createConfig();
         const plugins = [];
 
@@ -66,7 +67,7 @@ describe('plugins/notifier', function() {
         expect(plugins[0].plugin.options.title).toBe('foo');
     });
 
-    it('enabled with options callback that returns an object', async function() {
+    it('enabled with options callback that returns an object', async function () {
         const config = createConfig();
         const plugins = [];
 

--- a/test/plugins/terser.js
+++ b/test/plugins/terser.js
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import { describe, it, expect } from 'vitest';
 import TerserPlugin from 'terser-webpack-plugin';
-import WebpackConfig from '../../lib/WebpackConfig.js';
+import { describe, it, expect } from 'vitest';
+
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
 import terserPluginUtil from '../../lib/plugins/terser.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
 function createConfig(environment = 'production') {
     const runtimeConfig = new RuntimeConfig();
@@ -22,8 +23,8 @@ function createConfig(environment = 'production') {
     return new WebpackConfig(runtimeConfig);
 }
 
-describe('plugins/terser', function() {
-    it('production environment default settings', function() {
+describe('plugins/terser', function () {
+    it('production environment default settings', function () {
         const config = createConfig();
 
         const plugin = terserPluginUtil(config);
@@ -31,7 +32,7 @@ describe('plugins/terser', function() {
         expect(plugin.options.parallel).toBe(true);
     });
 
-    it('with options callback', function() {
+    it('with options callback', function () {
         const config = createConfig();
 
         config.configureTerserPlugin((options) => {
@@ -47,7 +48,7 @@ describe('plugins/terser', function() {
         expect(plugin.options.parallel).toBe(true);
     });
 
-    it('with options callback that returns an object', function() {
+    it('with options callback that returns an object', function () {
         const config = createConfig();
 
         config.configureTerserPlugin((options) => {

--- a/test/utils/get-file-extension.js
+++ b/test/utils/get-file-extension.js
@@ -8,32 +8,33 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import getFileExtension from '../../lib/utils/get-file-extension.js';
 
-describe('get-file-extension', function() {
-    it('returns the extension of simple filenames', function() {
+describe('get-file-extension', function () {
+    it('returns the extension of simple filenames', function () {
         expect(getFileExtension('foo.js')).toBe('js');
         expect(getFileExtension('foo-bar.txt')).toBe('txt');
         expect(getFileExtension('foo.bar.baz')).toBe('baz');
     });
 
-    it('returns an empty string for files with no extension', function() {
+    it('returns an empty string for files with no extension', function () {
         expect(getFileExtension('foo')).toBe('');
         expect(getFileExtension('foo-bar')).toBe('');
     });
 
-    it('returns the extension of a file from an absolute path', function() {
+    it('returns the extension of a file from an absolute path', function () {
         expect(getFileExtension('/home/foo/bar.js')).toBe('js');
         expect(getFileExtension('C:\\home\\foo\\bar.js')).toBe('js');
     });
 
-    it('returns the extension from an URI', function() {
+    it('returns the extension from an URI', function () {
         expect(getFileExtension('http://localhost/foo.js')).toBe('js');
         expect(getFileExtension('file://localhost/foo/bar.txt')).toBe('txt');
         expect(getFileExtension('https://localhost:8080/foo.bar.baz')).toBe('baz');
     });
 
-    it('works with query strings', function() {
+    it('works with query strings', function () {
         expect(getFileExtension('http://localhost/foo.js?abcd')).toBe('js');
         expect(getFileExtension('foo.txt?bar=baz&baz=bar')).toBe('txt');
     });

--- a/test/utils/get-vue-version.js
+++ b/test/utils/get-vue-version.js
@@ -8,13 +8,13 @@
  */
 
 import { vi, describe, it, expect } from 'vitest';
-import getVueVersion from '../../lib/utils/get-vue-version.js';
 
-import packageHelper from '../../lib/package-helper.js';
-import WebpackConfig from '../../lib/WebpackConfig.js';
 import RuntimeConfig from '../../lib/config/RuntimeConfig.js';
+import packageHelper from '../../lib/package-helper.js';
+import getVueVersion from '../../lib/utils/get-vue-version.js';
+import WebpackConfig from '../../lib/WebpackConfig.js';
 
-const createWebpackConfig = function() {
+const createWebpackConfig = function () {
     const runtimeConfig = new RuntimeConfig();
     runtimeConfig.context = import.meta.dirname;
     runtimeConfig.environment = 'dev';
@@ -23,53 +23,58 @@ const createWebpackConfig = function() {
     return new WebpackConfig(runtimeConfig);
 };
 
-describe('get-vue-version', function() {
-    it('returns the value configured in Webpack.config.js', function() {
+describe('get-vue-version', function () {
+    it('returns the value configured in Webpack.config.js', function () {
         const config = createWebpackConfig();
         config.vueOptions.version = 4;
 
         expect(getVueVersion(config)).toBe(4);
     });
 
-    it('returns the default recommended version when vue is not installed', function() {
+    it('returns the default recommended version when vue is not installed', function () {
         const config = createWebpackConfig();
-        const getPackageVersionStub = vi.spyOn(packageHelper, 'getPackageVersion')
+        const getPackageVersionStub = vi
+            .spyOn(packageHelper, 'getPackageVersion')
             .mockImplementation(() => null);
 
         expect(getVueVersion(config)).toBe(3);
         getPackageVersionStub.mockRestore();
     });
 
-    it('throw an error when Vue 2 is installed', function() {
+    it('throw an error when Vue 2 is installed', function () {
         const config = createWebpackConfig();
-        const getPackageVersionStub = vi.spyOn(packageHelper, 'getPackageVersion')
+        const getPackageVersionStub = vi
+            .spyOn(packageHelper, 'getPackageVersion')
             .mockImplementation(() => '2.2.4');
 
         expect(() => getVueVersion(config)).toThrow(/The support for Vue 2 has been removed/);
         getPackageVersionStub.mockRestore();
     });
 
-    it('returns 3 when Vue 3 beta is installed', function() {
+    it('returns 3 when Vue 3 beta is installed', function () {
         const config = createWebpackConfig();
-        const getPackageVersionStub = vi.spyOn(packageHelper, 'getPackageVersion')
+        const getPackageVersionStub = vi
+            .spyOn(packageHelper, 'getPackageVersion')
             .mockImplementation(() => '3.0.0-beta.9');
 
         expect(getVueVersion(config)).toBe(3);
         getPackageVersionStub.mockRestore();
     });
 
-    it('returns 3 when Vue 3 is installed', function() {
+    it('returns 3 when Vue 3 is installed', function () {
         const config = createWebpackConfig();
-        const getPackageVersionStub = vi.spyOn(packageHelper, 'getPackageVersion')
+        const getPackageVersionStub = vi
+            .spyOn(packageHelper, 'getPackageVersion')
             .mockImplementation(() => '3.0.0');
 
         expect(getVueVersion(config)).toBe(3);
         getPackageVersionStub.mockRestore();
     });
 
-    it('returns 3 when a version is too new', function() {
+    it('returns 3 when a version is too new', function () {
         const config = createWebpackConfig();
-        const getPackageVersionStub = vi.spyOn(packageHelper, 'getPackageVersion')
+        const getPackageVersionStub = vi
+            .spyOn(packageHelper, 'getPackageVersion')
             .mockImplementation(() => '4.0.0'); // unsupported version
 
         expect(getVueVersion(config)).toBe(3);

--- a/test/utils/package-up.js
+++ b/test/utils/package-up.js
@@ -8,10 +8,12 @@
  */
 
 import { resolve as resolvePath } from 'path';
+
 import { describe, it, expect } from 'vitest';
+
 import packageUp from '../../lib/utils/package-up.js';
 
-describe('package-up', function() {
+describe('package-up', function () {
     it.each([
         {
             test: 'package.json from Encore',
@@ -21,7 +23,10 @@ describe('package-up', function() {
         {
             test: 'package.json from a subdirectory',
             cwd: resolvePath(import.meta.dirname, '../../fixtures/stimulus/mock-module'),
-            expectedPath: resolvePath(import.meta.dirname, '../../fixtures/stimulus/mock-module/package.json'),
+            expectedPath: resolvePath(
+                import.meta.dirname,
+                '../../fixtures/stimulus/mock-module/package.json'
+            ),
         },
         {
             test: 'package.json from Encore when no package.json exists in the current directory',

--- a/test/utils/regexp-escaper.js
+++ b/test/utils/regexp-escaper.js
@@ -8,10 +8,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import regexpEscaper from '../../lib/utils/regexp-escaper.js';
 
-describe('regexp-escaper', function() {
-    it('escapes things properly', function() {
+describe('regexp-escaper', function () {
+    it('escapes things properly', function () {
         expect(regexpEscaper('.*')).toBe('\\.\\*');
         expect(regexpEscaper('[foo]')).toBe('\\[foo\\]');
         expect(regexpEscaper('(foo|bar)')).toBe('\\(foo\\|bar\\)');

--- a/test/utils/string-escaper.js
+++ b/test/utils/string-escaper.js
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+
 import stringEscaper from '../../lib/utils/string-escaper.js';
 
 function expectEvaledStringToEqual(str, expectedStr) {
@@ -15,17 +16,15 @@ function expectEvaledStringToEqual(str, expectedStr) {
     expect(eval(`'${str}'`)).toBe(expectedStr);
 }
 
-describe('string-escaper', function() {
-    it('escapes filenames with quotes', function() {
-        // eslint-disable-next-line quotes
+describe('string-escaper', function () {
+    it('escapes filenames with quotes', function () {
         const filename = "/foo/bar's/stuff";
 
         const escapedFilename = stringEscaper(filename);
         expectEvaledStringToEqual(escapedFilename, filename);
     });
 
-    it('escapes Windows filenames', function() {
-        // eslint-disable-next-line quotes
+    it('escapes Windows filenames', function () {
         const filename = `C:\\path\\to\\file`;
 
         const escapedFilename = stringEscaper(filename);

--- a/test/vitest-setup.js
+++ b/test/vitest-setup.js
@@ -8,6 +8,7 @@
  */
 
 import { vi, beforeEach, afterEach } from 'vitest';
+
 import logger from '../lib/logger.js';
 
 beforeEach(() => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,11 +14,7 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['test/**/*.js'],
-        exclude: [
-            'test/helpers/**',
-            'test/vitest-global-setup.js',
-            'test/vitest-setup.js',
-        ],
+        exclude: ['test/helpers/**', 'test/vitest-global-setup.js', 'test/vitest-setup.js'],
         testTimeout: 10000,
         hookTimeout: 15000,
         globalSetup: ['./test/vitest-global-setup.js'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT


For two reasons:
1. ESLint deprecated formatting rules, see https://eslint.org/blog/2023/10/deprecating-formatting-rules/
2. Oxfmt is a dedicated tool for code formatting, which is much faster