### PR TITLE
Prepare TypeScript migration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+    build:
+        name: Type-check & build
+        runs-on: ubuntu-latest
+        permissions: {}
+        env:
+            # We don't want Puppeteer to automatically download a browser when dependencies are being installed
+            PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+              with:
+                  persist-credentials: false
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+
+            - name: Node ${{matrix.node-versions}}
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+              with:
+                  node-version: '22.13.0'
+                  cache: pnpm
+
+            - name: Install pnpm Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Type-check
+              run: pnpm type-check
+
+            - name: Build (emit JS + type declarations)
+              run: pnpm build
+
+            - name: Ensure type declarations were generated
+              run: test -f dist/index.d.ts

--- a/.github/workflows/testing_apps.yml
+++ b/.github/workflows/testing_apps.yml
@@ -139,6 +139,10 @@ jobs:
                   cache: ${{ matrix.app.pkg_manager }}
                   cache-dependency-path: ${{ matrix.app.working_directory }}/${{ env.LOCKFILE }}
 
+            - name: Installing dependencies
+              run: |
+                  pnpm install --frozen-lockfile
+
             - name: Packing Encore
               run: pnpm pack --out webpack-encore.tgz
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 npm-debug.log*
 /test_tmp
+/dist
 
 webpack-encore.tgz

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,11 @@
 {
     "$schema": "./node_modules/oxfmt/configuration_schema.json",
-    "ignorePatterns": [".github/PULL_REQUEST_TEMPLATE.md", "fixtures/**", "test_apps/**"],
+    "ignorePatterns": [
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        "fixtures/**",
+        "test_apps/**",
+        "dist/**"
+    ],
     "singleQuote": true,
     "semi": true,
     "trailingComma": "es5",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.2.0
+
+- Migrate internal code to TypeScript, ship package with type definitions (better DX and IDE support!)
+
 ## 7.1.0
 
 - Add support for `sass-loader` ^17.0.0

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,10 +59,6 @@ export default [
             ],
             'n/no-unsupported-features/node-builtins': ['error'],
             'n/no-deprecated-api': 'error',
-            // The TypeScript compiler owns module-resolution checking: `.js`
-            // import specifiers resolve to `.ts` source files during the TS
-            // migration, which eslint-plugin-n cannot follow.
-            'n/no-missing-import': 'off',
             'n/no-missing-require': 'off',
             'n/no-unpublished-bin': 'error',
             'n/no-unpublished-import': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ import jsdoc from 'eslint-plugin-jsdoc';
 import nodePlugin from 'eslint-plugin-n';
 import vitestPlugin from 'eslint-plugin-vitest';
 import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 export default [
     js.configs.recommended,
@@ -58,7 +59,10 @@ export default [
             ],
             'n/no-unsupported-features/node-builtins': ['error'],
             'n/no-deprecated-api': 'error',
-            'n/no-missing-import': 'error',
+            // The TypeScript compiler owns module-resolution checking: during
+            // the TS migration, `.js` import specifiers resolve to `.ts` source
+            // files, which eslint-plugin-n cannot follow.
+            'n/no-missing-import': 'off',
             'n/no-missing-require': 'off',
             'n/no-unpublished-bin': 'error',
             'n/no-unpublished-import': 'error',
@@ -82,6 +86,20 @@ file that was distributed with this source code.`,
             jsdoc: {
                 mode: 'typescript',
             },
+        },
+    },
+    {
+        files: ['**/*.ts'],
+        languageOptions: {
+            parser: tseslint.parser,
+        },
+        rules: {
+            // The TypeScript compiler reports unused symbols; the core rule
+            // produces false positives on type-only syntax.
+            'no-unused-vars': 'off',
+            // In TypeScript files, types live in the signature, not in JSDoc.
+            'jsdoc/require-param': 'off',
+            'jsdoc/require-returns': 'off',
         },
     },
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,9 +59,9 @@ export default [
             ],
             'n/no-unsupported-features/node-builtins': ['error'],
             'n/no-deprecated-api': 'error',
-            // The TypeScript compiler owns module-resolution checking: during
-            // the TS migration, `.js` import specifiers resolve to `.ts` source
-            // files, which eslint-plugin-n cannot follow.
+            // The TypeScript compiler owns module-resolution checking: `.js`
+            // import specifiers resolve to `.ts` source files during the TS
+            // migration, which eslint-plugin-n cannot follow.
             'n/no-missing-import': 'off',
             'n/no-missing-require': 'off',
             'n/no-unpublished-bin': 'error',

--- a/lib/WebpackConfig.js
+++ b/lib/WebpackConfig.js
@@ -43,7 +43,7 @@ import path from 'path';
 import pathUtil from './config/path-util.js';
 import featuresHelper from './features.js';
 import logger from './logger.js';
-import regexpEscaper from './utils/regexp-escaper.js';
+import regexpEscaper from './utils/regexp-escaper.ts';
 
 /**
  * @param {RuntimeConfig|null} runtimeConfig

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -46,7 +46,7 @@ import vuePluginUtil from './plugins/vue.js';
 import applyOptionsCallback from './utils/apply-options-callback.js';
 import copyEntryTmpName from './utils/copyEntryTmpName.js';
 import getVueVersion from './utils/get-vue-version.js';
-import stringEscaper from './utils/string-escaper.js';
+import stringEscaper from './utils/string-escaper.ts';
 
 class ConfigGenerator {
     /**

--- a/lib/utils/get-file-extension.ts
+++ b/lib/utils/get-file-extension.ts
@@ -10,7 +10,7 @@
 import path from 'path';
 import url from 'url';
 
-export default function (filename) {
+export default function (filename: string): string {
     const parsedFilename = new url.URL(filename, 'http://foo');
     const extension = path.extname(parsedFilename.pathname);
     return extension ? extension.slice(1) : '';

--- a/lib/utils/regexp-escaper.ts
+++ b/lib/utils/regexp-escaper.ts
@@ -11,10 +11,7 @@
  * Function that escapes a string so it can be used in a RegExp.
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
- *
- * @param {string} str
- * @returns {string}
  */
-export default function regexpEscaper(str) {
+export default function regexpEscaper(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/lib/utils/string-escaper.ts
+++ b/lib/utils/string-escaper.ts
@@ -13,10 +13,7 @@
  *
  * This is imperfect - is used to escape a filename (so, mostly,
  * it needs to escape the Window path slashes).
- *
- * @param {string} str
- * @returns {string}
  */
-export default function stringEscaper(str) {
+export default function stringEscaper(str: string): string {
     return str.replace(/\\/g, '\\\\').replace(/\x27/g, '\\\x27');
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "build": "rm -fr dist/ && tsc",
-        "type-check": "tsc --noEmit --allowImportingTsExtensions",
+        "type-check": "tsc --noEmit",
         "prepare": "pnpm build",
         "prepublishOnly": "pnpm type-check",
         "pretest": "pnpm build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "build": "rm -fr dist/ && tsc",
-        "type-check": "tsc --noEmit",
+        "type-check": "tsc --noEmit --allowImportingTsExtensions",
         "prepare": "pnpm build",
         "prepublishOnly": "pnpm type-check",
         "pretest": "pnpm build",

--- a/package.json
+++ b/package.json
@@ -3,18 +3,30 @@
     "version": "7.1.0",
     "description": "Webpack Encore is a simpler way to integrate Webpack into your application",
     "type": "module",
+    "types": "./dist/index.d.ts",
     "exports": {
-        ".": "./index.js",
-        "./lib/plugins/plugin-priorities.js": "./lib/plugins/plugin-priorities.js"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./lib/plugins/plugin-priorities.js": {
+            "types": "./dist/lib/plugins/plugin-priorities.d.ts",
+            "default": "./dist/lib/plugins/plugin-priorities.js"
+        }
     },
     "scripts": {
+        "build": "rm -fr dist/ && tsc",
+        "type-check": "tsc --noEmit",
+        "prepare": "pnpm build",
+        "prepublishOnly": "pnpm type-check",
+        "pretest": "pnpm build",
         "test": "vitest run",
         "lint": "eslint lib test index.js eslint.config.js --report-unused-disable-directives --max-warnings=0",
         "fmt": "oxfmt",
         "fmt:check": "oxfmt --check"
     },
     "bin": {
-        "encore": "bin/encore.js"
+        "encore": "dist/bin/encore.js"
     },
     "repository": {
         "type": "git",
@@ -57,6 +69,8 @@
         "@hotwired/stimulus": "^3.0.0",
         "@symfony/mock-module": "file:fixtures/stimulus/mock-module",
         "@symfony/stimulus-bridge": "^3.0.0 || ^4.0.0",
+        "@tsconfig/node22": "^22.0.5",
+        "@types/node": "^22.18.0",
         "@vue/babel-plugin-jsx": "^3.0.0",
         "@vue/compiler-sfc": "^3.2.14",
         "autoprefixer": "^10.2.0",
@@ -95,6 +109,7 @@
         "svelte-loader": "^3.1.0",
         "ts-loader": "^9.0.0",
         "typescript": "^5.0.0 || ^6.0.0",
+        "typescript-eslint": "^8.39.0",
         "vitest": "^4.1.2",
         "vue": "^3.2.14",
         "vue-loader": "^17.0.0",
@@ -243,9 +258,7 @@
         }
     },
     "files": [
-        "lib/",
-        "bin/",
-        "index.js"
+        "dist/"
     ],
     "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,12 @@ importers:
       '@symfony/stimulus-bridge':
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.1(@hotwired/stimulus@3.2.2)
+      '@tsconfig/node22':
+        specifier: ^22.0.5
+        version: 22.0.5
+      '@types/node':
+        specifier: ^22.18.0
+        version: 22.20.0
       '@vue/babel-plugin-jsx':
         specifier: ^3.0.0
         version: 3.0.0(@babel/core@8.0.1)
@@ -107,7 +113,7 @@ importers:
         version: 1.3.4(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@9.39.4(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsdoc:
         specifier: ^50.8.0
         version: 50.8.0(eslint@9.39.4(jiti@2.7.0))
@@ -116,7 +122,7 @@ importers:
         version: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)))
+        version: 0.5.4(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.6(@types/node@22.20.0)(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)))
       fork-ts-checker-webpack-plugin:
         specifier: ^7.0.0 || ^8.0.0 || ^9.0.0
         version: 9.1.0(typescript@6.0.3)(webpack@5.106.2)
@@ -188,19 +194,22 @@ importers:
         version: 8.1.3(stylus@0.63.0)(webpack@5.106.2)
       svelte:
         specifier: ^3.50.0 || ^4.2.2 || ^5.0.0
-        version: 5.55.7(@typescript-eslint/types@8.59.3)
+        version: 5.55.7(@typescript-eslint/types@8.62.0)
       svelte-loader:
         specifier: ^3.1.0
-        version: 3.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+        version: 3.2.4(svelte@5.55.7(@typescript-eslint/types@8.62.0))
       ts-loader:
         specifier: ^9.0.0
         version: 9.5.7(typescript@6.0.3)(webpack@5.106.2)
       typescript:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.39.0
+        version: 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
+        version: 4.1.6(@types/node@22.20.0)(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
       vue:
         specifier: ^3.2.14
         version: 3.5.34(typescript@6.0.3)
@@ -1587,6 +1596,9 @@ packages:
     peerDependencies:
       '@hotwired/stimulus': ^3.0
 
+  '@tsconfig/node22@22.0.5':
+    resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1647,8 +1659,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
@@ -1683,9 +1695,47 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@typescript-eslint/eslint-plugin@8.62.0':
+    resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.62.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.62.0':
+    resolution: {integrity: sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.62.0':
+    resolution: {integrity: sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.62.0':
+    resolution: {integrity: sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.62.0':
+    resolution: {integrity: sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.62.0':
+    resolution: {integrity: sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@7.18.0':
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
@@ -1693,6 +1743,10 @@ packages:
 
   '@typescript-eslint/types@8.59.3':
     resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.62.0':
+    resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
@@ -1704,15 +1758,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.62.0':
+    resolution: {integrity: sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.62.0':
+    resolution: {integrity: sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.62.0':
+    resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
@@ -2029,6 +2100,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.3:
     resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
     peerDependencies:
@@ -2107,6 +2182,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3055,6 +3134,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   image-size@0.5.5:
     resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
@@ -3552,6 +3635,10 @@ packages:
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -4531,6 +4618,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-declaration-location@1.0.7:
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
@@ -4583,6 +4676,13 @@ packages:
   typed-query-selector@2.12.2:
     resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
+  typescript-eslint@8.62.0:
+    resolution: {integrity: sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -4597,8 +4697,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -6252,6 +6352,8 @@ snapshots:
       loader-utils: 3.3.1
       schema-utils: 4.3.3
 
+  '@tsconfig/node22@22.0.5': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -6260,11 +6362,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6274,11 +6376,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/deep-eql@4.0.2': {}
 
@@ -6298,7 +6400,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6316,7 +6418,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/jsesc@2.5.1': {}
 
@@ -6326,9 +6428,9 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@25.8.0':
+  '@types/node@22.20.0':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 6.21.0
 
   '@types/qs@6.15.1': {}
 
@@ -6339,11 +6441,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -6352,12 +6454,12 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6365,16 +6467,76 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
+
+  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/type-utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.62.0
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.62.0
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.62.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
+  '@typescript-eslint/scope-manager@8.62.0':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/visitor-keys': 8.62.0
+
+  '@typescript-eslint/tsconfig-utils@8.62.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@7.18.0': {}
 
   '@typescript-eslint/types@8.59.3': {}
+
+  '@typescript-eslint/types@8.62.0': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@6.0.3)':
     dependencies:
@@ -6391,6 +6553,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.62.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/visitor-keys': 8.62.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
@@ -6402,10 +6579,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.62.0':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
+      eslint-visitor-keys: 5.0.1
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -6416,13 +6609,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)
+      vite: 8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -6811,6 +7004,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.3: {}
 
   bare-fs@4.7.1:
@@ -6891,6 +7086,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7389,10 +7588,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -7409,7 +7609,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
 
-  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7420,7 +7620,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7431,6 +7631,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7467,12 +7669,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-vitest@0.5.4(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))):
+  eslint-plugin-vitest@0.5.4(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.6(@types/node@22.20.0)(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
     optionalDependencies:
-      vitest: 4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
+      vitest: 4.1.6(@types/node@22.20.0)(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7553,11 +7755,11 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.8(@typescript-eslint/types@8.59.3):
+  esrap@2.2.8(@typescript-eslint/types@8.62.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.62.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -7984,6 +8186,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   image-size@0.5.5:
     optional: true
 
@@ -8186,7 +8390,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -8419,6 +8623,10 @@ snapshots:
       webpack: 5.106.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.14)(webpack-cli@7.0.2)
 
   minimalistic-assert@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -9368,18 +9576,18 @@ snapshots:
 
   svelte-dev-helper@1.1.9: {}
 
-  svelte-hmr@0.14.12(svelte@5.55.7(@typescript-eslint/types@8.59.3)):
+  svelte-hmr@0.14.12(svelte@5.55.7(@typescript-eslint/types@8.62.0)):
     dependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.3)
+      svelte: 5.55.7(@typescript-eslint/types@8.62.0)
 
-  svelte-loader@3.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.3)):
+  svelte-loader@3.2.4(svelte@5.55.7(@typescript-eslint/types@8.62.0)):
     dependencies:
       loader-utils: 2.0.4
-      svelte: 5.55.7(@typescript-eslint/types@8.59.3)
+      svelte: 5.55.7(@typescript-eslint/types@8.62.0)
       svelte-dev-helper: 1.1.9
-      svelte-hmr: 0.14.12(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+      svelte-hmr: 0.14.12(svelte@5.55.7(@typescript-eslint/types@8.62.0))
 
-  svelte@5.55.7(@typescript-eslint/types@8.59.3):
+  svelte@5.55.7(@typescript-eslint/types@8.62.0):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9392,7 +9600,7 @@ snapshots:
       clsx: 2.1.1
       devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.8(@typescript-eslint/types@8.59.3)
+      esrap: 2.2.8(@typescript-eslint/types@8.62.0)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
@@ -9492,6 +9700,10 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
       picomatch: 4.0.4
@@ -9566,6 +9778,17 @@ snapshots:
 
   typed-query-selector@2.12.2: {}
 
+  typescript-eslint@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@6.0.3: {}
 
   uglify-js@3.19.3:
@@ -9578,7 +9801,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.24.6: {}
+  undici-types@6.21.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -9621,7 +9844,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1):
+  vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9629,7 +9852,7 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -9638,10 +9861,10 @@ snapshots:
       stylus: 0.63.0
       terser: 5.47.1
 
-  vitest@4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)):
+  vitest@4.1.6(@types/node@22.20.0)(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -9658,10 +9881,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)
+      vite: 8.0.13(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(stylus@0.63.0)(terser@5.47.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.20.0
     transitivePeerDependencies:
       - msw
 

--- a/test/bin/encore.js
+++ b/test/bin/encore.js
@@ -39,7 +39,7 @@ describe.sequential('bin/encore.js', function () {
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -51,7 +51,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const { stdout } = await exec(`node ${binPath} dev --context=${testDir}`, { cwd: testDir });
 
         expect(stdout).toContain('Compiled successfully');
@@ -67,7 +67,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -79,7 +79,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const { stdout } = await exec(`node ${binPath} dev --json --context=${testDir}`, {
             cwd: testDir,
         });
@@ -108,7 +108,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -120,7 +120,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const { stdout } = await exec(`node ${binPath} dev --profile --context=${testDir}`, {
             cwd: testDir,
         });
@@ -137,7 +137,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -149,7 +149,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const { stdout } = await exec(
             `node ${binPath} dev --keep-public-path --context=${testDir}`,
             { cwd: testDir }
@@ -173,7 +173,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -186,7 +186,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         try {
             await exec(`node ${binPath} dev --context=${testDir}`, { cwd: testDir });
         } catch (err) {
@@ -216,7 +216,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -228,7 +228,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const port = await getPort();
 
         const abortController = new AbortController();
@@ -287,7 +287,7 @@ export default await Encore.getWebpackConfig();
         fs.writeFileSync(
             path.join(testDir, 'webpack.config.js'),
             `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -299,7 +299,7 @@ export default await Encore.getWebpackConfig();
             `
         );
 
-        const binPath = path.resolve(import.meta.dirname, '../', '../', 'bin', 'encore.js');
+        const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
         const port = await getPort();
 
         const abortController = new AbortController();
@@ -375,7 +375,7 @@ export default await Encore.getWebpackConfig();
             fs.writeFileSync(
                 path.join(testDir, 'webpack.config.js'),
                 `
-import Encore from '../../index.js';
+import Encore from '../../dist/index.js';
 Encore
     .enableSingleRuntimeChunk()
     .setOutputPath('build/')
@@ -387,7 +387,7 @@ export default await Encore.getWebpackConfig();
         `
             );
 
-            const binPath = path.resolve(projectDir, 'bin', 'encore.js');
+            const binPath = path.resolve(projectDir, 'dist', 'bin', 'encore.js');
             const port = await getPort();
 
             try {

--- a/test/helpers/assert.js
+++ b/test/helpers/assert.js
@@ -12,7 +12,7 @@ import path from 'path';
 
 import { expect } from 'vitest';
 
-import regexEscaper from '../../lib/utils/regexp-escaper.js';
+import regexEscaper from '../../lib/utils/regexp-escaper.ts';
 
 const loadManifest = function (webpackConfig) {
     return JSON.parse(

--- a/test/utils/get-file-extension.js
+++ b/test/utils/get-file-extension.js
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import getFileExtension from '../../lib/utils/get-file-extension.js';
+import getFileExtension from '../../lib/utils/get-file-extension.ts';
 
 describe('get-file-extension', function () {
     it('returns the extension of simple filenames', function () {

--- a/test/utils/regexp-escaper.js
+++ b/test/utils/regexp-escaper.js
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import regexpEscaper from '../../lib/utils/regexp-escaper.js';
+import regexpEscaper from '../../lib/utils/regexp-escaper.ts';
 
 describe('regexp-escaper', function () {
     it('escapes things properly', function () {

--- a/test/utils/string-escaper.js
+++ b/test/utils/string-escaper.js
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import stringEscaper from '../../lib/utils/string-escaper.js';
+import stringEscaper from '../../lib/utils/string-escaper.ts';
 
 function expectEvaledStringToEqual(str, expectedStr) {
     // put the string in quotes & eval it: should match original

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "moduleDetection": "force",
         "isolatedModules": true,
         "verbatimModuleSyntax": true,
+        "erasableSyntaxOnly": true,
 
         // Library build
         "rootDir": ".",
@@ -18,7 +19,7 @@
         "noEmitOnError": true,
 
         // Strictness
-        "strict": false, // Disabled for now to ease migration from JS to TS, but we should enable it in the future
+        "strict": true,
         "noUncheckedIndexedAccess": true,
         "noImplicitOverride": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
         "isolatedModules": true,
         "verbatimModuleSyntax": true,
         "erasableSyntaxOnly": true,
+        "allowImportingTsExtensions": true,
+        "rewriteRelativeImportExtensions": true,
 
         // Library build
         "rootDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    // Inspired by https://www.totaltypescript.com/tsconfig-cheat-sheet
+    "extends": "@tsconfig/node22/tsconfig.json",
+    "compilerOptions": {
+        // Base options
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "allowJs": true,
+        "resolveJsonModule": true,
+        "moduleDetection": "force",
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true,
+
+        // Library build
+        "rootDir": ".",
+        "outDir": "dist",
+        "declaration": true,
+        "noEmitOnError": true,
+
+        // Strictness
+        "strict": false, // Disabled for now to ease migration from JS to TS, but we should enable it in the future
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+
+        // Types
+        "types": ["node"]
+    },
+    "include": ["index.ts", "index.js", "lib/**/*.ts", "lib/**/*.js", "bin/**/*.ts", "bin/**/*.js"],
+    "exclude": ["node_modules", "dist", "test", "test_apps", "fixtures", "test_tmp"]
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- please update CHANGELOG.md file -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License        | MIT

Related to https://github.com/symfony/webpack-encore/issues/816

This PR prepare the TypeScript migration, by:
- using `allowJs: true` in `tsconfig.json` configuration
- migrating some files under `lib/`, they were easy to migrate
- adding new job in the CI, checking types validity and if build is successful
- the `bin/encore.js` tests are now testing the file `dist/bin/encore.js` 
- still in the CI, node.js dependencies are now installed for `test_apps/*` jobs in order to success the build
- added some guards in `package.json`, `prepare` automatically build the project and `prepublicOnly` check types validity
