### PR TITLE
Use `peerDependencies` instead of `devDependencies` for optional dependencies runtime version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ can adopt modern async APIs from the ecosystem without hacks**.
 - Add support for [webpack-cli@7.0.0](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%407.0.0)
 - `Encore.copyFiles()` now internally generates ESM exports for better webpack optimizations (scope hoisting, module concatenation)
 - Add support for [typescript@6.0.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html)
+- The runtime version check for optional dependencies now reads supported version ranges from `peerDependencies` instead of `devDependencies`
 
 ## 6.0.0
 

--- a/lib/package-helper.js
+++ b/lib/package-helper.js
@@ -187,22 +187,24 @@ function addPackagesVersionConstraint(packages) {
         const newData = Object.assign({}, packageData);
 
         if (packageData.enforce_version) {
-            if (!packageJsonData.devDependencies) {
+            if (!packageJsonData.peerDependencies) {
                 logger.warning(
-                    'Could not find devDependencies key on @symfony/webpack-encore package'
+                    'Could not find peerDependencies key on @symfony/webpack-encore package'
                 );
 
                 return newData;
             }
 
-            // this method only supports devDependencies due to how it's used:
+            // this method only supports peerDependencies due to how it's used:
             // it's mean to inform the user what deps they need to install
             // for optional features
-            if (!packageJsonData.devDependencies[packageData.name]) {
-                throw new Error(`Could not find package ${packageData.name}`);
+            if (!packageJsonData.peerDependencies[packageData.name]) {
+                throw new Error(
+                    `Could not find package ${packageData.name} in peerDependencies of @symfony/webpack-encore`
+                );
             }
 
-            newData.version = packageJsonData.devDependencies[packageData.name];
+            newData.version = packageJsonData.peerDependencies[packageData.name];
             delete newData['enforce_version'];
         }
 

--- a/test/package-helper.js
+++ b/test/package-helper.js
@@ -222,7 +222,7 @@ describe('package-helper', function () {
             );
 
             const expectedPackages = [
-                { name: 'sass-loader', version: packageInfo.devDependencies['sass-loader'] },
+                { name: 'sass-loader', version: packageInfo.peerDependencies['sass-loader'] },
                 { name: 'node-sass' },
                 { name: 'vue', version: '^2' },
             ];


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- please update CHANGELOG.md file -->
| Issues         | Fix #1413 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License        | MIT
