### PR TITLE
Recommend the project's package manager for missing dependency errors

### DIFF
--- a/lib/friendly-errors/formatters/missing-dependency.ts
+++ b/lib/friendly-errors/formatters/missing-dependency.ts
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { FriendlyError } from '@kocal/friendly-errors-webpack-plugin';
+
+import packageHelper from '../../package-helper.js';
+
+function formatFileList(files: string[]): string {
+    if (files.length === 0) {
+        return '';
+    }
+
+    const others = files.length - 2;
+
+    return ` in ${files[0]}${files[1] ? `, ${files[1]}` : ''}${others > 0 ? ` and ${others} other${others === 1 ? '' : 's'}` : ''}`;
+}
+
+function groupByModule(errors: FriendlyError[]): Map<string, FriendlyError[]> {
+    const groups = new Map<string, FriendlyError[]>();
+
+    for (const error of errors) {
+        const module = error.module!;
+        if (!groups.has(module)) {
+            groups.set(module, []);
+        }
+
+        groups.get(module)!.push(error);
+    }
+
+    return groups;
+}
+
+function formatErrors(errors: FriendlyError[]): string[] {
+    if (errors.length === 0) {
+        return [];
+    }
+
+    const groups = groupByModule(errors);
+    const modules = [...groups.keys()];
+
+    const messages = [
+        modules.length === 1
+            ? 'This dependency was not found:'
+            : 'These dependencies were not found:',
+        '',
+    ];
+
+    for (const [module, moduleErrors] of groups) {
+        const files = moduleErrors
+            .map((error) => error.file)
+            .filter((file): file is string => Boolean(file));
+        messages.push(`* ${module}${formatFileList(files)}`);
+    }
+
+    messages.push('');
+    messages.push(
+        `To install ${modules.length === 1 ? 'it' : 'them'}, you can run: ${packageHelper.getMissingPackagesInstallCommand(modules)}`
+    );
+
+    return messages;
+}
+
+function format(errors: FriendlyError[]): string[] {
+    return formatErrors(errors.filter((e) => e.type === 'missing-dependency'));
+}
+
+export default format;

--- a/lib/friendly-errors/transformers/missing-dependency.ts
+++ b/lib/friendly-errors/transformers/missing-dependency.ts
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { FriendlyError } from '@kocal/friendly-errors-webpack-plugin';
+
+const TYPE = 'missing-dependency';
+
+function isRelative(module: string): boolean {
+    // package names can never start with a dot, so this covers "./", "../"
+    // and their Windows counterparts ".\" and "..\"
+    return module.startsWith('.');
+}
+
+function transform(error: FriendlyError): FriendlyError {
+    // the friendly-errors plugin already flags "module not found" errors with
+    // the "module-not-found" type. We re-type the ones pointing to an installable
+    // package (i.e. not a relative path) so that we can recommend an install
+    // command that matches the package manager used in the project, instead of
+    // the plugin's hardcoded "npm install" suggestion.
+    if (error.type !== 'module-not-found' || !error.module || isRelative(error.module)) {
+        return error;
+    }
+
+    return Object.assign({}, error, { type: TYPE });
+}
+
+export default transform;

--- a/lib/package-helper.ts
+++ b/lib/package-helper.ts
@@ -60,9 +60,19 @@ ${missingPackagesRecommendation.message}
     }
 }
 
+function getPackageManager(): 'pnpm' | 'yarn' | 'npm' {
+    if (fs.existsSync('pnpm-lock.yaml')) {
+        return 'pnpm';
+    }
+
+    if (fs.existsSync('yarn.lock')) {
+        return 'yarn';
+    }
+
+    return 'npm';
+}
+
 function getInstallCommand(packageConfigs: PackageConfig[][]): string {
-    const hasPnpmLockfile = fs.existsSync('pnpm-lock.yaml');
-    const hasYarnLockfile = fs.existsSync('yarn.lock');
     const packageInstallStrings = packageConfigs.map((packageConfig) => {
         const firstPackage = packageConfig[0]!;
 
@@ -80,15 +90,31 @@ function getInstallCommand(packageConfigs: PackageConfig[][]): string {
         return `${firstPackage.name}@${recommendedVersion}`;
     });
 
-    if (hasPnpmLockfile) {
-        return pc.yellow(`pnpm add ${packageInstallStrings.join(' ')} --save-dev`);
+    const packages = packageInstallStrings.join(' ');
+    switch (getPackageManager()) {
+        case 'pnpm':
+            return pc.yellow(`pnpm add ${packages} --save-dev`);
+        case 'yarn':
+            return pc.yellow(`yarn add ${packages} --dev`);
+        default:
+            return pc.yellow(`npm install ${packages} --save-dev`);
     }
+}
 
-    if (hasYarnLockfile) {
-        return pc.yellow(`yarn add ${packageInstallStrings.join(' ')} --dev`);
+/**
+ * Returns the command to install already-published packages (e.g. a missing
+ * dependency required by the user), respecting the package manager in use.
+ */
+function getMissingPackagesInstallCommand(packageNames: string[]): string {
+    const packages = packageNames.join(' ');
+    switch (getPackageManager()) {
+        case 'pnpm':
+            return pc.yellow(`pnpm add ${packages}`);
+        case 'yarn':
+            return pc.yellow(`yarn add ${packages}`);
+        default:
+            return pc.yellow(`npm install ${packages}`);
     }
-
-    return pc.yellow(`npm install ${packageInstallStrings.join(' ')} --save-dev`);
 }
 
 function isPackageInstalled(packageConfig: PackageConfig): boolean {
@@ -240,5 +266,6 @@ export default {
     getInvalidPackageVersionRecommendations,
     addPackagesVersionConstraint,
     getInstallCommand,
+    getMissingPackagesInstallCommand,
     getPackageVersion,
 };

--- a/lib/plugins/friendly-errors.ts
+++ b/lib/plugins/friendly-errors.ts
@@ -10,9 +10,11 @@
 import FriendlyErrorsWebpackPlugin from '@kocal/friendly-errors-webpack-plugin';
 
 import missingCssFileFormatter from '../friendly-errors/formatters/missing-css-file.js';
+import missingDependencyFormatter from '../friendly-errors/formatters/missing-dependency.js';
 import missingLoaderFormatter from '../friendly-errors/formatters/missing-loader.js';
 import missingPostCssConfigFormatter from '../friendly-errors/formatters/missing-postcss-config.js';
 import missingCssFileTransformer from '../friendly-errors/transformers/missing-css-file.js';
+import missingDependencyTransformer from '../friendly-errors/transformers/missing-dependency.js';
 import missingLoaderTransformerFactory from '../friendly-errors/transformers/missing-loader.js';
 import missingPostCssConfigTransformer from '../friendly-errors/transformers/missing-postcss-config.js';
 import applyOptionsCallback from '../utils/apply-options-callback.js';
@@ -25,11 +27,13 @@ export default function (webpackConfig: WebpackConfig) {
             missingCssFileTransformer,
             missingLoaderTransformerFactory(webpackConfig),
             missingPostCssConfigTransformer,
+            missingDependencyTransformer,
         ],
         additionalFormatters: [
             missingCssFileFormatter,
             missingLoaderFormatter,
             missingPostCssConfigFormatter,
+            missingDependencyFormatter,
         ],
         compilationSuccessInfo: {
             messages: [],

--- a/test/friendly-errors/formatters/missing-dependency.js
+++ b/test/friendly-errors/formatters/missing-dependency.js
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import path from 'path';
+import process from 'process';
+
+import stripAnsi from 'strip-ansi';
+import { describe, it, expect, afterAll } from 'vitest';
+
+import formatter from '../../../lib/friendly-errors/formatters/missing-dependency.ts';
+
+describe('formatters/missing-dependency', function () {
+    const baseCwd = process.cwd();
+
+    // force a deterministic package manager (npm) for the install command
+    afterAll(function () {
+        process.chdir(baseCwd);
+    });
+
+    function useNpm() {
+        process.chdir(path.join(import.meta.dirname, '../../../fixtures/package-helper/empty'));
+    }
+
+    it('works with no errors', function () {
+        useNpm();
+        const actualErrors = formatter([]);
+        expect(actualErrors).to.be.empty;
+    });
+
+    it('filters errors that dont have the correct type', function () {
+        useNpm();
+        const errors = [
+            { type: 'missing-dependency', module: 'foo', file: 'app.js' },
+            { type: 'other-type', module: 'bar', file: 'other.js' },
+        ];
+
+        const actualErrors = formatter(errors);
+        expect(JSON.stringify(actualErrors)).toContain('foo');
+        expect(JSON.stringify(actualErrors)).not.toContain('bar');
+    });
+
+    it('recommends an install command matching the package manager', function () {
+        useNpm();
+        const errors = [{ type: 'missing-dependency', module: 'foo', file: './assets/app.js' }];
+
+        const actualErrors = formatter(errors).map(stripAnsi);
+        expect(actualErrors).toContain('This dependency was not found:');
+        expect(actualErrors).toContain('* foo in ./assets/app.js');
+        expect(actualErrors).toContain('To install it, you can run: npm install foo');
+    });
+
+    it('groups several missing dependencies together', function () {
+        useNpm();
+        const errors = [
+            { type: 'missing-dependency', module: 'foo', file: './assets/app.js' },
+            { type: 'missing-dependency', module: 'bar', file: './assets/app.js' },
+        ];
+
+        const actualErrors = formatter(errors).map(stripAnsi);
+        expect(actualErrors).toContain('These dependencies were not found:');
+        expect(actualErrors).toContain('To install them, you can run: npm install foo bar');
+    });
+});

--- a/test/friendly-errors/transformers/missing-dependency.js
+++ b/test/friendly-errors/transformers/missing-dependency.js
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import transform from '../../../lib/friendly-errors/transformers/missing-dependency.ts';
+
+describe('transform/missing-dependency', function () {
+    describe('test transform', function () {
+        it('Error not typed as "module-not-found" is ignored', function () {
+            const startError = {
+                type: 'other-type',
+                module: 'foo',
+            };
+            const actualError = transform(Object.assign({}, startError));
+
+            expect(actualError).toEqual(startError);
+        });
+
+        it('Error without a module is ignored', function () {
+            const startError = {
+                type: 'module-not-found',
+            };
+            const actualError = transform(Object.assign({}, startError));
+
+            expect(actualError).toEqual(startError);
+        });
+
+        it('Error about a relative module is left untouched', function () {
+            const startError = {
+                type: 'module-not-found',
+                module: './missing',
+            };
+            const actualError = transform(Object.assign({}, startError));
+
+            expect(actualError).toEqual(startError);
+            expect(actualError.type).toBe('module-not-found');
+        });
+
+        it('Error about a Windows-style relative module is left untouched', function () {
+            const startError = {
+                type: 'module-not-found',
+                module: '.\\missing',
+            };
+            const actualError = transform(Object.assign({}, startError));
+
+            expect(actualError).toEqual(startError);
+            expect(actualError.type).toBe('module-not-found');
+        });
+
+        it('Error about an installable package is re-typed', function () {
+            const startError = {
+                type: 'module-not-found',
+                module: 'foo',
+                file: './assets/app.js',
+            };
+            const actualError = transform(Object.assign({}, startError));
+
+            expect(actualError.type).toBe('missing-dependency');
+            expect(actualError.module).toBe('foo');
+        });
+    });
+});

--- a/test/package-helper.js
+++ b/test/package-helper.js
@@ -107,6 +107,32 @@ describe('package-helper', function () {
         });
     });
 
+    describe('getMissingPackagesInstallCommand respects the package manager', function () {
+        const baseCwd = process.cwd();
+
+        afterAll(function () {
+            process.chdir(baseCwd);
+        });
+
+        it('uses "npm install" without any lock file', function () {
+            process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/empty'));
+            const command = packageHelper.getMissingPackagesInstallCommand(['foo', 'bar']);
+            expect(stripAnsi(command)).toBe('npm install foo bar');
+        });
+
+        it('uses "yarn add" with yarn.lock', function () {
+            process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/yarn'));
+            const command = packageHelper.getMissingPackagesInstallCommand(['foo', 'bar']);
+            expect(stripAnsi(command)).toBe('yarn add foo bar');
+        });
+
+        it('uses "pnpm add" with pnpm-lock.yaml', function () {
+            process.chdir(path.join(import.meta.dirname, '../fixtures/package-helper/pnpm'));
+            const command = packageHelper.getMissingPackagesInstallCommand(['foo', 'bar']);
+            expect(stripAnsi(command)).toBe('pnpm add foo bar');
+        });
+    });
+
     describe('check messaging on install commands', function () {
         it('Make sure the major version is included in the install command', function () {
             const packageRecommendations = packageHelper.getMissingPackageRecommendations([

--- a/test/plugins/friendly-errors.js
+++ b/test/plugins/friendly-errors.js
@@ -29,8 +29,8 @@ describe('plugins/friendly-errors', function () {
         const plugin = friendlyErrorsPluginUtil(config);
         expect(plugin).toBeInstanceOf(FriendlyErrorsWebpackPlugin);
         expect(plugin.shouldClearConsole).toBe(false);
-        expect(plugin.formatters.length).toBe(6);
-        expect(plugin.transformers.length).toBe(6);
+        expect(plugin.formatters.length).toBe(7);
+        expect(plugin.transformers.length).toBe(7);
     });
 
     it('with options callback', function () {
@@ -45,7 +45,7 @@ describe('plugins/friendly-errors', function () {
         expect(plugin).toBeInstanceOf(FriendlyErrorsWebpackPlugin);
         expect(plugin.shouldClearConsole).toBe(true);
         expect(plugin.formatters.length).toBe(3);
-        expect(plugin.transformers.length).toBe(6);
+        expect(plugin.transformers.length).toBe(7);
     });
 
     it('with options callback that returns an object', function () {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Issues         | Fix #57
| License        | MIT

When a required module cannot be resolved, the friendly-errors plugin suggests installing it with a hardcoded `npm install --save`, even in projects using Yarn or pnpm (the original report from @weaverryan, reopened by @stof).

Encore already detects the package manager from the lockfile when recommending its own build dependencies (`package-helper.js`). This reuses that detection for the "module not found" message: a new transformer re-types the errors that point to an installable package, and a matching formatter recommends the right command:

```
This dependency was not found:

* foo in ./assets/app.js

To install it, you can run: pnpm add foo
```

- non-relative modules only are handled, so relative imports (`./missing`) keep the plugin's untouched "This relative module was not found" message, with no install suggestion;
- the lockfile detection is now shared through a small `getPackageManager()` helper, used both by the existing `getInstallCommand()` and the new one;
- added unit tests for the transformer, the formatter (npm/yarn/pnpm) and `getMissingPackagesInstallCommand()`, and updated the plugin's transformer/formatter counts.

I left `CHANGELOG.md` untouched since there is no unreleased section right now, but happy to add an entry wherever you prefer.

Thanks a lot for Encore, and for keeping this one on the radar since 2017! 🙏
