### PR TITLE
[Dependabot] Stop version updates on test apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,33 +78,3 @@ updates:
               update-types: ['minor', 'patch']
       cooldown:
           default-days: 7
-
-    # Test apps exercising lowest peer-dependency bounds — bump transitives only,
-    # never the explicitly pinned peer deps under test.
-    - package-ecosystem: 'npm'
-      directories:
-          - '/test_apps/lowest-peers-*'
-      schedule:
-          interval: 'weekly'
-      ignore:
-          - dependency-name: '@babel/*'
-          - dependency-name: '@hotwired/stimulus'
-          - dependency-name: '@symfony/stimulus-bridge'
-          - dependency-name: '@vue/*'
-          - dependency-name: 'fork-ts-checker-webpack-plugin'
-          - dependency-name: 'less'
-          - dependency-name: 'less-loader'
-          - dependency-name: 'postcss'
-          - dependency-name: 'postcss-loader'
-          - dependency-name: 'sass'
-          - dependency-name: 'sass-loader'
-          - dependency-name: 'svelte'
-          - dependency-name: 'svelte-loader'
-          - dependency-name: 'ts-loader'
-          - dependency-name: 'typescript'
-          - dependency-name: 'vue'
-          - dependency-name: 'vue-loader'
-          - dependency-name: 'webpack'
-          - dependency-name: 'webpack-cli'
-      cooldown:
-          default-days: 7


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Issues         | -
| License        | MIT

This removes the `/test_apps/lowest-peers-*` block from `.github/dependabot.yml`, so Dependabot no longer opens version-update PRs against these test apps. Their whole purpose is to pin peer dependencies at their lowest supported versions, so letting Dependabot bump anything there works directly against that. The `ignore` list was also incomplete, missing `react` and `react-dom`, which is exactly how #1526 ended up proposing a react 18 -> 19 bump. Dependabot still watches the root `package.json` as before, only the test apps are excluded now.

