### PR TITLE
Throw a clear error when a callback is passed as the first argument of configureImageRule()/configureFontRule()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Throw a helpful error when a callback is passed as the first argument of `configureImageRule()` or `configureFontRule()` instead of being silently ignored
+
 ## 7.2.0
 
 - Migrate internal code to TypeScript, ship package with type definitions (better DX and IDE support!)

--- a/lib/WebpackConfig.ts
+++ b/lib/WebpackConfig.ts
@@ -1267,6 +1267,12 @@ class WebpackConfig {
         } = {},
         ruleCallback: OptionsCallback<webpack.RuleSetRule> = () => {}
     ) {
+        if (typeof options === 'function') {
+            throw new Error(
+                'configureImageRule() expects an options object as its first argument. To pass only a callback, use configureImageRule({}, callback).'
+            );
+        }
+
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.imageRuleOptions)) {
                 throw new Error(
@@ -1301,6 +1307,12 @@ class WebpackConfig {
         } = {},
         ruleCallback: OptionsCallback<webpack.RuleSetRule> = () => {}
     ) {
+        if (typeof options === 'function') {
+            throw new Error(
+                'configureFontRule() expects an options object as its first argument. To pass only a callback, use configureFontRule({}, callback).'
+            );
+        }
+
         for (const optionKey of Object.keys(options)) {
             if (!(optionKey in this.fontRuleOptions)) {
                 throw new Error(

--- a/test/WebpackConfig.js
+++ b/test/WebpackConfig.js
@@ -1446,6 +1446,14 @@ describe('WebpackConfig object', function () {
                 config.configureImageRule({}, {});
             }).toThrow('Argument 2 to configureImageRule() must be a callback');
         });
+
+        it('Passing a callback as the 1st arg throws a helpful error', function () {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureImageRule(() => {});
+            }).toThrow('configureImageRule() expects an options object as its first argument');
+        });
     });
 
     describe('configureFontRule', function () {
@@ -1486,6 +1494,14 @@ describe('WebpackConfig object', function () {
             expect(() => {
                 config.configureFontRule({}, {});
             }).toThrow('Argument 2 to configureFontRule() must be a callback');
+        });
+
+        it('Passing a callback as the 1st arg throws a helpful error', function () {
+            const config = createConfig();
+
+            expect(() => {
+                config.configureFontRule(() => {});
+            }).toThrow('configureFontRule() expects an options object as its first argument');
         });
     });
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Issues         | Fix #1221
| License        | MIT

`configureImageRule()` and `configureFontRule()` take `(options, ruleCallback)`. When a callback is passed as the first argument, for example:

```js
Encore.configureFontRule(rule => {
    rule.oneOf[1].generator.filename = 'whatever/[name][ext]';
});
```

the function lands in the `options` parameter. `Object.keys(aFunction)` is empty, so no option validation fails, and the callback is silently dropped: the rule is never customized. This is a common mistake because several other `Encore.configure*()` methods take a single callback.

This PR turns that silent no-op into a helpful error pointing at the correct 2-argument form:

> configureFontRule() expects an options object as its first argument. To pass only a callback, use configureFontRule({}, callback).

Only broken calls are affected (a function is never a valid `options` value), so there is no BC impact on working code.

This addresses the most surprising part of #1221 (the callback being ignored without any feedback). Note that overriding the filename does work today through the documented 2-argument callback by modifying the nested `rule.oneOf[1].generator`; setting `rule.generator` at the top level has no effect because Encore wraps the asset rule in a `oneOf`. Happy to follow up on that ergonomics point separately if you think it is worth improving.
