### PR TITLE
Exclude PULL_REQUEST_TEMPLATE.md from Oxfmt configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-| Q             | A                                                                                                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Bug fix?      | yes/no                                                                                                                    |
-| New feature?  | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
-| Deprecations? | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
-| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
-| License       | MIT                                                                                                                       |
+| Q              | A
+| -------------- | ---
+| Bug fix?       | yes/no
+| New feature?   | yes/no <!-- please update CHANGELOG.md file -->
+| Deprecations?  | yes/no <!-- please update CHANGELOG.md file -->
+| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
+| License        | MIT
 
 <!--
 Replace this notice by a description of your feature/bugfix.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./node_modules/oxfmt/configuration_schema.json",
-    "ignorePatterns": ["fixtures/**", "test_apps/**"],
+    "ignorePatterns": [".github/PULL_REQUEST_TEMPLATE.md", "fixtures/**", "test_apps/**"],
     "singleQuote": true,
     "semi": true,
     "trailingComma": "es5",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- please update CHANGELOG.md file -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License        | MIT

It should have never been formatted by Oxfmt