### PR TITLE
Avoid using deprecated Sass imports in tests

### DIFF
--- a/fixtures/css/sass_features.scss
+++ b/fixtures/css/sass_features.scss
@@ -1,4 +1,4 @@
-@import 'background_image';
+@use 'background_image';
 
 $primary-color: #333;
 

--- a/fixtures/css/sass_package_import.scss
+++ b/fixtures/css/sass_package_import.scss
@@ -4,4 +4,4 @@
 // @import '~lib/test-pkg';
 
 // Importing without the tilde seems to work for webpack aliases
-@import 'lib/test-pkg';
+@use 'lib/test-pkg';


### PR DESCRIPTION

| Q             | A                                                                                                                         |
| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
| Bug fix?      | no                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        |  |
| License       | MIT                                                                                                                       |

This avoids getting this deprecation logged in the test output.
